### PR TITLE
fix(pwa): prevent duplicate expense editor saves

### DIFF
--- a/.changeset/quiet-expense-save.md
+++ b/.changeset/quiet-expense-save.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Prevent duplicate Expense Editor saves while an existing save is still in progress.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -142,7 +142,7 @@ msgstr "Align QR code here"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:385
+#: src/components/ExpenseEditor.tsx:400
 msgid "Amount"
 msgstr "Amount"
 
@@ -150,11 +150,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:704
+#: src/components/ExpenseEditor.tsx:719
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:375
+#: src/components/ExpenseEditor.tsx:390
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -227,7 +227,7 @@ msgstr "Attachments"
 msgid "Australian Dollar"
 msgstr "Australian Dollar"
 
-#: src/components/ExpenseEditor.tsx:284
+#: src/components/ExpenseEditor.tsx:295
 #: src/routes/settings.tsx:230
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -591,7 +591,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:439
+#: src/components/ExpenseEditor.tsx:454
 msgid "Date"
 msgstr "Date"
 
@@ -751,7 +751,7 @@ msgstr "Exact"
 msgid "Expense added"
 msgstr "Expense added"
 
-#: src/components/ExpenseEditor.tsx:165
+#: src/components/ExpenseEditor.tsx:170
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
@@ -815,7 +815,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:900
+#: src/components/ExpenseEditor.tsx:915
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -916,7 +916,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:798
+#: src/components/ExpenseEditor.tsx:813
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -1001,7 +1001,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:469
+#: src/components/ExpenseEditor.tsx:484
 msgid "Include all"
 msgstr "Include all"
 
@@ -1221,7 +1221,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:268
+#: src/components/ExpenseEditor.tsx:279
 #: src/routes/index.tsx:117
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:103
 #: src/routes/party.$partyId.tsx:226
@@ -1455,7 +1455,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:287
+#: src/components/ExpenseEditor.tsx:298
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1496,7 +1496,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:414
+#: src/components/ExpenseEditor.tsx:429
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:251
 msgid "Paid by"
 msgstr "Paid by"
@@ -1670,7 +1670,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:816
+#: src/components/ExpenseEditor.tsx:831
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -1739,7 +1739,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1005
+#: src/components/ExpenseEditor.tsx:1020
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -1795,7 +1795,7 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:307
+#: src/components/ExpenseEditor.tsx:318
 #: src/routes/migrate_.tricount.tsx:174
 #: src/routes/new.tsx:158
 #: src/routes/party_.$partyId.settings.tsx:138
@@ -1873,7 +1873,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:666
+#: src/components/ExpenseEditor.tsx:681
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -1881,7 +1881,7 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:802
+#: src/components/ExpenseEditor.tsx:817
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
@@ -1966,7 +1966,7 @@ msgstr "Stats"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:307
+#: src/components/ExpenseEditor.tsx:318
 #: src/routes/migrate_.tricount.tsx:174
 #: src/routes/new.tsx:158
 #: src/routes/party_.$partyId.settings.tsx:138
@@ -2012,11 +2012,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:690
+#: src/components/ExpenseEditor.tsx:705
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:691
+#: src/components/ExpenseEditor.tsx:706
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2050,7 +2050,7 @@ msgid "Tajikistani Somoni"
 msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:140
-#: src/components/ExpenseEditor.tsx:927
+#: src/components/ExpenseEditor.tsx:942
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2125,7 +2125,7 @@ msgstr "This project uses various open source libraries and tools."
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:348
+#: src/components/ExpenseEditor.tsx:363
 msgid "Title"
 msgstr "Title"
 
