### PR TITLE
fix(pwa): address lint and build warnings

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -1,0 +1,46 @@
+name: Update Browserslist DB
+
+on:
+  schedule:
+    # Every Tuesday at 03:17 UTC.
+    # We avoid the top of the hour because GitHub scheduled workflows can be delayed more often than usual.
+    - cron: "17 3 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update Browserslist DB
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Update Browserslist DB
+        run: pnpm browserslist:update-db
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/update-browserslist-db
+          delete-branch: true
+          commit-message: "chore(deps): update Browserslist DB"
+          title: "chore(deps): update Browserslist DB"
+          body: |
+            Updates the Browserslist database in `pnpm-lock.yaml` using
+            `pnpm browserslist:update-db`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "agent-browser": "agent-browser",
     "agent-browser:install": "agent-browser install",
-    "browserslist:update-db": "turbo run browserslist:update-db",
+    "browserslist:update-db": "pnpm dlx update-browserslist-db@latest",
     "build": "turbo run build",
     "lingui:extract": "turbo run lingui:extract",
     "lint": "turbo run lint",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "agent-browser": "agent-browser",
     "agent-browser:install": "agent-browser install",
+    "browserslist:update-db": "turbo run browserslist:update-db",
     "build": "turbo run build",
     "lingui:extract": "turbo run lingui:extract",
     "lint": "turbo run lint",
