### PR TITLE
fix(pwa): support localized Tricount URLs

### DIFF
--- a/.changeset/fuzzy-tricount-urls.md
+++ b/.changeset/fuzzy-tricount-urls.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Fix Tricount imports from localized share URLs.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -888,7 +888,7 @@ msgstr "Go Back"
 msgid "Go back and try again from the balances list."
 msgstr "Go back and try again from the balances list."
 
-#: src/routes/migrate_.tricount.tsx:290
+#: src/routes/migrate_.tricount.tsx:283
 msgid "Go back to home"
 msgstr "Go back to home"
 
@@ -985,7 +985,7 @@ msgstr "Image must be smaller than 10MB"
 msgid "Impact on my balance: <0/>"
 msgstr "Impact on my balance: <0/>"
 
-#: src/routes/migrate_.tricount.tsx:212
+#: src/routes/migrate_.tricount.tsx:205
 msgid "Import attachments"
 msgstr "Import attachments"
 
@@ -1001,7 +1001,7 @@ msgstr "Imported {0} ({1} of {2})"
 msgid "Importing attachments ({0} of {1})"
 msgstr "Importing attachments ({0} of {1})"
 
-#: src/routes/migrate_.tricount.tsx:93
+#: src/routes/migrate_.tricount.tsx:78
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
@@ -1025,7 +1025,7 @@ msgstr "Indonesian Rupiah"
 msgid "Invalid QR code. This doesn't appear to be a trizum party code."
 msgstr "Invalid QR code. This doesn't appear to be a trizum party code."
 
-#: src/routes/migrate_.tricount.tsx:139
+#: src/routes/migrate_.tricount.tsx:132
 msgid "Invalid tricount URL or key"
 msgstr "Invalid tricount URL or key"
 
@@ -1242,15 +1242,15 @@ msgstr "Mexican Peso"
 
 #: src/routes/index.tsx:221
 #: src/routes/index.tsx:419
-#: src/routes/migrate_.tricount.tsx:156
+#: src/routes/migrate_.tricount.tsx:149
 msgid "Migrate from Tricount"
 msgstr "Migrate from Tricount"
 
-#: src/routes/migrate_.tricount.tsx:226
+#: src/routes/migrate_.tricount.tsx:219
 msgid "Migration in progress"
 msgstr "Migration in progress"
 
-#: src/routes/migrate_.tricount.tsx:257
+#: src/routes/migrate_.tricount.tsx:250
 msgid "Migration successful"
 msgstr "Migration successful"
 
@@ -1609,7 +1609,7 @@ msgstr "Party stats"
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
-#: src/routes/migrate_.tricount.tsx:192
+#: src/routes/migrate_.tricount.tsx:185
 msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 msgstr "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 
@@ -1678,11 +1678,11 @@ msgstr "Please allow camera access in your browser settings to scan QR codes."
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
-#: src/routes/migrate_.tricount.tsx:232
+#: src/routes/migrate_.tricount.tsx:225
 msgid "Please don't close the app while we migrate your data"
 msgstr "Please don't close the app while we migrate your data"
 
-#: src/routes/migrate_.tricount.tsx:57
+#: src/routes/migrate_.tricount.tsx:42
 msgid "Please paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or key"
 msgstr "Please paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or key"
 
@@ -1804,7 +1804,7 @@ msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
 #: src/components/ExpenseEditor.tsx:279
-#: src/routes/migrate_.tricount.tsx:167
+#: src/routes/migrate_.tricount.tsx:160
 #: src/routes/new.tsx:148
 #: src/routes/party_.$partyId.settings.tsx:127
 #: src/routes/party_.$partyId.who.tsx:109
@@ -1917,7 +1917,7 @@ msgstr "Solomon Islands Dollar"
 msgid "Somali Shilling"
 msgstr "Somali Shilling"
 
-#: src/routes/migrate_.tricount.tsx:280
+#: src/routes/migrate_.tricount.tsx:273
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
@@ -1975,7 +1975,7 @@ msgid "Submit a Request"
 msgstr "Submit a Request"
 
 #: src/components/ExpenseEditor.tsx:279
