### PR TITLE
fix(ci): bound playwright installs and update versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright Browser
-        run: pnpm --filter @trizum/pwa exec playwright install --with-deps chromium webkit
+      - name: Install Playwright Browsers
+        timeout-minutes: 5
+        run: pnpm --filter @trizum/pwa run test:e2e:install:ci
 
       - name: Run Playwright E2E
         run: pnpm test:e2e

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: Install dependencies
@@ -23,6 +23,7 @@ jobs:
         run: pnpm turbo run build --filter=@trizum/screenshots^...
 
       - name: Install Playwright Browsers
+        timeout-minutes: 5
         run: pnpm run setup
         working-directory: packages/screenshots
 

--- a/packages/pwa/e2e/README.md
+++ b/packages/pwa/e2e/README.md
@@ -50,5 +50,8 @@ setup and reusable journey state.
 
 ## Validation
 
+- `pnpm --filter @trizum/pwa test:e2e:install` installs the local browser set.
+- `pnpm --filter @trizum/pwa test:e2e:install:ci` installs the CI browser set
+  with system dependencies and the smaller Chromium headless shell.
 - `pnpm --filter @trizum/pwa test:e2e -- e2e/harness.spec.ts`
 - `pnpm --filter @trizum/pwa test:e2e -- e2e/smoke.spec.ts`

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -26,6 +26,7 @@
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:install": "playwright install chromium webkit",
+    "test:e2e:install:ci": "playwright install --with-deps --only-shell chromium webkit",
     "pretypecheck": "pnpm icons:generate",
     "typecheck": "tsc --noEmit",
     "generate:assets": "pwa-assets-generator",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -94,7 +94,7 @@
     "@lingui/conf": "5.9.3",
     "@lingui/format-po": "5.9.3",
     "@lingui/vite-plugin": "5.9.3",
-    "@playwright/test": "1.58.2",
+    "@playwright/test": "1.60.0",
     "@rolldown/plugin-babel": "0.2.1",
     "@tanstack/router-devtools": "1.166.9",
     "@tanstack/router-plugin": "1.166.12",

--- a/packages/screenshots/README.md
+++ b/packages/screenshots/README.md
@@ -25,7 +25,8 @@ Fastlane screenshot handoff.
 
 Run the package scripts defined in [`package.json`](./package.json):
 
-- `pnpm setup` on first use to install Playwright browser dependencies
+- `pnpm setup` on first use to install Playwright browser dependencies with
+  the smaller Chromium headless shell
 - `pnpm start` to capture screenshots
 - `pnpm organize:fastlane --platform <ios|android> --output <path>` to prepare
   store-upload assets

--- a/packages/screenshots/package.json
+++ b/packages/screenshots/package.json
@@ -44,6 +44,6 @@
   "prettier": "@trizum/prettier-config",
   "dependencies": {
     "@trizum/logging": "workspace:*",
-    "playwright": "1.57.0"
+    "playwright": "1.60.0"
   }
 }

--- a/packages/screenshots/package.json
+++ b/packages/screenshots/package.json
@@ -30,7 +30,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint --ext .ts src",
     "lint:fix": "pnpm run lint --fix",
-    "setup": "pnpm playwright install --with-deps chromium"
+    "setup": "pnpm playwright install --with-deps --only-shell chromium"
   },
   "devDependencies": {
     "@trizum/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,8 +406,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3(babel-plugin-macros@3.1.0)(typescript@5.9.2)(vite@8.0.0(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.0)(terser@5.44.1)(tsx@4.20.4)(yaml@2.4.5))
       '@playwright/test':
-        specifier: 1.58.2
-        version: 1.58.2
+        specifier: 1.60.0
+        version: 1.60.0
       '@rolldown/plugin-babel':
         specifier: 0.2.1
         version: 0.2.1(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.9)(vite@8.0.0(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.6.0)(terser@5.44.1)(tsx@4.20.4)(yaml@2.4.5))
@@ -511,8 +511,8 @@ importers:
         specifier: workspace:*
         version: link:../logging
       playwright:
-        specifier: 1.57.0
-        version: 1.57.0
+        specifier: 1.60.0
+        version: 1.60.0
     devDependencies:
       '@trizum/eslint-config':
         specifier: workspace:*
@@ -2819,8 +2819,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7771,23 +7771,13 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  playwright-core@1.57.0:
-    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.57.0:
-    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -12094,9 +12084,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@poppinss/colors@4.1.5':
     dependencies:
@@ -17928,19 +17918,11 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  playwright-core@1.57.0: {}
+  playwright-core@1.60.0: {}
 
-  playwright-core@1.58.2: {}
-
-  playwright@1.57.0:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.57.0
-    optionalDependencies:
-      fsevents: 2.3.2
-
-  playwright@1.58.2:
-    dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Description

Bounds the Playwright browser install steps that can hang in CI, and updates the affected Playwright packages to the current npm latest release, `1.60.0`.

The E2E and screenshots workflows now fail the browser install step after 5 minutes. The PWA workflow uses a CI-specific install script with `--with-deps --only-shell chromium webkit`, while the existing local `test:e2e:install` script still installs the full browser set for headed local runs. The screenshots setup script now installs the Chromium headless shell because screenshot capture launches headless Chromium only.

This also upgrades `@playwright/test` in `@trizum/pwa` from `1.58.2` to `1.60.0`, upgrades `playwright` in `@trizum/screenshots` from `1.57.0` to `1.60.0`, and refreshes `pnpm-lock.yaml` so both packages share the same Playwright version.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [x] Other: dependency update

## Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [ ] I have run `pnpm lint` and `pnpm typecheck`
- [ ] I have run `pnpm test` and all tests pass
- [x] I have added tests for new functionality (if applicable)
- [x] I have run `pnpm lingui:extract` (if I added new strings)
- [x] I have added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this PR only changes CI browser setup, Playwright package versions, and related docs.

## Additional Notes

Targeted validation run:

- `pnpm view @playwright/test version` -> `1.60.0`
- `pnpm view playwright version` -> `1.60.0`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @trizum/pwa exec playwright --version` -> `Version 1.60.0`
- `pnpm --filter @trizum/screenshots exec playwright --version` -> `Version 1.60.0`
- `pnpm --filter @trizum/pwa exec playwright install --with-deps --only-shell --dry-run chromium webkit`
- `pnpm --filter @trizum/screenshots exec playwright install --with-deps --only-shell --dry-run chromium`
- `pnpm turbo run build --filter=@trizum/pwa^... --filter=@trizum/screenshots^...`
- `pnpm --filter @trizum/pwa exec playwright test --list`
- `pnpm --filter @trizum/screenshots typecheck`
- `pnpm --filter @trizum/pwa exec prettier --check packages/pwa/package.json packages/screenshots/package.json`
- JSON parse checks
- `git diff --check`

The full browser install and E2E suite were not run locally because the change specifically bounds browser downloads that have been hanging in CI.