@@ -56,6 +57,5 @@
       "unrs-resolver",
       "workerd"
     ]
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/pwa/eslint.config.js
+++ b/packages/pwa/eslint.config.js
@@ -9,6 +9,12 @@ export default defineConfig([
     ignores: ["dist", "eslint.config.js"],
   },
   {
+    files: ["src/main.tsx"],
+    rules: {
+      "react-refresh/only-export-components": "off",
+    },
+  },
+  {
     rules: {
       "import/no-named-as-default-member": "off",
       "import/no-named-as-default": "off",

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -13,8 +13,8 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/party_.$partyId.pay.tsx:99
-#: src/routes/party_.$partyId.pay.tsx:105
+#: src/routes/party_.$partyId.pay.tsx:101
+#: src/routes/party_.$partyId.pay.tsx:107
 #: src/routes/party.$partyId.tsx:918
 #: src/routes/party.$partyId.tsx:924
 msgid "(me)"
@@ -37,10 +37,13 @@ msgstr "{message}"
 msgid "{name}"
 msgstr "{name}"
 
-#. placeholder {0}: new Date().getFullYear()
 #: src/routes/about.tsx:158
 msgid "© {0} trizum"
 msgstr "© {0} trizum"
+
+#: src/routes/about.tsx:159
+msgid "© {currentYear} trizum"
+msgstr "© {currentYear} trizum"
 
 #: src/routes/about.tsx:120
 msgid "© 2024 trizum. Open source software."
@@ -50,7 +53,7 @@ msgstr "© 2024 trizum. Open source software."
 msgid "A name for the participant is required"
 msgstr "A name for the participant is required"
 
-#: src/routes/about.tsx:20
+#: src/routes/about.tsx:21
 #: src/routes/index.tsx:177
 msgid "About"
 msgstr "About"
@@ -134,10 +137,13 @@ msgstr "All time"
 msgid "Amount"
 msgstr "Amount"
 
-#. placeholder {0}: participant.name
 #: src/components/ExpenseEditor.tsx:702
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
+
+#: src/components/ExpenseEditor.tsx:703
+msgid "Amount for {participantName}"
+msgstr "Amount for {participantName}"
 
 #: src/components/ExpenseEditor.tsx:374
 msgid "Amount must be greater than 0"
@@ -373,7 +379,7 @@ msgstr "Canadian Dollar"
 msgid "Cape Verdean Escudo"
 msgstr "Cape Verdean Escudo"
 
-#: src/routes/party_.$partyId.pay.tsx:192
+#: src/routes/party_.$partyId.pay.tsx:194
 msgid "Cash or other ways"
 msgstr "Cash or other ways"
 
@@ -393,7 +399,7 @@ msgstr "CFA Franc BEAC"
 msgid "CFP Franc"
 msgstr "CFP Franc"
 
-#: src/routes/about.tsx:75
+#: src/routes/about.tsx:76
 msgid "Changes sync automatically across all your devices"
 msgstr "Changes sync automatically across all your devices"
 
@@ -486,15 +492,15 @@ msgstr "Congolese Franc"
 msgid "Contact Us"
 msgstr "Contact Us"
 
-#: src/routes/about.tsx:129
+#: src/routes/about.tsx:130
 msgid "Contributors"
 msgstr "Contributors"
 
-#: src/routes/party_.$partyId.share.tsx:96
+#: src/routes/party_.$partyId.share.tsx:98
 msgid "Copy party link"
 msgstr "Copy party link"
 
-#: src/routes/party_.$partyId.pay.tsx:160
+#: src/routes/party_.$partyId.pay.tsx:162
 msgid "Copy the phone number and pay through Bizum using your bank app."
 msgstr "Copy the phone number and pay through Bizum using your bank app."
 
@@ -511,7 +517,7 @@ msgstr "Create a new Party"
 msgid "Created with ❤️ by the open source community. Special thanks to all contributors who made this project possible."
 msgstr "Created with ❤️ by the open source community. Special thanks to all contributors who made this project possible."
 
-#: src/routes/about.tsx:140
+#: src/routes/about.tsx:141
 msgid "Credits"
 msgstr "Credits"
 
@@ -558,11 +564,13 @@ msgstr "Danish Krone"
 msgid "Date"
 msgstr "Date"
 
-#. placeholder {0}: from.name
-#. placeholder {1}: to.name
 #: src/routes/party_.$partyId.pay.tsx:70
 msgid "Debt settled between {0} and {1}!"
 msgstr "Debt settled between {0} and {1}!"
+
+#: src/routes/party_.$partyId.pay.tsx:72
+msgid "Debt settled between {fromName} and {toName}!"
+msgstr "Debt settled between {fromName} and {toName}!"
 
 #: src/components/CalculatorToolbar.tsx:554
 msgid "Decimal point"
@@ -723,11 +731,11 @@ msgstr "Failed to add expense"
 msgid "Failed to check for updates"
 msgstr "Failed to check for updates"
 
-#: src/routes/party_.$partyId.share.tsx:44
+#: src/routes/party_.$partyId.share.tsx:46
 msgid "Failed to copy party link to clipboard, please copy it manually"
 msgstr "Failed to copy party link to clipboard, please copy it manually"
 
-#: src/routes/party_.$partyId.pay.tsx:175
+#: src/routes/party_.$partyId.pay.tsx:177
 msgid "Failed to copy phone number to clipboard, please copy it manually"
 msgstr "Failed to copy phone number to clipboard, please copy it manually"
 
@@ -739,7 +747,7 @@ msgstr "Failed to load licenses"
 msgid "Failed to load licenses. Please try again later."
 msgstr "Failed to load licenses. Please try again later."
 
-#: src/routes/party_.$partyId.pay.tsx:71
+#: src/routes/party_.$partyId.pay.tsx:73
 msgid "Failed to mark expense as paid"
 msgstr "Failed to mark expense as paid"
 
@@ -751,7 +759,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:895
+#: src/components/ExpenseEditor.tsx:899
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -763,7 +771,7 @@ msgstr "Falkland Islands Pound"
 msgid "Feature Requests"
 msgstr "Feature Requests"
 
-#: src/routes/about.tsx:59
+#: src/routes/about.tsx:60
 msgid "Features"
 msgstr "Features"
 
@@ -795,7 +803,7 @@ msgstr "Gambian Dalasi"
 msgid "Georgian Lari"
 msgstr "Georgian Lari"
 
-#: src/routes/party_.$partyId.pay.tsx:195
+#: src/routes/party_.$partyId.pay.tsx:197
 msgid "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 msgstr "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 
@@ -847,7 +855,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:793
+#: src/components/ExpenseEditor.tsx:797
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -855,7 +863,7 @@ msgstr "Heads up!"
 msgid "Here is a list of operations you and other party members can do to balance your position."
 msgstr "Here is a list of operations you and other party members can do to balance your position."
 
-#: src/routes/party_.$partyId.pay.tsx:128
+#: src/routes/party_.$partyId.pay.tsx:130
 msgid "Here's a list of ways you can pay, once done, press the button above to mark the expense as paid in this trizum party."
 msgstr "Here's a list of ways you can pay, once done, press the button above to mark the expense as paid in this trizum party."
 
@@ -888,7 +896,7 @@ msgstr "How does offline sync work?"
 msgid "How should I balance?"
 msgstr "How should I balance?"
 
-#: src/routes/party_.$partyId.pay.tsx:124
+#: src/routes/party_.$partyId.pay.tsx:126
 msgid "How to pay?"
 msgstr "How to pay?"
 
@@ -994,10 +1002,13 @@ msgstr "Japanese Yen"
 msgid "Join"
 msgstr "Join"
 
-#. placeholder {0}: party.name
 #: src/routes/party_.$partyId.share.tsx:31
 msgid "Join {0} on trizum!"
 msgstr "Join {0} on trizum!"
+
+#: src/routes/party_.$partyId.share.tsx:33
+msgid "Join {partyName} on trizum!"
+msgstr "Join {partyName} on trizum!"
 
 #: src/routes/index.tsx:242
 #: src/routes/index.tsx:450
@@ -1072,7 +1083,7 @@ msgstr "Liberian Dollar"
 msgid "Libyan Dinar"
 msgstr "Libyan Dinar"
 
-#: src/routes/about.tsx:109
+#: src/routes/about.tsx:110
 msgid "License"
 msgstr "License"
 
@@ -1080,7 +1091,7 @@ msgstr "License"
 msgid "Link or code"
 msgstr "Link or code"
 
-#: src/routes/about.tsx:93
+#: src/routes/about.tsx:94
 msgid "Links"
 msgstr "Links"
 
@@ -1124,13 +1135,13 @@ msgstr "Malformed Party ID"
 msgid "Manage the participants list. Existing members can only be archived."
 msgstr "Manage the participants list. Existing members can only be archived."
 
-#: src/routes/party_.$partyId.pay.tsx:91
-#: src/routes/party_.$partyId.pay.tsx:120
+#: src/routes/party_.$partyId.pay.tsx:93
+#: src/routes/party_.$partyId.pay.tsx:122
 #: src/routes/party.$partyId.tsx:955
 msgid "Mark as paid"
 msgstr "Mark as paid"
 
-#: src/routes/party_.$partyId.pay.tsx:69
+#: src/routes/party_.$partyId.pay.tsx:71
 msgid "Marking expense as paid..."
 msgstr "Marking expense as paid..."
 
@@ -1206,7 +1217,7 @@ msgstr "Move cursor right"
 msgid "Mozambican Metical"
 msgstr "Mozambican Metical"
 
-#: src/routes/about.tsx:82
+#: src/routes/about.tsx:83
 msgid "Multi-Party Splitting"
 msgstr "Multi-Party Splitting"
 
@@ -1342,7 +1353,7 @@ msgstr "Not a valid trizum party code"
 msgid "of total spending"
 msgstr "of total spending"
 
-#: src/routes/about.tsx:64
+#: src/routes/about.tsx:65
 msgid "Offline-First"
 msgstr "Offline-First"
 
@@ -1394,7 +1405,7 @@ msgstr "or enter code"
 msgid "Other operations"
 msgstr "Other operations"
 
-#: src/routes/party_.$partyId.pay.tsx:102
+#: src/routes/party_.$partyId.pay.tsx:104
 #: src/routes/party.$partyId.tsx:921
 msgid "owes"
 msgstr "owes"
@@ -1412,10 +1423,13 @@ msgstr "Paid at"
 msgid "Paid by"
 msgstr "Paid by"
 
-#. placeholder {0}: to.name
 #: src/routes/party_.$partyId.pay.tsx:60
 msgid "Paid debt to {0}"
 msgstr "Paid debt to {0}"
+
+#: src/routes/party_.$partyId.pay.tsx:62
+msgid "Paid debt to {toName}"
+msgstr "Paid debt to {toName}"
 
 #: src/routes/new.tsx:548
 msgid "Pakistani Rupee"
@@ -1481,7 +1495,7 @@ msgstr "Party is completely balanced!"
 msgid "Party leaderboard"
 msgstr "Party leaderboard"
 
-#: src/routes/party_.$partyId.share.tsx:41
+#: src/routes/party_.$partyId.share.tsx:43
 msgid "Party link copied to clipboard!"
 msgstr "Party link copied to clipboard!"
 
@@ -1501,7 +1515,7 @@ msgstr "Party Settings"
 msgid "Party settings saved!"
 msgstr "Party settings saved!"
 
-#: src/routes/party_.$partyId.share.tsx:35
+#: src/routes/party_.$partyId.share.tsx:37
 msgid "Party shared!"
 msgstr "Party shared!"
 
@@ -1517,7 +1531,7 @@ msgstr "Party unpinned"
 msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 msgstr "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 
-#: src/routes/party_.$partyId.pay.tsx:91
+#: src/routes/party_.$partyId.pay.tsx:93
 #: src/routes/party.$partyId.tsx:955
 msgid "Pay"
 msgstr "Pay"
@@ -1542,7 +1556,7 @@ msgstr "Philippine Peso"
 msgid "Phone number"
 msgstr "Phone number"
 
-#: src/routes/party_.$partyId.pay.tsx:171
+#: src/routes/party_.$partyId.pay.tsx:173
 msgid "Phone number copied to clipboard!"
 msgstr "Phone number copied to clipboard!"
 
@@ -1578,7 +1592,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:811
+#: src/components/ExpenseEditor.tsx:815
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -1610,7 +1624,7 @@ msgstr "Polish Zloty"
 msgid "Previous"
 msgstr "Previous"
 
-#: src/routes/about.tsx:120
+#: src/routes/about.tsx:121
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -1622,7 +1636,7 @@ msgstr "Qatari Rial"
 msgid "Ranking based on how much each participant paid in the selected timeframe."
 msgstr "Ranking based on how much each participant paid in the selected timeframe."
 
-#: src/routes/about.tsx:73
+#: src/routes/about.tsx:74
 msgid "Real-Time Sync"
 msgstr "Real-Time Sync"
 
@@ -1643,11 +1657,11 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1000
+#: src/components/ExpenseEditor.tsx:1004
 msgid "Remove photo"
 msgstr "Remove photo"
 
-#: src/routes/about.tsx:104
+#: src/routes/about.tsx:105
 msgid "Report an Issue"
 msgstr "Report an Issue"
 
@@ -1703,7 +1717,7 @@ msgstr "Saudi Riyal"
 #: src/routes/migrate_.tricount.tsx:174
 #: src/routes/new.tsx:158
 #: src/routes/party_.$partyId.settings.tsx:138
-#: src/routes/party_.$partyId.who.tsx:113
+#: src/routes/party_.$partyId.who.tsx:115
 #: src/routes/settings.tsx:108
 msgid "Save"
 msgstr "Save"
@@ -1755,8 +1769,8 @@ msgstr "Settings saved"
 msgid "Seychellois Rupee"
 msgstr "Seychellois Rupee"
 
-#: src/routes/party_.$partyId.share.tsx:56
-#: src/routes/party_.$partyId.share.tsx:91
+#: src/routes/party_.$partyId.share.tsx:58
+#: src/routes/party_.$partyId.share.tsx:93
 #: src/routes/party.$partyId.tsx:314
 msgid "Share party"
 msgstr "Share party"
@@ -1769,17 +1783,21 @@ msgstr "Share the party link so others can join."
 msgid "Shares"
 msgstr "Shares"
 
-#. placeholder {0}: participant.name
 #: src/components/ExpenseEditor.tsx:664
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#. placeholder {0}: totalUnitAmount / 100
-#. placeholder {1}: party.currency
-#. placeholder {2}: party.currency
+#: src/components/ExpenseEditor.tsx:665
+msgid "Shares for {participantName}"
+msgstr "Shares for {participantName}"
+
 #: src/components/ExpenseEditor.tsx:797
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
+
+#: src/components/ExpenseEditor.tsx:801
+msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
+msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
 #: src/routes/new.tsx:557
 msgid "Sierra Leonean Leone"
@@ -1833,11 +1851,11 @@ msgstr "Special Drawing Rights"
 msgid "Split bills with friends and family. Track expenses, calculate balances, and settle up together."
 msgstr "Split bills with friends and family. Track expenses, calculate balances, and settle up together."
 
-#: src/routes/about.tsx:49
+#: src/routes/about.tsx:50
 msgid "Split bills with friends and family. Track, calculate, and settle expenses together."
 msgstr "Split bills with friends and family. Track, calculate, and settle expenses together."
 
-#: src/routes/about.tsx:84
+#: src/routes/about.tsx:85
 msgid "Split expenses fairly among multiple participants"
 msgstr "Split expenses fairly among multiple participants"
 
@@ -1866,7 +1884,7 @@ msgstr "Submit a Request"
 #: src/routes/migrate_.tricount.tsx:174
 #: src/routes/new.tsx:158
 #: src/routes/party_.$partyId.settings.tsx:138
-#: src/routes/party_.$partyId.who.tsx:113
+#: src/routes/party_.$partyId.who.tsx:115
 #: src/routes/settings.tsx:108
 msgid "Submitting..."
 msgstr "Submitting..."
@@ -1883,7 +1901,7 @@ msgstr "Sucre"
 msgid "Sudanese Pound"
 msgstr "Sudanese Pound"
 
-#: src/routes/about.tsx:114
+#: src/routes/about.tsx:115
 #: src/routes/support.tsx:17
 msgid "Support"
 msgstr "Support"
@@ -1908,11 +1926,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:688
+#: src/components/ExpenseEditor.tsx:689
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:689
+#: src/components/ExpenseEditor.tsx:690
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -1946,7 +1964,7 @@ msgid "Tajikistani Somoni"
 msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:140
-#: src/components/ExpenseEditor.tsx:922
+#: src/components/ExpenseEditor.tsx:926
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2000,7 +2018,7 @@ msgstr "This HEIC or HEIF image could not be processed. Try another photo or exp
 msgid "This isn't a valid ID"
 msgstr "This isn't a valid ID"
 
-#: src/routes/about.tsx:143
+#: src/routes/about.tsx:144
 msgid "This project uses various open source libraries and tools."
 msgstr "This project uses various open source libraries and tools."
 
@@ -2021,10 +2039,13 @@ msgstr "Title is required"
 msgid "Title must be less than 50 characters"
 msgstr "Title must be less than 50 characters"
 
-#. placeholder {0}: party.name
 #: src/routes/party_.$partyId.who.tsx:134
 msgid "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
+
+#: src/routes/party_.$partyId.who.tsx:136
+msgid "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
+msgstr "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 
 #: src/routes/new.tsx:568
 msgid "Tongan Paʻanga"
@@ -2120,7 +2141,7 @@ msgstr "Unpin party"
 msgid "Update available"
 msgstr "Update available"
 
-#: src/routes/party_.$partyId.who.tsx:140
+#: src/routes/party_.$partyId.who.tsx:142
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 msgstr "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 
@@ -2132,12 +2153,12 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:836
+#: src/components/ExpenseEditor.tsx:840
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:149
-#: src/components/ExpenseEditor.tsx:931
+#: src/components/ExpenseEditor.tsx:935
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2150,7 +2171,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:874
+#: src/components/ExpenseEditor.tsx:878
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2198,7 +2219,7 @@ msgstr "Vanuatu Vatu"
 msgid "Venezuelan Bolívar Soberano"
 msgstr "Venezuelan Bolívar Soberano"
 
-#: src/routes/about.tsx:33
+#: src/routes/about.tsx:34
 msgid "Version"
 msgstr "Version"
 
@@ -2206,7 +2227,7 @@ msgstr "Version"
 msgid "Vietnamese Dong"
 msgstr "Vietnamese Dong"
 
-#: src/routes/about.tsx:99
+#: src/routes/about.tsx:100
 msgid "View on GitHub"
 msgstr "View on GitHub"
 
@@ -2214,12 +2235,12 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:981
+#: src/components/ExpenseEditor.tsx:985
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:319
 msgid "View photo"
 msgstr "View photo"
 
-#: src/routes/about.tsx:150
+#: src/routes/about.tsx:151
 msgid "View Third-Party Licenses"
 msgstr "View Third-Party Licenses"
 
@@ -2235,10 +2256,13 @@ msgstr "Viewing as {participantName}"
 msgid "Warning: Split amounts don't match total expense"
 msgstr "Warning: Split amounts don't match total expense"
 
-#. placeholder {0}: participant.name
 #: src/routes/party_.$partyId.who.tsx:64
 msgid "Welcome to the party, {0}!"
 msgstr "Welcome to the party, {0}!"
+
+#: src/routes/party_.$partyId.who.tsx:66
+msgid "Welcome to the party, {participantName}!"
+msgstr "Welcome to the party, {participantName}!"
 
 #: src/routes/index.tsx:381
 msgid "Welcome to trizum"
@@ -2253,7 +2277,7 @@ msgstr "What is this party about?"
 msgid "What's your preferred way to be addressed?"
 msgstr "What's your preferred way to be addressed?"
 
-#: src/routes/party_.$partyId.who.tsx:96
+#: src/routes/party_.$partyId.who.tsx:98
 msgid "Who are you?"
 msgstr "Who are you?"
 
@@ -2273,7 +2297,7 @@ msgstr "WIR Euro"
 msgid "WIR Franc"
 msgstr "WIR Franc"
 
-#: src/routes/about.tsx:66
+#: src/routes/about.tsx:67
 msgid "Works seamlessly offline with automatic sync when online"
 msgstr "Works seamlessly offline with automatic sync when online"
 
@@ -2301,10 +2325,13 @@ msgstr "You owe money to people"
 msgid "You're debt free!"
 msgstr "You're debt free!"
 
-#. placeholder {0}: participant.name
 #: src/routes/party_.$partyId.who.tsx:66
 msgid "You're now seeing the party as {0}"
 msgstr "You're now seeing the party as {0}"
+
+#: src/routes/party_.$partyId.who.tsx:68
+msgid "You're now seeing the party as {participantName}"
+msgstr "You're now seeing the party as {participantName}"
 
 #: src/routes/support.tsx:113
 msgid "Your data is stored locally on your device and synced to trizum servers for collaboration. Data is encrypted during transmission. Groups are shared via links - anyone with the link can access the group. See our Privacy Policy for details."

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -13,8 +13,8 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/party_.$partyId.pay.tsx:99
-#: src/routes/party_.$partyId.pay.tsx:105
+#: src/routes/party_.$partyId.pay.tsx:101
+#: src/routes/party_.$partyId.pay.tsx:107
 #: src/routes/party.$partyId.tsx:918
 #: src/routes/party.$partyId.tsx:924
 msgid "(me)"
@@ -37,16 +37,19 @@ msgstr "{message}"
 msgid "{name}"
 msgstr "{name}"
 
-#. placeholder {0}: new Date().getFullYear()
 #: src/routes/about.tsx:158
 msgid "© {0} trizum"
 msgstr "© {0} trizum"
+
+#: src/routes/about.tsx:159
+msgid "© {currentYear} trizum"
+msgstr "© {currentYear} trizum"
 
 #: src/lib/validation.ts:66
 msgid "A name for the participant is required"
 msgstr "Se requiere un nombre para el participante"
 
-#: src/routes/about.tsx:20
+#: src/routes/about.tsx:21
 #: src/routes/index.tsx:177
 msgid "About"
 msgstr "Acerca de"
@@ -126,10 +129,13 @@ msgstr "Todo el tiempo"
 msgid "Amount"
 msgstr "Cantidad"
 
-#. placeholder {0}: participant.name
 #: src/components/ExpenseEditor.tsx:702
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
+
+#: src/components/ExpenseEditor.tsx:703
+msgid "Amount for {participantName}"
+msgstr "Cantidad para {participantName}"
 
 #: src/components/ExpenseEditor.tsx:374
 msgid "Amount must be greater than 0"
@@ -353,7 +359,7 @@ msgstr "Dólar Canadiense"
 msgid "Cape Verdean Escudo"
 msgstr "Escudo Caboverdiano"
 
-#: src/routes/party_.$partyId.pay.tsx:192
+#: src/routes/party_.$partyId.pay.tsx:194
 msgid "Cash or other ways"
 msgstr "Efectivo u otras formas"
 
@@ -373,7 +379,7 @@ msgstr "Franco CFA BEAC"
 msgid "CFP Franc"
 msgstr "Franco CFP"
 
-#: src/routes/about.tsx:75
+#: src/routes/about.tsx:76
 msgid "Changes sync automatically across all your devices"
 msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 
@@ -462,15 +468,15 @@ msgstr "Franco Congoleño"
 msgid "Contact Us"
 msgstr "Contacto"
 
-#: src/routes/about.tsx:129
+#: src/routes/about.tsx:130
 msgid "Contributors"
 msgstr "Colaboradores"
 
-#: src/routes/party_.$partyId.share.tsx:96
+#: src/routes/party_.$partyId.share.tsx:98
 msgid "Copy party link"
 msgstr "Copiar enlace del grupo"
 
-#: src/routes/party_.$partyId.pay.tsx:160
+#: src/routes/party_.$partyId.pay.tsx:162
 msgid "Copy the phone number and pay through Bizum using your bank app."
 msgstr "Copia el número de teléfono y paga mediante Bizum usando la aplicación de tu banco."
 
@@ -483,7 +489,7 @@ msgstr "Colón Costarricense"
 msgid "Create a new Party"
 msgstr "Crear un nuevo Grupo"
 
-#: src/routes/about.tsx:140
+#: src/routes/about.tsx:141
 msgid "Credits"
 msgstr "Créditos"
 
@@ -530,11 +536,13 @@ msgstr "Corona Danesa"
 msgid "Date"
 msgstr "Fecha"
 
-#. placeholder {0}: from.name
-#. placeholder {1}: to.name
 #: src/routes/party_.$partyId.pay.tsx:70
 msgid "Debt settled between {0} and {1}!"
 msgstr "¡Deuda saldada entre {0} y {1}!"
+
+#: src/routes/party_.$partyId.pay.tsx:72
+msgid "Debt settled between {fromName} and {toName}!"
+msgstr "¡Deuda saldada entre {fromName} y {toName}!"
 
 #: src/components/CalculatorToolbar.tsx:554
 msgid "Decimal point"
@@ -679,11 +687,11 @@ msgstr "Error al acceder a la cámara"
 msgid "Failed to add expense"
 msgstr "Error al añadir el gasto"
 
-#: src/routes/party_.$partyId.share.tsx:44
+#: src/routes/party_.$partyId.share.tsx:46
 msgid "Failed to copy party link to clipboard, please copy it manually"
 msgstr "Error al copiar el enlace del grupo al portapapeles, por favor cópialo manualmente"
 
-#: src/routes/party_.$partyId.pay.tsx:175
+#: src/routes/party_.$partyId.pay.tsx:177
 msgid "Failed to copy phone number to clipboard, please copy it manually"
 msgstr "Error al copiar el número de teléfono al portapapeles, por favor cópialo manualmente"
 
@@ -695,7 +703,7 @@ msgstr "Error al cargar las licencias"
 msgid "Failed to load licenses. Please try again later."
 msgstr "Error al cargar las licencias. Por favor, inténtalo más tarde."
 
-#: src/routes/party_.$partyId.pay.tsx:71
+#: src/routes/party_.$partyId.pay.tsx:73
 msgid "Failed to mark expense as paid"
 msgstr "Error al marcar el gasto como pagado"
 
@@ -707,7 +715,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:895
+#: src/components/ExpenseEditor.tsx:899
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -719,7 +727,7 @@ msgstr "Libra Malvinense"
 msgid "Feature Requests"
 msgstr "Sugerencias"
 
-#: src/routes/about.tsx:59
+#: src/routes/about.tsx:60
 msgid "Features"
 msgstr "Características"
 
@@ -751,7 +759,7 @@ msgstr "Dalasi Gambiano"
 msgid "Georgian Lari"
 msgstr "Lari Georgiano"
 
-#: src/routes/party_.$partyId.pay.tsx:195
+#: src/routes/party_.$partyId.pay.tsx:197
 msgid "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 msgstr "Ponte en contacto con la persona para hacer el pago en efectivo o de otra forma diferente a las descritas anteriormente."
 
@@ -799,7 +807,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:793
+#: src/components/ExpenseEditor.tsx:797
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -807,7 +815,7 @@ msgstr "¡Atención!"
 msgid "Here is a list of operations you and other party members can do to balance your position."
 msgstr "Aquí tienes una lista de operaciones que tú y otros miembros del grupo podéis hacer para equilibrar vuestra posición."
 
-#: src/routes/party_.$partyId.pay.tsx:128
+#: src/routes/party_.$partyId.pay.tsx:130
 msgid "Here's a list of ways you can pay, once done, press the button above to mark the expense as paid in this trizum party."
 msgstr "Aquí tienes una lista de formas en las que puedes pagar, una vez hecho, pulsa el botón de arriba para marcar el gasto como pagado en este grupo de trizum."
 
@@ -836,7 +844,7 @@ msgstr "¿Cómo funciona la sincronización sin conexión?"
 msgid "How should I balance?"
 msgstr "¿Cómo debería equilibrar?"
 
-#: src/routes/party_.$partyId.pay.tsx:124
+#: src/routes/party_.$partyId.pay.tsx:126
 msgid "How to pay?"
 msgstr "¿Cómo pagar?"
 
@@ -946,10 +954,13 @@ msgstr "Yen Japonés"
 msgid "Join"
 msgstr "Unirse"
 
-#. placeholder {0}: party.name
 #: src/routes/party_.$partyId.share.tsx:31
 msgid "Join {0} on trizum!"
 msgstr "¡Únete a {0} en trizum!"
+
+#: src/routes/party_.$partyId.share.tsx:33
+msgid "Join {partyName} on trizum!"
+msgstr "¡Únete a {partyName} en trizum!"
 
 #: src/routes/index.tsx:242
 #: src/routes/index.tsx:450
@@ -1020,7 +1031,7 @@ msgstr "Dólar Liberiano"
 msgid "Libyan Dinar"
 msgstr "Dinar Libio"
 
-#: src/routes/about.tsx:109
+#: src/routes/about.tsx:110
 msgid "License"
 msgstr "Licencia"
 
@@ -1028,7 +1039,7 @@ msgstr "Licencia"
 msgid "Link or code"
 msgstr "Enlace o código"
 
-#: src/routes/about.tsx:93
+#: src/routes/about.tsx:94
 msgid "Links"
 msgstr "Enlaces"
 
@@ -1072,13 +1083,13 @@ msgstr "ID de grupo mal formado"
 msgid "Manage the participants list. Existing members can only be archived."
 msgstr "Gestiona la lista de participantes. Los miembros existentes solo pueden ser archivados."
 
-#: src/routes/party_.$partyId.pay.tsx:91
-#: src/routes/party_.$partyId.pay.tsx:120
+#: src/routes/party_.$partyId.pay.tsx:93
+#: src/routes/party_.$partyId.pay.tsx:122
 #: src/routes/party.$partyId.tsx:955
 msgid "Mark as paid"
 msgstr "Marcar como pagado"
 
-#: src/routes/party_.$partyId.pay.tsx:69
+#: src/routes/party_.$partyId.pay.tsx:71
 msgid "Marking expense as paid..."
 msgstr "Marcando gasto como pagado..."
 
@@ -1154,7 +1165,7 @@ msgstr "Mover cursor a la derecha"
 msgid "Mozambican Metical"
 msgstr "Metical Mozambiqueño"
 
-#: src/routes/about.tsx:82
+#: src/routes/about.tsx:83
 msgid "Multi-Party Splitting"
 msgstr "División Multi-Grupo"
 
@@ -1286,7 +1297,7 @@ msgstr "No es un código de grupo de trizum válido"
 msgid "of total spending"
 msgstr "del gasto total"
 
-#: src/routes/about.tsx:64
+#: src/routes/about.tsx:65
 msgid "Offline-First"
 msgstr "Sin Conexión Primero"
 
@@ -1334,7 +1345,7 @@ msgstr "o introduce código"
 msgid "Other operations"
 msgstr "Otras operaciones"
 
-#: src/routes/party_.$partyId.pay.tsx:102
+#: src/routes/party_.$partyId.pay.tsx:104
 #: src/routes/party.$partyId.tsx:921
 msgid "owes"
 msgstr "le debe"
@@ -1352,10 +1363,13 @@ msgstr "Pagado el"
 msgid "Paid by"
 msgstr "Pagado por"
 
-#. placeholder {0}: to.name
 #: src/routes/party_.$partyId.pay.tsx:60
 msgid "Paid debt to {0}"
 msgstr "Deuda pagada a {0}"
+
+#: src/routes/party_.$partyId.pay.tsx:62
+msgid "Paid debt to {toName}"
+msgstr "Deuda pagada a {toName}"
 
 #: src/routes/new.tsx:548
 msgid "Pakistani Rupee"
@@ -1413,7 +1427,7 @@ msgstr "Grupo creado"
 msgid "Party leaderboard"
 msgstr "Clasificación del grupo"
 
-#: src/routes/party_.$partyId.share.tsx:41
+#: src/routes/party_.$partyId.share.tsx:43
 msgid "Party link copied to clipboard!"
 msgstr "¡Enlace del grupo copiado al portapapeles!"
 
@@ -1433,7 +1447,7 @@ msgstr "Configuración del Grupo"
 msgid "Party settings saved!"
 msgstr "¡Configuración del grupo guardada!"
 
-#: src/routes/party_.$partyId.share.tsx:35
+#: src/routes/party_.$partyId.share.tsx:37
 msgid "Party shared!"
 msgstr "¡Grupo compartido!"
 
@@ -1449,7 +1463,7 @@ msgstr "Grupo desfijado"
 msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 msgstr "Pega el mensaje de compartir de Tricount, la URL (p. ej., https://tricount.com/abc123), o la clave directa"
 
-#: src/routes/party_.$partyId.pay.tsx:91
+#: src/routes/party_.$partyId.pay.tsx:93
 #: src/routes/party.$partyId.tsx:955
 msgid "Pay"
 msgstr "Pagar"
@@ -1474,7 +1488,7 @@ msgstr "Peso Filipino"
 msgid "Phone number"
 msgstr "Número de teléfono"
 
-#: src/routes/party_.$partyId.pay.tsx:171
+#: src/routes/party_.$partyId.pay.tsx:173
 msgid "Phone number copied to clipboard!"
 msgstr "¡Número de teléfono copiado al portapapeles!"
 
@@ -1510,7 +1524,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:811
+#: src/components/ExpenseEditor.tsx:815
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -1542,7 +1556,7 @@ msgstr "Zloty Polaco"
 msgid "Previous"
 msgstr "Anterior"
 
-#: src/routes/about.tsx:120
+#: src/routes/about.tsx:121
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
@@ -1554,7 +1568,7 @@ msgstr "Rial Catarí"
 msgid "Ranking based on how much each participant paid in the selected timeframe."
 msgstr "Clasificación según cuánto ha pagado cada participante en el período seleccionado."
 
-#: src/routes/about.tsx:73
+#: src/routes/about.tsx:74
 msgid "Real-Time Sync"
 msgstr "Sincronización en Tiempo Real"
 
@@ -1571,11 +1585,11 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1000
+#: src/components/ExpenseEditor.tsx:1004
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
-#: src/routes/about.tsx:104
+#: src/routes/about.tsx:105
 msgid "Report an Issue"
 msgstr "Reportar un Problema"
 
@@ -1631,7 +1645,7 @@ msgstr "Riyal Saudí"
 #: src/routes/migrate_.tricount.tsx:174
 #: src/routes/new.tsx:158
 #: src/routes/party_.$partyId.settings.tsx:138
-#: src/routes/party_.$partyId.who.tsx:113
+#: src/routes/party_.$partyId.who.tsx:115
 #: src/routes/settings.tsx:108
 msgid "Save"
 msgstr "Guardar"
@@ -1683,8 +1697,8 @@ msgstr "Configuración guardada"
 msgid "Seychellois Rupee"
 msgstr "Rupia de Seychelles"
 
-#: src/routes/party_.$partyId.share.tsx:56
-#: src/routes/party_.$partyId.share.tsx:91
+#: src/routes/party_.$partyId.share.tsx:58
+#: src/routes/party_.$partyId.share.tsx:93
 #: src/routes/party.$partyId.tsx:314
 msgid "Share party"
 msgstr "Compartir grupo"
@@ -1697,17 +1711,21 @@ msgstr "Comparte el enlace del grupo para que otros puedan unirse."
 msgid "Shares"
 msgstr "Partes"
 
-#. placeholder {0}: participant.name
 #: src/components/ExpenseEditor.tsx:664
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#. placeholder {0}: totalUnitAmount / 100
-#. placeholder {1}: party.currency
-#. placeholder {2}: party.currency
+#: src/components/ExpenseEditor.tsx:665
+msgid "Shares for {participantName}"
+msgstr "Partes para {participantName}"
+
 #: src/components/ExpenseEditor.tsx:797
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
+
+#: src/components/ExpenseEditor.tsx:801
+msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
+msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
 #: src/routes/new.tsx:557
 msgid "Sierra Leonean Leone"
@@ -1757,11 +1775,11 @@ msgstr "Derechos Especiales de Giro"
 msgid "Split bills with friends and family. Track expenses, calculate balances, and settle up together."
 msgstr "Divide facturas con amigos y familia. Registra, calcula y salda gastos juntos."
 
-#: src/routes/about.tsx:49
+#: src/routes/about.tsx:50
 msgid "Split bills with friends and family. Track, calculate, and settle expenses together."
 msgstr "Divide facturas con amigos y familia. Registra, calcula y salda gastos juntos."
 
-#: src/routes/about.tsx:84
+#: src/routes/about.tsx:85
 msgid "Split expenses fairly among multiple participants"
 msgstr "Divide los gastos de forma justa entre múltiples participantes"
 
@@ -1790,7 +1808,7 @@ msgstr "Enviar sugerencia"
 #: src/routes/migrate_.tricount.tsx:174
 #: src/routes/new.tsx:158
 #: src/routes/party_.$partyId.settings.tsx:138
-#: src/routes/party_.$partyId.who.tsx:113
+#: src/routes/party_.$partyId.who.tsx:115
 #: src/routes/settings.tsx:108
 msgid "Submitting..."
 msgstr "Enviando..."
@@ -1807,7 +1825,7 @@ msgstr "Sucre"
 msgid "Sudanese Pound"
 msgstr "Libra Sudanesa"
 
-#: src/routes/about.tsx:114
+#: src/routes/about.tsx:115
 #: src/routes/support.tsx:17
 msgid "Support"
 msgstr "Soporte"
@@ -1832,11 +1850,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:688
+#: src/components/ExpenseEditor.tsx:689
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:689
+#: src/components/ExpenseEditor.tsx:690
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -1870,7 +1888,7 @@ msgid "Tajikistani Somoni"
 msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:140
-#: src/components/ExpenseEditor.tsx:922
+#: src/components/ExpenseEditor.tsx:926
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -1924,7 +1942,7 @@ msgstr "Esta imagen HEIC o HEIF no se pudo procesar. Prueba con otra foto o exp�
 msgid "This isn't a valid ID"
 msgstr "Este no es un ID válido"
 
-#: src/routes/about.tsx:143
+#: src/routes/about.tsx:144
 msgid "This project uses various open source libraries and tools."
 msgstr "Este proyecto utiliza varias bibliotecas y herramientas de código abierto."
 
@@ -1945,10 +1963,13 @@ msgstr "Se requiere un título"
 msgid "Title must be less than 50 characters"
 msgstr "El título debe tener menos de 50 caracteres"
 
-#. placeholder {0}: party.name
 #: src/routes/party_.$partyId.who.tsx:134
 msgid "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "Para unirte al <0>{0}</0>, por favor selecciona quién eres para que podamos mostrarte los gastos y estadísticas que te importan."
+
+#: src/routes/party_.$partyId.who.tsx:136
+msgid "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
+msgstr "Para unirte al <0>{partyName}</0>, por favor selecciona quién eres para que podamos mostrarte los gastos y estadísticas que te importan."
 
 #: src/routes/new.tsx:568
 msgid "Tongan Paʻanga"
@@ -2032,7 +2053,7 @@ msgstr "Desfijar grupo"
 msgid "Update available"
 msgstr "Actualización disponible"
 
-#: src/routes/party_.$partyId.who.tsx:140
+#: src/routes/party_.$partyId.who.tsx:142
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 msgstr "Actualiza quién eres en este grupo para que podamos mostrarte los gastos y estadísticas que te importan."
 
@@ -2044,12 +2065,12 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:836
+#: src/components/ExpenseEditor.tsx:840
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:149
-#: src/components/ExpenseEditor.tsx:931
+#: src/components/ExpenseEditor.tsx:935
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2057,7 +2078,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:874
+#: src/components/ExpenseEditor.tsx:878
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2101,7 +2122,7 @@ msgstr "Vatu de Vanuatu"
 msgid "Venezuelan Bolívar Soberano"
 msgstr "Bolívar Soberano Venezolano"
 
-#: src/routes/about.tsx:33
+#: src/routes/about.tsx:34
 msgid "Version"
 msgstr "Versión"
 
@@ -2109,7 +2130,7 @@ msgstr "Versión"
 msgid "Vietnamese Dong"
 msgstr "Dong Vietnamita"
 
-#: src/routes/about.tsx:99
+#: src/routes/about.tsx:100
 msgid "View on GitHub"
 msgstr "Ver en GitHub"
 
@@ -2117,12 +2138,12 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:981
+#: src/components/ExpenseEditor.tsx:985
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:319
 msgid "View photo"
 msgstr "Ver foto"
 
-#: src/routes/about.tsx:150
+#: src/routes/about.tsx:151
 msgid "View Third-Party Licenses"
 msgstr "Ver Licencias de Terceros"
 
@@ -2134,10 +2155,13 @@ msgstr "Viendo como {0}"
 msgid "Viewing as {participantName}"
 msgstr "Viendo como {participantName}"
 
-#. placeholder {0}: participant.name
 #: src/routes/party_.$partyId.who.tsx:64
 msgid "Welcome to the party, {0}!"
 msgstr "¡Bienvenido al grupo, {0}!"
+
+#: src/routes/party_.$partyId.who.tsx:66
+msgid "Welcome to the party, {participantName}!"
+msgstr "¡Bienvenido al grupo, {participantName}!"
 
 #: src/routes/index.tsx:381
 msgid "Welcome to trizum"
@@ -2152,7 +2176,7 @@ msgstr "¿De qué trata este grupo?"
 msgid "What's your preferred way to be addressed?"
 msgstr "¿Cuál es tu forma preferida de que te llamen?"
 
-#: src/routes/party_.$partyId.who.tsx:96
+#: src/routes/party_.$partyId.who.tsx:98
 msgid "Who are you?"
 msgstr "¿Quién eres?"
 
@@ -2172,7 +2196,7 @@ msgstr "Euro WIR"
 msgid "WIR Franc"
 msgstr "Franco WIR"
 
-#: src/routes/about.tsx:66
+#: src/routes/about.tsx:67
 msgid "Works seamlessly offline with automatic sync when online"
 msgstr "Funciona sin problemas sin conexión con sincronización automática cuando estás en línea"
 
@@ -2200,10 +2224,13 @@ msgstr "Debes dinero a personas"
 msgid "You're debt free!"
 msgstr "¡Estás libre de deudas!"
 
-#. placeholder {0}: participant.name
 #: src/routes/party_.$partyId.who.tsx:66
 msgid "You're now seeing the party as {0}"
 msgstr "Ahora estás viendo el grupo como {0}"
+
+#: src/routes/party_.$partyId.who.tsx:68
+msgid "You're now seeing the party as {participantName}"
+msgstr "Ahora estás viendo el grupo como {participantName}"
 
 #: src/routes/support.tsx:113
 msgid "Your data is stored locally on your device and synced to trizum servers for collaboration. Data is encrypted during transmission. Groups are shared via links - anyone with the link can access the group. See our Privacy Policy for details."

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -8,7 +8,6 @@
     "#*": "./*"
   },
   "scripts": {
-    "browserslist:update-db": "cd ../.. && update-browserslist-db latest",
     "build": "./build.sh",
     "cleanup": "rm -rf dist",
     "dev": "vite",
@@ -111,7 +110,6 @@
     "tailwindcss-react-aria-components": "1.2.0",
     "tailwindcss-safe-area-capacitor": "0.5.1",
     "typescript": "5.9.2",
-    "update-browserslist-db": "1.2.3",
     "vite": "8.0.0",
     "vite-plugin-pwa": "1.2.0",
     "vite-plugin-top-level-await": "1.6.0",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -8,6 +8,7 @@
     "#*": "./*"
   },
   "scripts": {
+    "browserslist:update-db": "cd ../.. && update-browserslist-db latest",
     "build": "./build.sh",
     "cleanup": "rm -rf dist",
     "dev": "vite",
@@ -97,7 +98,7 @@
     "@types/react-dom": "npm:types-react-dom@rc",
     "@vite-pwa/assets-generator": "1.0.2",
     "@vitejs/plugin-react": "6.0.1",
-    "autoprefixer": "10.4.21",
+    "autoprefixer": "10.4.27",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "9.39.1",
     "eslint-plugin-lingui": "0.11.0",
@@ -110,6 +111,7 @@
     "tailwindcss-react-aria-components": "1.2.0",
     "tailwindcss-safe-area-capacitor": "0.5.1",
     "typescript": "5.9.2",
+    "update-browserslist-db": "1.2.3",
     "vite": "8.0.0",
     "vite-plugin-pwa": "1.2.0",
     "vite-plugin-top-level-await": "1.6.0",

--- a/packages/pwa/src/components/AppEmojiField.tsx
+++ b/packages/pwa/src/components/AppEmojiField.tsx
@@ -5,7 +5,7 @@ import {
   Text,
 } from "react-aria-components";
 import { cn } from "#src/ui/utils.js";
-import { FieldError, Label } from "#src/ui/Field.js";
+import { FieldError, Label } from "#src/ui/fields/Field.js";
 import { EmojiPicker } from "#src/components/EmojiPicker.js";
 
 const TextField = AriaTextField;

--- a/packages/pwa/src/components/CurrencyField.tsx
+++ b/packages/pwa/src/components/CurrencyField.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/core/macro";
-import { AppCurrencyField } from "#src/ui/TextField.js";
+import { AppCurrencyField } from "#src/ui/fields/TextField.js";
 import React, { use, useRef } from "react";
 import { CurrencyContext } from "./CurrencyContext";
 import { useCalculatorMode } from "#src/hooks/useCalculatorMode.ts";

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -608,6 +608,7 @@ function ParticipantItem({
   }
 
   const currentShareType = participantShare?.type || "divide";
+  const participantName = participant.name;
 
   return (
     <div
@@ -661,7 +662,7 @@ function ParticipantItem({
 
                     updateShares(newShares);
                   }}
-                  aria-label={t`Shares for ${participant.name}`}
+                  aria-label={t`Shares for ${participantName}`}
                 />
                 <IconButton
                   icon="#lucide/plus"
@@ -699,7 +700,7 @@ function ParticipantItem({
               participantId={participant.id}
               autoOpenCalculator={autoOpenCalculator}
               onChange={onExactAmountChange}
-              aria-label={t`Amount for ${participant.name}`}
+              aria-label={t`Amount for ${participantName}`}
             />
           </div>
         </div>
@@ -781,6 +782,9 @@ function SharesWarning({ amount, shares }: SharesWarningProps) {
     0,
   );
   const showWarning = totalUnitAmount - convertToUnits(amount) !== 0;
+  const currency = party.currency;
+  const totalAmount = totalUnitAmount / 100;
+  const expenseAmount = amount;
 
   if (!showWarning) {
     return null;
@@ -797,11 +801,11 @@ function SharesWarning({ amount, shares }: SharesWarningProps) {
           <Trans>
             Shares sum up to{" "}
             <strong>
-              {totalUnitAmount / 100} {party.currency}
+              {totalAmount} {currency}
             </strong>{" "}
             while the expense amount is{" "}
             <strong>
-              {amount} {party.currency}
+              {expenseAmount} {currency}
             </strong>
             .
           </Trans>

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -14,7 +14,7 @@ import {
 import { IconButton } from "#src/ui/IconButton.js";
 import { useLingui } from "@lingui/react";
 import { validateExpenseTitle } from "#src/lib/validation.js";
-import { AppNumberField, AppTextField } from "#src/ui/TextField.js";
+import { AppNumberField, AppTextField } from "#src/ui/fields/TextField.js";
 import { CurrencyField } from "./CurrencyField";
 import { convertToUnits } from "#src/lib/expenses.js";
 import { toast } from "sonner";

--- a/packages/pwa/src/routes/about.tsx
+++ b/packages/pwa/src/routes/about.tsx
@@ -10,6 +10,7 @@ export const Route = createFileRoute("/about")({
 function About() {
   const version = import.meta.env.VITE_APP_VERSION;
   const commit = import.meta.env.VITE_APP_COMMIT;
+  const currentYear = new Date().getFullYear();
 
   return (
     <div className="flex min-h-full flex-col">
@@ -155,7 +156,7 @@ function About() {
         {/* Footer */}
         <section className="mt-8 border-t border-accent-200 pt-6 text-center text-sm text-accent-600 dark:border-accent-800 dark:text-accent-400">
           <p>
-            <Trans>© {new Date().getFullYear()} trizum</Trans>
+            <Trans>© {currentYear} trizum</Trans>
           </p>
         </section>
       </div>

--- a/packages/pwa/src/routes/join.tsx
+++ b/packages/pwa/src/routes/join.tsx
@@ -7,7 +7,7 @@ import { RouteQRScanner } from "#src/components/RouteQRScanner.js";
 import { useRouteQRScanner } from "#src/components/useRouteQRScanner.js";
 import { Button } from "#src/ui/Button.js";
 import { Icon } from "#src/ui/Icon.js";
-import { AppTextField } from "#src/ui/TextField.js";
+import { AppTextField } from "#src/ui/fields/TextField.js";
 import { isValidDocumentId } from "@automerge/automerge-repo/slim";
 import { useForm } from "@tanstack/react-form";
 import {

--- a/packages/pwa/src/routes/migrate_.tricount.tsx
+++ b/packages/pwa/src/routes/migrate_.tricount.tsx
@@ -2,7 +2,7 @@ import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { BackButton } from "#src/components/BackButton.tsx";
 import { IconButton } from "#src/ui/IconButton.tsx";
-import { AppTextField } from "#src/ui/TextField.tsx";
+import { AppTextField } from "#src/ui/fields/TextField.js";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Suspense, useId, useState } from "react";

--- a/packages/pwa/src/routes/new.tsx
+++ b/packages/pwa/src/routes/new.tsx
@@ -7,7 +7,7 @@ import {
   type PartyParticipant,
 } from "#src/models/party.js";
 import { IconButton } from "#src/ui/IconButton.js";
-import { AppTextField } from "#src/ui/TextField.js";
+import { AppTextField } from "#src/ui/fields/TextField.js";
 import { AppSelect, SelectItem } from "#src/ui/Select.tsx";
 import type { DocumentId } from "@automerge/automerge-repo/slim";
 import { useRepo } from "#src/lib/automerge/useRepo.ts";

--- a/packages/pwa/src/routes/party_.$partyId.pay.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.pay.tsx
@@ -49,6 +49,8 @@ function RouteComponent() {
   const to = party.participants[toId];
   const isFromMe = fromId === me.id;
   const navigate = useNavigate();
+  const fromName = from.name;
+  const toName = to.name;
 
   const methods: PaymentMethod[] = [
     to.phone ? { type: "bizum", phoneNumber: to.phone } : null,
@@ -57,7 +59,7 @@ function RouteComponent() {
 
   function onMarkAsPaid() {
     const expensePromise = addExpenseToParty({
-      name: t`Paid debt to ${to.name}`,
+      name: t`Paid debt to ${toName}`,
       paidAt: new Date(),
       paidBy: { [fromId]: amount },
       isTransfer: true,
@@ -67,7 +69,7 @@ function RouteComponent() {
 
     toast.promise(expensePromise, {
       loading: t`Marking expense as paid...`,
-      success: t`Debt settled between ${from.name} and ${to.name}!`,
+      success: t`Debt settled between ${fromName} and ${toName}!`,
       error: t`Failed to mark expense as paid`,
     });
 

--- a/packages/pwa/src/routes/party_.$partyId.settings.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.settings.tsx
@@ -15,7 +15,7 @@ import {
   type PartyParticipant,
 } from "#src/models/party.js";
 import { IconButton } from "#src/ui/IconButton.js";
-import { AppTextField } from "#src/ui/TextField.js";
+import { AppTextField } from "#src/ui/fields/TextField.js";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute } from "@tanstack/react-router";
 import { PartyPendingComponent } from "#src/components/PartyPendingComponent.tsx";

--- a/packages/pwa/src/routes/party_.$partyId.share.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.share.tsx
@@ -25,10 +25,12 @@ function RouteComponent() {
   const { partyId, party } = useCurrentParty();
   const shareUrl = getAppLink(`/party/${partyId}`);
   const { canShare } = Route.useLoaderData();
+  const partyName = party.name;
+
   async function onShareParty() {
     if (canShare) {
       await Share.share({
-        title: t`Join ${party.name} on trizum!`,
+        title: t`Join ${partyName} on trizum!`,
         url: shareUrl,
       });
 

--- a/packages/pwa/src/routes/party_.$partyId.share.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.share.tsx
@@ -104,7 +104,7 @@ function RouteComponent() {
   );
 }
 
-export function getQRCodeImage() {
+function getQRCodeImage() {
   // Get color from CSS variable
   const variable = getComputedStyle(document.documentElement).getPropertyValue(
     "--accent-400",

--- a/packages/pwa/src/routes/party_.$partyId.who.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.who.tsx
@@ -43,6 +43,7 @@ function Who() {
   const { party, setParticipantDetails } = useParty(params.partyId);
   const { partyList, addPartyToList } = usePartyList();
   const navigate = useNavigate();
+  const partyName = party.name;
 
   const [needsToJoin] = useState(
     () =>
@@ -52,6 +53,7 @@ function Who() {
 
   function onSaveSettings(values: WhoFormValues) {
     const participant = party.participants[values.participantId];
+    const participantName = participant.name;
 
     addPartyToList(party.id, participant.id);
 
@@ -61,9 +63,9 @@ function Who() {
         avatarId: partyList.avatarId,
       });
 
-      toast.success(t`Welcome to the party, ${participant.name}!`);
+      toast.success(t`Welcome to the party, ${participantName}!`);
     } else {
-      toast.success(t`You're now seeing the party as ${participant.name}`);
+      toast.success(t`You're now seeing the party as ${participantName}`);
     }
 
     if (search.redirectTo) {
@@ -132,7 +134,7 @@ function Who() {
         <p className="whitespace-pre-wrap px-2">
           {needsToJoin ? (
             <Trans>
-              To join the <span className="font-medium">{party.name}</span>,
+              To join the <span className="font-medium">{partyName}</span>,
               please select who you are so that we can show you the expenses and
               stats that matter to you.
             </Trans>

--- a/packages/pwa/src/routes/settings.tsx
+++ b/packages/pwa/src/routes/settings.tsx
@@ -8,7 +8,7 @@ import {
   validatePhoneNumber,
 } from "#src/lib/validation.js";
 import { IconButton } from "#src/ui/IconButton.js";
-import { AppTextField } from "#src/ui/TextField.js";
+import { AppTextField } from "#src/ui/fields/TextField.js";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Suspense, useId } from "react";
@@ -18,7 +18,7 @@ import { DEFAULT_LOCALE, type SupportedLocale } from "#src/lib/i18n.js";
 import { AppSelect, SelectItem } from "#src/ui/Select.tsx";
 import { SwitchField } from "#src/components/SwitchField.tsx";
 import { ColorSlider, ColorThumb, SliderTrack } from "#src/ui/Color.tsx";
-import { Label } from "#src/ui/Field.tsx";
+import { Label } from "#src/ui/fields/Field.js";
 import { defaultThemeHue, setThemeHue } from "#src/ui/theme.ts";
 
 export const Route = createFileRoute("/settings")({

--- a/packages/pwa/src/ui/Checkbox.tsx
+++ b/packages/pwa/src/ui/Checkbox.tsx
@@ -10,7 +10,8 @@ import {
 
 import { cn } from "./utils";
 
-import { FieldError, Label, labelVariants } from "./Field";
+import { FieldError, Label } from "./fields/Field";
+import { labelVariants } from "./fields/Field.styles";
 import { Icon } from "./Icon";
 
 const CheckboxGroup = AriaCheckboxGroup;

--- a/packages/pwa/src/ui/DatePicker.tsx
+++ b/packages/pwa/src/ui/DatePicker.tsx
@@ -22,8 +22,8 @@ import {
   CalendarHeaderCell,
   CalendarHeading,
 } from "./Calendar";
-import { DateInput } from "./DateField";
-import { FieldError, FieldGroup, Label } from "./Field";
+import { DateInput } from "./fields/DateField";
+import { FieldError, FieldGroup, Label } from "./fields/Field";
 import { Popover } from "./Popover";
 import { IconButton } from "./IconButton";
 

--- a/packages/pwa/src/ui/Icon.tsx
+++ b/packages/pwa/src/ui/Icon.tsx
@@ -34,7 +34,7 @@ export const Icon = ({ ...props }: IconProps) => {
   return <IconWithFallback {...props} />;
 };
 
-function FallbackIcon({ name, ...props }: IconProps) {
+function FallbackIcon({ ...props }: IconProps) {
   const fallbackStyle = {
     width: props.size || props.width,
     height: props.size || props.height,

--- a/packages/pwa/src/ui/Select.tsx
+++ b/packages/pwa/src/ui/Select.tsx
@@ -15,7 +15,7 @@ import {
 
 import { cn } from "./utils";
 
-import { FieldError, Label } from "./Field";
+import { FieldError, Label } from "./fields/Field";
 import {
   ListBoxCollection,
   ListBoxHeader,

--- a/packages/pwa/src/ui/fields/DateField.tsx
+++ b/packages/pwa/src/ui/fields/DateField.tsx
@@ -8,9 +8,9 @@ import {
   composeRenderProps,
 } from "react-aria-components";
 
-import { cn, type VariantProps } from "./utils";
+import { cn, type VariantProps } from "../utils";
 
-import { fieldGroupVariants } from "./Field";
+import { fieldGroupVariants } from "./Field.styles";
 
 const DateField = AriaDateField;
 

--- a/packages/pwa/src/ui/fields/Field.styles.ts
+++ b/packages/pwa/src/ui/fields/Field.styles.ts
@@ -1,0 +1,27 @@
+import { cn, cva } from "../utils";
+
+export const labelVariants = cn([
+  "text-sm font-medium leading-none",
+  /* Disabled */
+  "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-70",
+  /* Invalid */
+  "group-data-[invalid]:text-danger-500",
+]);
+
+export const fieldGroupVariants = cva({
+  variants: {
+    variant: {
+      default: cn([
+        "relative flex h-10 w-full items-center overflow-hidden rounded-md border border-accent-500 dark:border-accent-700 bg-white dark:bg-accent-900 px-3 py-2 text-sm ring-offset-white dark:ring-offset-accent-900",
+        /* Focus Within */
+        "data-[focus-within]:outline-none data-[focus-within]:ring-2 data-[focus-within]:ring-ring data-[focus-within]:ring-offset-2",
+        /* Disabled */
+        "data-[disabled]:opacity-50",
+      ]),
+      ghost: "",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});

--- a/packages/pwa/src/ui/fields/Field.tsx
+++ b/packages/pwa/src/ui/fields/Field.tsx
@@ -9,15 +9,8 @@ import {
   type TextProps as AriaTextProps,
   composeRenderProps,
 } from "react-aria-components";
-import { cn, cva, type VariantProps } from "./utils";
-
-const labelVariants = cn([
-  "text-sm font-medium leading-none",
-  /* Disabled */
-  "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-70",
-  /* Invalid */
-  "group-data-[invalid]:text-danger-500",
-]);
+import { type VariantProps, cn } from "../utils";
+import { fieldGroupVariants, labelVariants } from "./Field.styles";
 
 const Label = ({ className, ...props }: AriaLabelProps) => (
   <AriaLabel className={cn(labelVariants, className)} {...props} />
@@ -42,24 +35,6 @@ function FieldError({ className, ...props }: AriaFieldErrorProps) {
   );
 }
 
-export const fieldGroupVariants = cva({
-  variants: {
-    variant: {
-      default: cn([
-        "relative flex h-10 w-full items-center overflow-hidden rounded-md border border-accent-500 dark:border-accent-700 bg-white dark:bg-accent-900 px-3 py-2 text-sm ring-offset-white dark:ring-offset-accent-900",
-        /* Focus Within */
-        "data-[focus-within]:outline-none data-[focus-within]:ring-2 data-[focus-within]:ring-ring data-[focus-within]:ring-offset-2",
-        /* Disabled */
-        "data-[disabled]:opacity-50",
-      ]),
-      ghost: "",
-    },
-  },
-  defaultVariants: {
-    variant: "default",
-  },
-});
-
 interface GroupProps
   extends AriaGroupProps,
     VariantProps<typeof fieldGroupVariants> {}
@@ -75,4 +50,4 @@ function FieldGroup({ className, variant, ...props }: GroupProps) {
   );
 }
 
-export { labelVariants, Label, FieldGroup, FieldError, FormDescription };
+export { Label, FieldGroup, FieldError, FormDescription };

--- a/packages/pwa/src/ui/fields/TextField.tsx
+++ b/packages/pwa/src/ui/fields/TextField.tsx
@@ -13,7 +13,7 @@ import {
   Text,
 } from "react-aria-components";
 
-import { cn, type ClassName } from "./utils";
+import { cn, type ClassName } from "../utils";
 
 import { FieldError, Label } from "./Field";
 

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -42,6 +42,9 @@ const fullVersion = `${appVersion}-${appCommit}`;
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const isTest = mode === "test" || process.env.VITEST === "true";
+  // Skip the Sentry Vite plugin in local/dev builds when auth is unavailable.
+  const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN?.trim();
+  const hasSentryAuthToken = Boolean(sentryAuthToken);
 
   process.env.VITE_APP_WSS_URL =
     mode === "production"
@@ -159,22 +162,26 @@ export default defineConfig(({ mode }) => {
         },
       }),
       appendSourceMappingURLPlugin(),
-      sentryVitePlugin({
-        org: process.env.SENTRY_ORG,
-        project: process.env.SENTRY_PROJECT,
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        release: {
-          create: true,
-          name: fullVersion,
-          setCommits: {
-            auto: true,
-          },
-          inject: true,
-        },
-        sourcemaps: {
-          disable: true,
-        },
-      }),
+      ...(hasSentryAuthToken
+        ? [
+            sentryVitePlugin({
+              org: process.env.SENTRY_ORG,
+              project: process.env.SENTRY_PROJECT,
+              authToken: sentryAuthToken,
+              release: {
+                create: true,
+                name: fullVersion,
+                setCommits: {
+                  auto: true,
+                },
+                inject: true,
+              },
+              sourcemaps: {
+                disable: true,
+              },
+            }),
+          ]
+        : []),
     ],
   };
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,8 +414,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(@rolldown/plugin-babel@0.2.1(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.9)(vite@8.0.0(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.0)(terser@5.44.1)(tsx@4.20.4)(yaml@2.4.5)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.0(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.0)(terser@5.44.1)(tsx@4.20.4)(yaml@2.4.5))
       autoprefixer:
-        specifier: 10.4.21
-        version: 10.4.21(postcss@8.5.6)
+        specifier: 10.4.27
+        version: 10.4.27(postcss@8.5.6)
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
@@ -452,6 +452,9 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
+      update-browserslist-db:
+        specifier: 1.2.3
+        version: 1.2.3(browserslist@4.28.2)
       vite:
         specifier: 8.0.0
         version: 8.0.0(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.0)(terser@5.44.1)(tsx@4.20.4)(yaml@2.4.5)
@@ -4713,8 +4716,8 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
-  autoprefixer@10.4.21:
-    resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
+  autoprefixer@10.4.27:
+    resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
@@ -4819,6 +4822,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.16:
+    resolution: {integrity: sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   baseline-browser-mapping@2.9.2:
     resolution: {integrity: sha512-PxSsosKQjI38iXkmb3d0Y32efqyA0uW4s41u4IVBsLlWLhCiYNpH/AfNOVWRqCQBlD8TFJTz6OUWNd4DFJCnmw==}
     hasBin: true
@@ -4879,13 +4887,13 @@ packages:
   browser-image-compression@2.0.2:
     resolution: {integrity: sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==}
 
-  browserslist@4.25.2:
-    resolution: {integrity: sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==}
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -4947,11 +4955,11 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001735:
-    resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
-
   caniuse-lite@1.0.30001759:
     resolution: {integrity: sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==}
+
+  caniuse-lite@1.0.30001786:
+    resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
 
   capacitor-plugin-safe-area@5.0.0:
     resolution: {integrity: sha512-Q7+mV7oxGGDB4qPPGXFwS/dexR2/bo/uwkoBRTeR3d/rCzboi3Rnylw18MxSFx/mbQHD9BB7gSDWl+YnncJohQ==}
@@ -5609,11 +5617,11 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.203:
-    resolution: {integrity: sha512-uz4i0vLhfm6dLZWbz/iH88KNDV+ivj5+2SA+utpgjKaj9Q0iDLuwk6Idhe9BTxciHudyx6IvTvijhkPvFGUQ0g==}
-
   electron-to-chromium@1.5.265:
     resolution: {integrity: sha512-B7IkLR1/AE+9jR2LtVF/1/6PFhY5TlnEHnlrKmGk7PvkJibg5jr+mLXLLzq3QYl6PA1T/vLDthQPqIPAlS/PPA==}
+
+  electron-to-chromium@1.5.332:
+    resolution: {integrity: sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==}
 
   elementtree@0.1.7:
     resolution: {integrity: sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==}
@@ -6079,9 +6087,6 @@ packages:
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
-
-  fraction.js@4.3.7:
-    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -7371,11 +7376,11 @@ packages:
     resolution: {integrity: sha512-Cov028YhBZ5aB7MdMWJEmwyBig43aGL5WT4vdoB28Oitau1zZAcHUn8Sgfk9HM33TqhtLJ9PlM/O0Mv+QpV/4Q==}
     engines: {node: '>=8.9.4'}
 
-  node-releases@2.0.19:
-    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
-
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -7386,10 +7391,6 @@ packages:
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
-  normalize-range@0.1.2:
-    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
   npm-package-arg@11.0.2:
@@ -9065,14 +9066,8 @@ packages:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
 
-  update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
-  update-browserslist-db@1.2.2:
-    resolution: {integrity: sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==}
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -9475,8 +9470,8 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
   yaml@2.4.5:
@@ -9704,7 +9699,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.28.5
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -13834,6 +13829,7 @@ snapshots:
       react-aria: 3.42.0(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       react-aria-components: 1.11.0(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       react-dom: 0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722)
+      react-modal-sheet: 5.6.0(motion@12.38.0(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722))(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       sonner: 2.0.7(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       suspense: 0.1.0(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       tailwind-merge: 2.6.0
@@ -14513,12 +14509,11 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  autoprefixer@10.4.21(postcss@8.5.6):
+  autoprefixer@10.4.27(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.2
-      caniuse-lite: 1.0.30001735
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001786
+      fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
@@ -14628,6 +14623,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.16: {}
+
   baseline-browser-mapping@2.9.2: {}
 
   basic-ftp@5.0.5: {}
@@ -14687,20 +14684,21 @@ snapshots:
     dependencies:
       uzip: 0.20201231.0
 
-  browserslist@4.25.2:
-    dependencies:
-      caniuse-lite: 1.0.30001735
-      electron-to-chromium: 1.5.203
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.2)
-
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.2
       caniuse-lite: 1.0.30001759
       electron-to-chromium: 1.5.265
       node-releases: 2.0.27
-      update-browserslist-db: 1.2.2(browserslist@4.28.1)
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.16
+      caniuse-lite: 1.0.30001786
+      electron-to-chromium: 1.5.332
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bs58@5.0.0:
     dependencies:
@@ -14766,9 +14764,9 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001735: {}
-
   caniuse-lite@1.0.30001759: {}
+
+  caniuse-lite@1.0.30001786: {}
 
   capacitor-plugin-safe-area@5.0.0(@capacitor/core@8.0.1):
     dependencies:
@@ -15098,7 +15096,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 1.10.3
     optional: true
 
   cosmiconfig@8.3.6(typescript@5.9.2):
@@ -15396,9 +15394,9 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.203: {}
-
   electron-to-chromium@1.5.265: {}
+
+  electron-to-chromium@1.5.332: {}
 
   elementtree@0.1.7:
     dependencies:
@@ -16121,8 +16119,6 @@ snapshots:
       once: 1.4.0
 
   forwarded-parse@2.1.2: {}
-
-  fraction.js@4.3.7: {}
 
   fraction.js@5.3.4: {}
 
@@ -17435,9 +17431,9 @@ snapshots:
       mkdirp: 0.5.6
       resolve: 1.22.8
 
-  node-releases@2.0.19: {}
-
   node-releases@2.0.27: {}
+
+  node-releases@2.0.37: {}
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -17454,8 +17450,6 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
-
-  normalize-range@0.1.2: {}
 
   npm-package-arg@11.0.2:
     dependencies:
@@ -19522,15 +19516,15 @@ snapshots:
 
   upath@1.2.0: {}
 
-  update-browserslist-db@1.1.3(browserslist@4.25.2):
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
-      browserslist: 4.25.2
+      browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  update-browserslist-db@1.2.2(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -19963,7 +19957,7 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  yaml@1.10.2:
+  yaml@1.10.3:
     optional: true
 
   yaml@2.4.5: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,9 +452,6 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      update-browserslist-db:
-        specifier: 1.2.3
-        version: 1.2.3(browserslist@4.28.2)
       vite:
         specifier: 8.0.0
         version: 8.0.0(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.0)(terser@5.44.1)(tsx@4.20.4)(yaml@2.4.5)

--- a/turbo.json
+++ b/turbo.json
@@ -45,9 +45,6 @@
     },
     "lingui:extract": {
       "cache": false
-    },
-    "browserslist:update-db": {
-      "cache": false
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -45,6 +45,9 @@
     },
     "lingui:extract": {
       "cache": false
+    },
+    "browserslist:update-db": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Description

- resolves the Lingui `no-expression-in-message` warnings in the PWA and refreshes the extracted locale catalogs
- cleans up the `react-refresh/only-export-components` cases by isolating field primitives under `src/ui/fields`, keeping the share QR helper local, and excluding the Vite bootstrap entry from that rule
- removes the remaining unused variable warning in the PWA icon component
- automates Browserslist DB refreshes with a root `pnpm dlx` command and a scheduled GitHub Actions PR
- skips the Sentry Vite plugin when `SENTRY_AUTH_TOKEN` is missing so local and CI builds avoid noisy auth warnings

## Related Issues

- None linked.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (build and dependency maintenance)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `pnpm lint` and `pnpm typecheck`
- [x] I've run `pnpm test` and all tests pass
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `pnpm lingui:extract` (if I added new strings)
- [ ] I've added a changeset (if this is a user-facing change)

## Screenshots

- N/A

## Additional Notes

- This PR is maintenance-only, so it does not include a changeset.
- `pnpm lint` still reports the three existing `react-hooks/incompatible-library` warnings from `@tanstack/react-virtual` in `EmojiPicker.tsx` and `party.$partyId.tsx`; those are intentionally deferred to a follow-up PR.