@@ -2261,12 +2261,12 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:841
+#: src/components/ExpenseEditor.tsx:856
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:149
-#: src/components/ExpenseEditor.tsx:936
+#: src/components/ExpenseEditor.tsx:951
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2279,7 +2279,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:879
+#: src/components/ExpenseEditor.tsx:894
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2343,7 +2343,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:986
+#: src/components/ExpenseEditor.tsx:1001
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:321
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -134,7 +134,7 @@ msgstr "Alinea el código QR aquí"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:385
+#: src/components/ExpenseEditor.tsx:400
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -142,11 +142,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:704
+#: src/components/ExpenseEditor.tsx:719
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:375
+#: src/components/ExpenseEditor.tsx:390
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -215,7 +215,7 @@ msgstr "Adjuntos"
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
-#: src/components/ExpenseEditor.tsx:284
+#: src/components/ExpenseEditor.tsx:295
 #: src/routes/settings.tsx:230
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -563,7 +563,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:439
+#: src/components/ExpenseEditor.tsx:454
 msgid "Date"
 msgstr "Fecha"
 
@@ -715,7 +715,7 @@ msgstr "Por ahora todo está archivado. Puedes reabrir cualquier grupo desde la 
 msgid "Expense added"
 msgstr "Gasto añadido"
 
-#: src/components/ExpenseEditor.tsx:165
+#: src/components/ExpenseEditor.tsx:170
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
@@ -771,7 +771,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:900
+#: src/components/ExpenseEditor.tsx:915
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -868,7 +868,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:798
+#: src/components/ExpenseEditor.tsx:813
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -953,7 +953,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:469
+#: src/components/ExpenseEditor.tsx:484
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1169,7 +1169,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:268
+#: src/components/ExpenseEditor.tsx:279
 #: src/routes/index.tsx:117
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:103
 #: src/routes/party.$partyId.tsx:226
@@ -1399,7 +1399,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:287
+#: src/components/ExpenseEditor.tsx:298
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1436,7 +1436,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:414
+#: src/components/ExpenseEditor.tsx:429
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:251
 msgid "Paid by"
 msgstr "Pagado por"
@@ -1602,7 +1602,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:816
+#: src/components/ExpenseEditor.tsx:831
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -1667,7 +1667,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1005
+#: src/components/ExpenseEditor.tsx:1020
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -1723,7 +1723,7 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:307
+#: src/components/ExpenseEditor.tsx:318
 #: src/routes/migrate_.tricount.tsx:174
 #: src/routes/new.tsx:158
 #: src/routes/party_.$partyId.settings.tsx:138
@@ -1801,7 +1801,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:666
+#: src/components/ExpenseEditor.tsx:681
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -1809,7 +1809,7 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:802
+#: src/components/ExpenseEditor.tsx:817
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
@@ -1890,7 +1890,7 @@ msgstr "Estadísticas"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:307
+#: src/components/ExpenseEditor.tsx:318
 #: src/routes/migrate_.tricount.tsx:174
 #: src/routes/new.tsx:158
 #: src/routes/party_.$partyId.settings.tsx:138
@@ -1936,11 +1936,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:690
+#: src/components/ExpenseEditor.tsx:705
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:691
+#: src/components/ExpenseEditor.tsx:706
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -1974,7 +1974,7 @@ msgid "Tajikistani Somoni"
 msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:140
-#: src/components/ExpenseEditor.tsx:927
+#: src/components/ExpenseEditor.tsx:942
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2049,7 +2049,7 @@ msgstr "Este proyecto utiliza varias bibliotecas y herramientas de código abier
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:348
+#: src/components/ExpenseEditor.tsx:363
 msgid "Title"
 msgstr "Título"
 
