### PR TITLE
chore(tooling): run lingui extraction in git hook

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -140,7 +140,7 @@ const toolingConfig = {
     ],
   },
   staged: {
-    "*": "vp check --fix",
+    "*": ["vp check --fix", () => "vp run lingui:extract"],
   },
   plugins: [rootAppCommandGuard()],
   run: {


### PR DESCRIPTION
## Description

Updates the Vite+ staged hook config so the pre-commit hook runs `vp check --fix` and then `vp run lingui:extract`.

The Lingui step is configured as a generated lint-staged task so staged file paths are not appended to the workspace command.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other: tooling

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [ ] I've run `vp run build` (attempted; mobile iOS sync failed because Ruby could not find Bundler 2.7.2 from `packages/mobile/ios/App/Gemfile.lock`)
- [x] I've added tests for new functionality (not applicable: hook config only)
- [x] I've run `vp run lingui:extract` (runs through the hook; no catalog changes)
- [x] I've added a changeset (not applicable: tooling-only change)

## Screenshots

Not applicable.

## Additional Notes

Validation run locally:

- `vp staged --verbose` passed and ran both `vp check --fix` and `vp run lingui:extract`.
- `git commit` pre-commit hook passed and ran both commands again.
- `vp run check` passed on rerun.
- `vp run test` passed.
- `vp run build` failed in `packages/mobile` during iOS Capacitor sync: `/usr/bin/bundle` could not find Bundler 2.7.2.
