### PR TITLE
chore(ci): update GitHub actions for Node 24

### DIFF
--- a/.github/workflows/android-playstore-deploy.yml
+++ b/.github/workflows/android-playstore-deploy.yml
@@ -43,9 +43,9 @@ jobs:
     needs: [check-pending-changesets, screenshots]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: "pnpm"
@@ -75,7 +75,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Download screenshots artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: screenshots
           path: packages/screenshots/screenshots
@@ -114,7 +114,7 @@ jobs:
             release_status:${{ inputs.release_status }}
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: android-playstore-aab
           path: packages/mobile/android/app/build/outputs/bundle/**/*.aab

--- a/.github/workflows/android-playstore-deploy.yml
+++ b/.github/workflows/android-playstore-deploy.yml
@@ -49,13 +49,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - name: Cache Turborepo artifacts
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - uses: rharkor/caching-for-turbo@v2.3.11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/android-playstore-deploy.yml
+++ b/.github/workflows/android-playstore-deploy.yml
@@ -49,7 +49,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Cache Turborepo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/check-pending-changesets.yml
+++ b/.github/workflows/check-pending-changesets.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Ensure no pending changesets remain before release
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - name: Cache Turborepo artifacts
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - uses: rharkor/caching-for-turbo@v2.3.11
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -58,13 +52,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - name: Cache Turborepo artifacts
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - uses: rharkor/caching-for-turbo@v2.3.11
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -101,13 +89,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - name: Cache Turborepo artifacts
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - uses: rharkor/caching-for-turbo@v2.3.11
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Create Release Pull Request or Publish
@@ -131,13 +113,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - name: Cache Turborepo artifacts
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - uses: rharkor/caching-for-turbo@v2.3.11
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           - build
           - test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: "pnpm"
@@ -46,9 +46,9 @@ jobs:
     needs: [check]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: "pnpm"
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload Playwright Report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: |
@@ -83,9 +83,9 @@ jobs:
       pull-requests: write
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: "pnpm"
@@ -107,9 +107,9 @@ jobs:
       contents: write
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: "pnpm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Cache Turborepo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -52,7 +58,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Cache Turborepo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -89,7 +101,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Cache Turborepo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Create Release Pull Request or Publish
@@ -113,7 +131,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Cache Turborepo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
@@ -134,7 +158,7 @@ jobs:
             exit 1
           fi
 
-      - uses: EndBug/add-and-commit@v9
+      - uses: EndBug/add-and-commit@v10
         with:
           commit: --signoff
           add: --all

--- a/.github/workflows/ios-appstore-deploy.yml
+++ b/.github/workflows/ios-appstore-deploy.yml
@@ -40,13 +40,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - name: Cache Turborepo artifacts
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - uses: rharkor/caching-for-turbo@v2.3.11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ios-appstore-deploy.yml
+++ b/.github/workflows/ios-appstore-deploy.yml
@@ -34,9 +34,9 @@ jobs:
     needs: [check-pending-changesets, screenshots]
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: "pnpm"
@@ -60,7 +60,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Download screenshots artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: screenshots
           path: packages/screenshots/screenshots
@@ -89,14 +89,14 @@ jobs:
             automatic_release:${{ inputs.automatic_release }}
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-appstore-ipa
           path: packages/mobile/ios/App/*.ipa
           retention-days: 14
 
       - name: Upload dSYM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-dsym
           path: packages/mobile/ios/App/*.dSYM.zip

--- a/.github/workflows/ios-appstore-deploy.yml
+++ b/.github/workflows/ios-appstore-deploy.yml
@@ -40,7 +40,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Cache Turborepo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -53,7 +53,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Cache Turborepo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -137,7 +143,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - uses: rharkor/caching-for-turbo@v2.3.11
+      - name: Cache Turborepo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -47,9 +47,9 @@ jobs:
     if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: "pnpm"
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload Android APK artifact
         if: ${{ github.event.inputs.android_artifact == 'apk' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: android-${{ github.event.inputs.build_type }}-apk
           path: packages/mobile/android/app/build/outputs/apk/**/*.apk
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload Android AAB artifact
         if: ${{ github.event.inputs.build_type == 'release' && github.event.inputs.android_artifact == 'aab' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: android-release-aab
           path: packages/mobile/android/app/build/outputs/bundle/**/*.aab
@@ -131,9 +131,9 @@ jobs:
     if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' }}
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: "pnpm"
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload iOS IPA artifact
         if: ${{ github.event.inputs.build_type == 'release' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-${{ github.event.inputs.ios_export_method }}-ipa
           path: packages/mobile/ios/App/*.ipa
@@ -195,7 +195,7 @@ jobs:
 
       - name: Upload iOS dSYM artifact
         if: ${{ github.event.inputs.build_type == 'release' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-dsym
           path: packages/mobile/ios/App/*.dSYM.zip

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -53,13 +53,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - name: Cache Turborepo artifacts
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - uses: rharkor/caching-for-turbo@v2.3.11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -143,13 +137,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-      - name: Cache Turborepo artifacts
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+      - uses: rharkor/caching-for-turbo@v2.3.11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: "pnpm"
@@ -31,7 +31,7 @@ jobs:
         working-directory: packages/screenshots
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: screenshots
           path: packages/screenshots/screenshots


### PR DESCRIPTION
## Description

This PR updates the workflow action versions used in CI, mobile, deploy, and screenshots pipelines so the repository is better prepared for the GitHub Actions Node 24 transition.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (CI maintenance)

## Checklist

- [ ] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `pnpm lint` and `pnpm typecheck`
- [x] I've run `pnpm test` and all tests pass
- [ ] I've added tests for new functionality (if applicable)
- [ ] I've run `pnpm lingui:extract` (if I added new strings)
- [ ] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

- Updated official GitHub Actions to Node 24-capable majors: `actions/checkout@v6`, `actions/setup-node@v6`, `actions/upload-artifact@v6`, and `actions/download-artifact@v8`.
- Updated `EndBug/add-and-commit` from `v9` to `v10`.
- Restored `rharkor/caching-for-turbo@v2.3.11`; its Node 24 readiness still needs a separate follow-up.
