### PR TITLE
ci: use bot token for autofix commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: ".node-version"


### PR DESCRIPTION
## Description

Updates the autofix CI job so `actions/checkout` uses `secrets.BOT_GITHUB_TOKEN`. This makes the `EndBug/add-and-commit` push authenticate with the configured bot/PAT token, so autofix commits can retrigger CI instead of being suppressed as default `GITHUB_TOKEN` pushes.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (describe below)

CI configuration.

## Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have run `vp run check`
- [x] I have run `vp run test` and all tests pass
- [ ] I have run `vp run build`
- [x] I have added tests for new functionality (if applicable)
- [x] I have run `vp run lingui:extract` (if I added new strings)
- [x] I have added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

`vp run build` was attempted locally, but the mobile iOS sync step failed before completion because the local system Ruby is `2.6.10` and the iOS lockfile requires Bundler `2.7.2`, which requires Ruby `>= 3.2.0`. Installing `bundler:2.7.2` into the current Ruby failed for that reason.

No user-facing strings or user-facing package changes were added, so Lingui extraction and a changeset are not required.