-#: src/routes/migrate_.tricount.tsx:167
+#: src/routes/migrate_.tricount.tsx:160
 #: src/routes/new.tsx:148
 #: src/routes/party_.$partyId.settings.tsx:127
 #: src/routes/party_.$partyId.who.tsx:109
@@ -2193,11 +2193,11 @@ msgstr "Tricount key"
 msgid "Tricount key is required"
 msgstr "Tricount key is required"
 
-#: src/routes/migrate_.tricount.tsx:52
+#: src/routes/migrate_.tricount.tsx:37
 msgid "Tricount key or URL is required"
 msgstr "Tricount key or URL is required"
 
-#: src/routes/migrate_.tricount.tsx:191
+#: src/routes/migrate_.tricount.tsx:184
 msgid "Tricount URL or key"
 msgstr "Tricount URL or key"
 
@@ -2351,7 +2351,7 @@ msgstr "Vietnamese Dong"
 msgid "View on GitHub"
 msgstr "View on GitHub"
 
-#: src/routes/migrate_.tricount.tsx:267
+#: src/routes/migrate_.tricount.tsx:260
 msgid "View party"
 msgstr "View party"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -844,7 +844,7 @@ msgstr "Volver"
 msgid "Go back and try again from the balances list."
 msgstr "Vuelve atrás e inténtalo de nuevo desde la lista de saldos."
 
-#: src/routes/migrate_.tricount.tsx:290
+#: src/routes/migrate_.tricount.tsx:283
 msgid "Go back to home"
 msgstr "Volver al inicio"
 
@@ -937,7 +937,7 @@ msgstr "Impacto en mi balance: <0/>"
 msgid "Impact on my balance: <0/>"
 msgstr "Impacto en mi balance: <0/>"
 
-#: src/routes/migrate_.tricount.tsx:212
+#: src/routes/migrate_.tricount.tsx:205
 msgid "Import attachments"
 msgstr "Importar adjuntos"
 
@@ -953,7 +953,7 @@ msgstr "Importado {0} ({1} de {2})"
 msgid "Importing attachments ({0} of {1})"
 msgstr "Importando adjuntos ({0} de {1})"
 
-#: src/routes/migrate_.tricount.tsx:93
+#: src/routes/migrate_.tricount.tsx:78
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
@@ -977,7 +977,7 @@ msgstr "Rupia Indonesia"
 msgid "Invalid QR code. This doesn't appear to be a trizum party code."
 msgstr "Código QR no válido. No parece ser un código de grupo de trizum."
 
-#: src/routes/migrate_.tricount.tsx:139
+#: src/routes/migrate_.tricount.tsx:132
 msgid "Invalid tricount URL or key"
 msgstr "URL o clave de Tricount no válida"
 
@@ -1190,15 +1190,15 @@ msgstr "Peso Mexicano"
 
 #: src/routes/index.tsx:221
 #: src/routes/index.tsx:419
-#: src/routes/migrate_.tricount.tsx:156
+#: src/routes/migrate_.tricount.tsx:149
 msgid "Migrate from Tricount"
 msgstr "Migrar desde Tricount"
 
-#: src/routes/migrate_.tricount.tsx:226
+#: src/routes/migrate_.tricount.tsx:219
 msgid "Migration in progress"
 msgstr "Migración en progreso"
 
-#: src/routes/migrate_.tricount.tsx:257
+#: src/routes/migrate_.tricount.tsx:250
 msgid "Migration successful"
 msgstr "Migración exitosa"
 
@@ -1541,7 +1541,7 @@ msgstr "Estadísticas del grupo"
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
-#: src/routes/migrate_.tricount.tsx:192
+#: src/routes/migrate_.tricount.tsx:185
 msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 msgstr "Pega el mensaje de compartir de Tricount, la URL (p. ej., https://tricount.com/abc123), o la clave directa"
 
@@ -1610,11 +1610,11 @@ msgstr "Por favor, permite el acceso a la cámara en la configuración de tu nav
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
-#: src/routes/migrate_.tricount.tsx:232
+#: src/routes/migrate_.tricount.tsx:225
 msgid "Please don't close the app while we migrate your data"
 msgstr "Por favor, no cierres la aplicación mientras migramos tus datos"
 