@@ -2173,12 +2173,12 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:841
+#: src/components/ExpenseEditor.tsx:856
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:149
-#: src/components/ExpenseEditor.tsx:936
+#: src/components/ExpenseEditor.tsx:951
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2186,7 +2186,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:879
+#: src/components/ExpenseEditor.tsx:894
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2246,7 +2246,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:986
+#: src/components/ExpenseEditor.tsx:1001
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:321
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -70,7 +70,7 @@ const logger = getLogger("components", "ExpenseEditor");
 
 interface ExpenseEditorProps {
   title: string;
-  onSubmit: (values: ExpenseEditorFormValues) => void;
+  onSubmit: (values: ExpenseEditorFormValues) => void | Promise<void>;
   onChange?: (
     previousValues: ExpenseEditorFormValues,
     currentValues: ExpenseEditorFormValues,
@@ -98,6 +98,7 @@ export function ExpenseEditor({
   const { i18n } = useLingui();
   const { partyList, setAutoOpenCalculator } = usePartyList();
   const autoOpenCalculator = partyList.autoOpenCalculator ?? false;
+  const saveInFlightRef = useRef(false);
   const unsortedParticipants = useExpenseParticipants({
     paidBy: {
       [defaultValues.paidBy]: 1,
@@ -124,7 +125,11 @@ export function ExpenseEditor({
           >,
         ),
     },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
+      if (saveInFlightRef.current) {
+        return;
+      }
+
       // Validate that amounts add up correctly using Dinero.js for precise calculations
       const activeParticipants = Object.keys(value.shares);
       const totalAmount = Dinero({ amount: convertToUnits(value.amount) });
@@ -167,7 +172,13 @@ export function ExpenseEditor({
         return;
       }
 
-      onSubmit(value);
+      saveInFlightRef.current = true;
+
+      try {
+        await onSubmit(value);
+      } finally {
+        saveInFlightRef.current = false;
+      }
     },
   });
 
@@ -320,6 +331,10 @@ export function ExpenseEditor({
         id={formId}
         onSubmit={(e) => {
           e.preventDefault();
+          if (form.state.isSubmitting || saveInFlightRef.current) {
+            return;
+          }
+
           void form.handleSubmit();
         }}
         className="container mt-4 flex flex-col px-4"

--- a/packages/pwa/src/routes/party_.$partyId.add.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.add.tsx
@@ -85,7 +85,7 @@ function AddExpense() {
         photos: values.photos,
       });
 
-      void navigate({
+      await navigate({
         to: "/party/$partyId/expense/$expenseId",
         replace: true,
         params: {
@@ -116,7 +116,7 @@ function AddExpense() {
     <>
       <ExpenseEditor
         title={t`New expense`}
-        onSubmit={(values) => void onCreateExpense(values)}
+        onSubmit={onCreateExpense}
         onChange={(_prev, current) => setPhotos(current.photos)}
         defaultValues={{
           name: "",

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit.tsx
@@ -126,7 +126,7 @@ function EditExpense() {
     [onChangeExpense, expenseId],
   );
 
-  function onSubmit(values: ExpenseEditorFormValues) {
+  async function onSubmit(values: ExpenseEditorFormValues) {
     try {
       // Create shares based on the form values
       const shares: Expense["shares"] = {};
@@ -149,12 +149,12 @@ function EditExpense() {
         photos: values.photos,
       };
 
-      onUpdateExpense({
+      await onUpdateExpense({
         ...expense,
         __hash: calculateExpenseHash(expense),
       });
 
-      void navigate({
+      await navigate({
         to: "/party/$partyId/expense/$expenseId",
         replace: true,
         params: {
@@ -232,7 +232,7 @@ function useExpense() {
   const [expense] = findExpenseById(chunk.expenses, expenseId);
 
   function onUpdateExpense(expense: Expense) {
-    void updateExpense(expense);
+    return updateExpense(expense);
   }
 
   function onChangeExpense(patches: DiffResult[]) {


### PR DESCRIPTION
## Description

Prevents duplicate Expense Editor saves by awaiting the route save promises and blocking additional submit attempts while a save is already in progress.

The root cause was that the add and edit routes detached async save work with `void`, so TanStack Form could clear `isSubmitting` before the create/update and navigation flow finished. This keeps the save action locked until the active save succeeds or fails.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `pnpm lint` and `pnpm typecheck`
- [x] I've run `pnpm test` and all tests pass
- [ ] I've added tests for new functionality (if applicable; no new functionality added)
- [ ] I've run `pnpm lingui:extract` (if I added new strings; no strings added)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this changes save behavior without visual UI changes.

## Additional Notes

Validation run from the repository root:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

A patch changeset was added for `@trizum/pwa`.