### PR TITLE
fix(pwa): disable Sentry during Playwright E2E

### DIFF
--- a/packages/pwa/e2e/README.md
+++ b/packages/pwa/e2e/README.md
@@ -18,8 +18,9 @@ setup and reusable journey state.
 - Start new browser journeys from [`harness/trizum.fixture.ts`](./harness/trizum.fixture.ts)
   instead of importing `@playwright/test` directly.
 - The fixture always boots the app with `__internal_offline_only=true` and
-  blocks service workers. Each Playwright test gets a fresh browser context, so
-  local storage, IndexedDB, and party-list state do not leak across runs.
+  blocks service workers and Sentry network requests. Each Playwright test gets
+  a fresh browser context, so local storage, IndexedDB, and party-list state do
+  not leak across runs.
 - Seed state directly only when it is a precondition, not the behavior being
   tested. Use seeded setup for existing party docs, last-opened party behavior,
   and imbalanced balances.

--- a/packages/pwa/e2e/harness/trizum.fixture.ts
+++ b/packages/pwa/e2e/harness/trizum.fixture.ts
@@ -97,6 +97,10 @@ function createOfflinePath(pathname = "/") {
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
+function isSentryUrl(url: URL) {
+  return url.hostname === "sentry.io" || url.hostname.endsWith(".sentry.io");
+}
+
 function createBrowserHarness(page: Page): BrowserHarness {
   async function hasInternalHooks() {
     return page
@@ -307,6 +311,13 @@ function createBrowserHarness(page: Page): BrowserHarness {
 export const test = base.extend<{
   harness: BrowserHarness;
 }>({
+  context: async ({ context }, use) => {
+    await context.route(isSentryUrl, async (route) => {
+      await route.abort();
+    });
+
+    await use(context);
+  },
   harness: async ({ page }, use) => {
     await use(createBrowserHarness(page));
   },

--- a/packages/pwa/playwright.config.ts
+++ b/packages/pwa/playwright.config.ts
@@ -7,6 +7,10 @@ const host = "127.0.0.1";
 const localBaseURL = `http://${host}:${port}`;
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? localBaseURL;
 const cwd = path.dirname(fileURLToPath(import.meta.url));
+const webServerCommand = [
+  "VITE_APP_DISABLE_SENTRY=true pnpm run build",
+  `pnpm exec vite preview --host ${host} --port ${port} --strictPort --outDir dist/client`,
+].join(" && ");
 
 export default defineConfig({
   testDir: "./e2e",
@@ -23,7 +27,7 @@ export default defineConfig({
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
-        command: `pnpm run build && pnpm exec vite preview --host ${host} --port ${port} --strictPort --outDir dist/client`,
+        command: webServerCommand,
         url: localBaseURL,
         reuseExistingServer: !process.env.CI,
         cwd,

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -45,8 +45,11 @@ import {
 } from "./lib/testing/browserHarness.ts";
 
 const initialUrl = new URL(window.location.href);
+const isProduction = import.meta.env.MODE === "production";
+const shouldInitializeSentry =
+  isProduction && import.meta.env.VITE_APP_DISABLE_SENTRY !== "true";
 
-if (import.meta.env.MODE === "production") {
+if (shouldInitializeSentry) {
   Sentry.init({
     dsn: "https://379ed68929ca4667e3466293189544a6@o524893.ingest.us.sentry.io/4510504067268608",
     integrations: [
@@ -72,7 +75,7 @@ if (import.meta.env.MODE === "production") {
   });
 } else {
   configurePwaLogging({
-    lowestLevel: "debug",
+    lowestLevel: isProduction ? "info" : "debug",
   });
 }
 

--- a/packages/pwa/src/vite-env.d.ts
+++ b/packages/pwa/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_VERSION: string;
   readonly VITE_APP_COMMIT: string;
   readonly VITE_APP_WSS_URL: string;
+  readonly VITE_APP_DISABLE_SENTRY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Description

Playwright E2E runs a production preview build, so the existing production-mode check initialized Sentry during tests. This PR adds a typed `VITE_APP_DISABLE_SENTRY` build flag, sets it for the Playwright-managed production build, and keeps production logging at `info` without attaching the Sentry sink when that flag is enabled.

The shared E2E fixture also aborts `sentry.io` requests from browser contexts so tests cannot send Sentry events even when they run against an externally supplied `PLAYWRIGHT_BASE_URL`.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `pnpm lint` and `pnpm typecheck`
- [x] I've run `pnpm test` and all tests pass
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `pnpm lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

No UI changes.

## Additional Notes

Validation run:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm -C packages/pwa exec playwright test e2e/smoke.spec.ts --project=chromium`
- Confirmed the E2E-built `dist/client` did not contain the Sentry DSN, ingest host, or init strings.

No Lingui extraction or changeset was needed because this is test/observability behavior with no user-facing copy or release-note-worthy product change.