-#: src/routes/migrate_.tricount.tsx:57
+#: src/routes/migrate_.tricount.tsx:42
 msgid "Please paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or key"
 msgstr "Por favor, pega el mensaje de compartir de Tricount, la URL (p. ej., https://tricount.com/abc123), o la clave"
 
@@ -1732,7 +1732,7 @@ msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
 #: src/components/ExpenseEditor.tsx:279
-#: src/routes/migrate_.tricount.tsx:167
+#: src/routes/migrate_.tricount.tsx:160
 #: src/routes/new.tsx:148
 #: src/routes/party_.$partyId.settings.tsx:127
 #: src/routes/party_.$partyId.who.tsx:109
@@ -1841,7 +1841,7 @@ msgstr "Dólar de las Islas Salomón"
 msgid "Somali Shilling"
 msgstr "Chelín Somalí"
 
-#: src/routes/migrate_.tricount.tsx:280
+#: src/routes/migrate_.tricount.tsx:273
 msgid "Something went wrong"
 msgstr "Algo salió mal"
 
@@ -1899,7 +1899,7 @@ msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
 #: src/components/ExpenseEditor.tsx:279
-#: src/routes/migrate_.tricount.tsx:167
+#: src/routes/migrate_.tricount.tsx:160
 #: src/routes/new.tsx:148
 #: src/routes/party_.$partyId.settings.tsx:127
 #: src/routes/party_.$partyId.who.tsx:109
@@ -2105,11 +2105,11 @@ msgstr "Transferir deuda"
 msgid "Transfer to another party"
 msgstr "Transferir a otro grupo"
 
-#: src/routes/migrate_.tricount.tsx:52
+#: src/routes/migrate_.tricount.tsx:37
 msgid "Tricount key or URL is required"
 msgstr "Se requiere la clave o URL de Tricount"
 
-#: src/routes/migrate_.tricount.tsx:191
+#: src/routes/migrate_.tricount.tsx:184
 msgid "Tricount URL or key"
 msgstr "URL o clave de Tricount"
 
@@ -2254,7 +2254,7 @@ msgstr "Dong Vietnamita"
 msgid "View on GitHub"
 msgstr "Ver en GitHub"
 
-#: src/routes/migrate_.tricount.tsx:267
+#: src/routes/migrate_.tricount.tsx:260
 msgid "View party"
 msgstr "Ver grupo"
 

--- a/packages/pwa/src/lib/tricount.test.ts
+++ b/packages/pwa/src/lib/tricount.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vite-plus/test";
+
+import { extractTricountId } from "./tricount.ts";
+
+describe("extractTricountId", () => {
+  test("extracts a direct key", () => {
+    expect(extractTricountId("tBDnlEsfSMOQDamELo")).toBe("tBDnlEsfSMOQDamELo");
+  });
+
+  test("extracts the key from a standard Tricount URL", () => {
+    expect(extractTricountId("https://www.tricount.com/tBDnlEsfSMOQDamELo")).toBe(
+      "tBDnlEsfSMOQDamELo",
+    );
+  });
+
+  test("extracts the key from a localized Tricount URL", () => {
+    expect(extractTricountId("https://www.tricount.com/de-de/tBDnlEsfSMOQDamELo")).toBe(
+      "tBDnlEsfSMOQDamELo",
+    );
+  });
+
+  test("extracts the key from a localized Tricount URL inside text", () => {
+    expect(
+      extractTricountId(
+        "Join my Tricount: https://www.tricount.com/de-de/tBDnlEsfSMOQDamELo?utm=share.",
+      ),
+    ).toBe("tBDnlEsfSMOQDamELo");
+  });
+
+  test("rejects a Tricount URL without a key", () => {
+    expect(extractTricountId("https://www.tricount.com/de-de/")).toBeNull();
+  });
+
+  test("rejects unsupported input", () => {
+    expect(extractTricountId("not a key")).toBeNull();
+  });
+});

--- a/packages/pwa/src/lib/tricount.ts
+++ b/packages/pwa/src/lib/tricount.ts
@@ -1,0 +1,33 @@
+const tricountUrlPattern = /https?:\/\/(?:www\.)?tricount\.com\/[^\s<>"']+/i;
+const tricountKeyPattern = /^[a-zA-Z0-9]+$/;
+const localeSegmentPattern = /^[a-z]{2}(?:-[a-z]{2})?$/i;
+
+export function extractTricountId(input: string): string | null {
+  const value = input.trim();
+  const urlMatch = value.match(tricountUrlPattern);
+
+  if (urlMatch) {
+    return extractTricountIdFromUrl(urlMatch[0]);
+  }
+
+  if (tricountKeyPattern.test(value)) {
+    return value;
+  }
+
+  return null;
+}
+
+function extractTricountIdFromUrl(value: string): string | null {
+  try {
+    const url = new URL(value.replace(/[),.;:!?]+$/, ""));
+    const pathSegments = url.pathname.split("/").filter(Boolean);
+    const idSegments =
+      pathSegments.length > 1 && localeSegmentPattern.test(pathSegments[0] ?? "")
+        ? pathSegments.slice(1)
+        : pathSegments;
+
+    return idSegments.find((segment) => tricountKeyPattern.test(segment)) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/pwa/src/routes/migrate_.tricount.tsx
+++ b/packages/pwa/src/routes/migrate_.tricount.tsx
@@ -11,6 +11,7 @@ import { Button } from "#src/ui/Button.tsx";
 import { createPartyFromMigrationData, type MigrationData } from "#src/models/migration.ts";
 import { Checkbox } from "#src/ui/Checkbox.tsx";
 import { getAppLink } from "#src/lib/link.ts";
+import { extractTricountId } from "#src/lib/tricount.ts";
 
 export const Route = createFileRoute("/migrate_/tricount")({
   component: RouteComponent,
@@ -29,22 +30,6 @@ function RouteComponent() {
     case "error":
       return <ErrorState {...state} />;
   }
-}
-
-function extractTricountId(input: string): string | null {
-  // Check if it's a tricount.com URL (standalone or within text)
-  const urlMatch = input.match(/https?:\/\/(?:www\.)?tricount\.com\/([a-zA-Z0-9]+)/);
-  if (urlMatch) {
-    return urlMatch[1];
-  }
-
-  // Check if it's already a direct key (alphanumeric string)
-  const keyMatch = input.match(/^[a-zA-Z0-9]+$/);
-  if (keyMatch) {
-    return input;
-  }
-
-  return null;
 }
 
 function validateTricountKey(value: string) {
@@ -95,12 +80,20 @@ function useMigrateTricount() {
     });
 
     try {
-      const response = await fetch(getAppLink(`/api/migrate?key=${key}`));
-      const data = (await response.json()) as MigrationData;
+      const response = await fetch(getAppLink(`/api/migrate?key=${encodeURIComponent(key)}`));
+      const data = (await response.json()) as MigrationData | { error?: unknown };
+
+      if (!response.ok) {
+        const message =
+          typeof data === "object" && data && "error" in data && typeof data.error === "string"
+            ? data.error
+            : response.statusText;
+        throw new Error(message);
+      }
 
       const partyId = await createPartyFromMigrationData({
         repo,
-        data,
+        data: data as MigrationData,
         importAttachments,
         onProgress: (progress) => {
           setState({


### PR DESCRIPTION
## Description

Fixes Tricount share URL parsing so locale-prefixed URLs such as `https://www.tricount.com/de-de/tBDnlEsfSMOQDamELo` extract the real public identifier instead of the locale segment.

This PR also moves the parser into a focused helper with unit coverage and prevents non-OK migrate API responses from being passed into the importer as migration data.

## Related Issues

Fixes #161

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [ ] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

No UI visual changes.

## Additional Notes

`vp run build` was attempted. The PWA build passes via `vp run --filter @trizum/pwa build`, but the full workspace build fails during the mobile iOS sync step because this local environment has Ruby 2.6.10 with Bundler 1.17.2 while `packages/mobile/ios/App/Gemfile.lock` requires Bundler 2.7.2.

No new user-facing strings were added, so `vp run lingui:extract` was not needed.