### PR TITLE
ci(mobile): automate production releases

### DIFF
--- a/.github/workflows/android-playstore-deploy.yml
+++ b/.github/workflows/android-playstore-deploy.yml
@@ -22,6 +22,16 @@ on:
           - draft
           - completed
           - halted
+  workflow_call:
+    inputs:
+      track:
+        description: "Play Store track to deploy to"
+        required: true
+        type: string
+      release_status:
+        description: "Release status"
+        required: true
+        type: string
 
 concurrency:
   group: android-playstore-deploy
@@ -37,6 +47,8 @@ jobs:
     name: Generate Screenshots
     needs: [check-pending-changesets]
     uses: ./.github/workflows/screenshots.yml
+    with:
+      artifact_name: android-screenshots
 
   deploy:
     name: Build & Deploy to Play Store
@@ -72,7 +84,7 @@ jobs:
       - name: Download screenshots artifact
         uses: actions/download-artifact@v8
         with:
-          name: screenshots
+          name: android-screenshots
           path: packages/screenshots/screenshots
 
       - name: Organize screenshots for fastlane

--- a/.github/workflows/ios-appstore-deploy.yml
+++ b/.github/workflows/ios-appstore-deploy.yml
@@ -13,6 +13,18 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      submit_for_review:
+        description: "Submit for App Store review"
+        required: false
+        default: false
+        type: boolean
+      automatic_release:
+        description: "Automatically release after approval"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ios-appstore-deploy
@@ -28,6 +40,8 @@ jobs:
     name: Generate Screenshots
     needs: [check-pending-changesets]
     uses: ./.github/workflows/screenshots.yml
+    with:
+      artifact_name: ios-screenshots
 
   deploy:
     name: Build & Deploy to App Store
@@ -57,7 +71,7 @@ jobs:
       - name: Download screenshots artifact
         uses: actions/download-artifact@v8
         with:
-          name: screenshots
+          name: ios-screenshots
           path: packages/screenshots/screenshots
 
       - name: Organize screenshots for fastlane

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -36,6 +36,26 @@ on:
         options:
           - app-store
           - ad-hoc
+  workflow_call:
+    inputs:
+      platform:
+        description: "Platform to build"
+        required: true
+        type: string
+      build_type:
+        description: "Build type"
+        required: true
+        type: string
+      android_artifact:
+        description: "Android artifact type (only for release builds)"
+        required: false
+        default: "apk"
+        type: string
+      ios_export_method:
+        description: "iOS export method (only for release builds)"
+        required: false
+        default: "app-store"
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,7 +64,7 @@ concurrency:
 jobs:
   android:
     name: Build Android
-    if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both' }}
+    if: ${{ inputs.platform == 'android' || inputs.platform == 'both' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -74,19 +94,19 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Decode Android keystore
-        if: ${{ github.event.inputs.build_type == 'release' }}
+        if: ${{ inputs.build_type == 'release' }}
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > packages/mobile/android/app/release.keystore
 
       - name: Build Android Debug
-        if: ${{ github.event.inputs.build_type == 'debug' }}
+        if: ${{ inputs.build_type == 'debug' }}
         working-directory: packages/mobile/android
         run: bundle exec fastlane build_debug
 
       - name: Build Android Release APK
-        if: ${{ github.event.inputs.build_type == 'release' && github.event.inputs.android_artifact == 'apk' }}
+        if: ${{ inputs.build_type == 'release' && inputs.android_artifact == 'apk' }}
         working-directory: packages/mobile/android
         env:
           ANDROID_KEYSTORE_FILE: ${{ github.workspace }}/packages/mobile/android/app/release.keystore
@@ -96,7 +116,7 @@ jobs:
         run: bundle exec fastlane build_release
 
       - name: Build Android Release AAB
-        if: ${{ github.event.inputs.build_type == 'release' && github.event.inputs.android_artifact == 'aab' }}
+        if: ${{ inputs.build_type == 'release' && inputs.android_artifact == 'aab' }}
         working-directory: packages/mobile/android
         env:
           ANDROID_KEYSTORE_FILE: ${{ github.workspace }}/packages/mobile/android/app/release.keystore
@@ -106,15 +126,15 @@ jobs:
         run: bundle exec fastlane build_aab
 
       - name: Upload Android APK artifact
-        if: ${{ github.event.inputs.android_artifact == 'apk' }}
+        if: ${{ inputs.android_artifact == 'apk' }}
         uses: actions/upload-artifact@v6
         with:
-          name: android-${{ github.event.inputs.build_type }}-apk
+          name: android-${{ inputs.build_type }}-apk
           path: packages/mobile/android/app/build/outputs/apk/**/*.apk
           retention-days: 14
 
       - name: Upload Android AAB artifact
-        if: ${{ github.event.inputs.build_type == 'release' && github.event.inputs.android_artifact == 'aab' }}
+        if: ${{ inputs.build_type == 'release' && inputs.android_artifact == 'aab' }}
         uses: actions/upload-artifact@v6
         with:
           name: android-release-aab
@@ -123,7 +143,7 @@ jobs:
 
   ios:
     name: Build iOS
-    if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' }}
+    if: ${{ inputs.platform == 'ios' || inputs.platform == 'both' }}
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
@@ -147,12 +167,12 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Build iOS Debug
-        if: ${{ github.event.inputs.build_type == 'debug' }}
+        if: ${{ inputs.build_type == 'debug' }}
         working-directory: packages/mobile/ios/App
         run: bundle exec fastlane build_debug
 
       - name: Build iOS Release (App Store)
-        if: ${{ github.event.inputs.build_type == 'release' && github.event.inputs.ios_export_method == 'app-store' }}
+        if: ${{ inputs.build_type == 'release' && inputs.ios_export_method == 'app-store' }}
         working-directory: packages/mobile/ios/App
         env:
           IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
@@ -164,7 +184,7 @@ jobs:
         run: bundle exec fastlane build_release
 
       - name: Build iOS Release (Ad Hoc)
-        if: ${{ github.event.inputs.build_type == 'release' && github.event.inputs.ios_export_method == 'ad-hoc' }}
+        if: ${{ inputs.build_type == 'release' && inputs.ios_export_method == 'ad-hoc' }}
         working-directory: packages/mobile/ios/App
         env:
           IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
@@ -176,15 +196,15 @@ jobs:
         run: bundle exec fastlane build_adhoc
 
       - name: Upload iOS IPA artifact
-        if: ${{ github.event.inputs.build_type == 'release' }}
+        if: ${{ inputs.build_type == 'release' }}
         uses: actions/upload-artifact@v6
         with:
-          name: ios-${{ github.event.inputs.ios_export_method }}-ipa
+          name: ios-${{ inputs.ios_export_method }}-ipa
           path: packages/mobile/ios/App/*.ipa
           retention-days: 14
 
       - name: Upload iOS dSYM artifact
-        if: ${{ github.event.inputs.build_type == 'release' }}
+        if: ${{ inputs.build_type == 'release' }}
         uses: actions/upload-artifact@v6
         with:
           name: ios-dsym

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,79 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           packageManager: npm
           workingDirectory: packages/pwa
+
+  build-mobile-android-release-apk:
+    name: Build Mobile Android Release APK
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, '@trizum/mobile@') && !github.event.release.prerelease
+    permissions:
+      contents: read
+    uses: ./.github/workflows/mobile-build.yml
+    with:
+      platform: android
+      build_type: release
+      android_artifact: apk
+    secrets: inherit
+
+  deploy-mobile-android-production:
+    name: Deploy Mobile Android Production
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, '@trizum/mobile@') && !github.event.release.prerelease
+    permissions:
+      contents: read
+    uses: ./.github/workflows/android-playstore-deploy.yml
+    with:
+      track: production
+      release_status: completed
+    secrets: inherit
+
+  deploy-mobile-ios-production:
+    name: Deploy Mobile iOS Production
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, '@trizum/mobile@') && !github.event.release.prerelease
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ios-appstore-deploy.yml
+    with:
+      submit_for_review: true
+      automatic_release: true
+    secrets: inherit
+
+  attach-mobile-android-release-assets:
+    name: Attach Mobile Android Release Assets
+    needs: [build-mobile-android-release-apk, deploy-mobile-android-production]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, '@trizum/mobile@') && !github.event.release.prerelease
+    permissions:
+      contents: write
+    steps:
+      - name: Download signed APK artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: android-release-apk
+          path: release-assets/apk
+
+      - name: Download signed AAB artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: android-playstore-aab
+          path: release-assets/aab
+
+      - name: Attach Android release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#@trizum/mobile@}"
+          apk_path="$(find release-assets/apk -name "*.apk" -print -quit)"
+          aab_path="$(find release-assets/aab -name "*.aab" -print -quit)"
+
+          if [ -z "$apk_path" ] || [ -z "$aab_path" ]; then
+            echo "Missing Android APK or AAB artifact" >&2
+            exit 1
+          fi
+
+          cp "$apk_path" "trizum-mobile-${version}-signed.apk"
+          cp "$aab_path" "trizum-mobile-${version}-signed.aab"
+          gh release upload "$RELEASE_TAG" \
+            "trizum-mobile-${version}-signed.apk" \
+            "trizum-mobile-${version}-signed.aab" \
+            --clobber

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -2,7 +2,19 @@ name: Make app screenshots
 
 on:
   workflow_dispatch:
+    inputs:
+      artifact_name:
+        description: "Name for the screenshots artifact"
+        required: false
+        default: "screenshots"
+        type: string
   workflow_call:
+    inputs:
+      artifact_name:
+        description: "Name for the screenshots artifact"
+        required: false
+        default: "screenshots"
+        type: string
 
 jobs:
   screenshots:
@@ -30,6 +42,6 @@ jobs:
       - name: Upload screenshots
         uses: actions/upload-artifact@v6
         with:
-          name: screenshots
+          name: ${{ inputs.artifact_name }}
           path: packages/screenshots/screenshots
           retention-days: 7

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -297,18 +297,26 @@ A `workflow_dispatch` workflow is available for building mobile apps in CI. Navi
 - **Android artifact**: `apk` or `aab` (for release builds)
 - **iOS export method**: `app-store` or `ad-hoc` (for release builds)
 
+Published, non-prerelease GitHub releases tagged as `@trizum/mobile@*` also
+trigger the shared release workflow. That path reuses the mobile build and
+store deployment workflows to generate store screenshots, publish Android to the
+Play Store production track with `release_status` `completed`, submit iOS to
+App Store review with `automatic_release` enabled, and attach the signed Android
+APK and AAB to the GitHub release.
+
 ### Required Secrets
 
 Configure these secrets in your GitHub repository settings (**Settings → Secrets and variables → Actions**):
 
 #### Android Secrets
 
-| Secret                      | Description                     |
-| --------------------------- | ------------------------------- |
-| `ANDROID_KEYSTORE_BASE64`   | Base64-encoded release keystore |
-| `ANDROID_KEYSTORE_PASSWORD` | Keystore password               |
-| `ANDROID_KEY_ALIAS`         | Key alias                       |
-| `ANDROID_KEY_PASSWORD`      | Key password                    |
+| Secret                        | Description                                     |
+| ----------------------------- | ----------------------------------------------- |
+| `ANDROID_KEYSTORE_BASE64`     | Base64-encoded release keystore                 |
+| `ANDROID_KEYSTORE_PASSWORD`   | Keystore password                               |
+| `ANDROID_KEY_ALIAS`           | Key alias                                       |
+| `ANDROID_KEY_PASSWORD`        | Key password                                    |
+| `GOOGLE_PLAY_JSON_KEY_BASE64` | Base64-encoded Google Play service account JSON |
 
 **How to get Android secrets:**
 


### PR DESCRIPTION
## Description

- Reuses the existing mobile build and store deployment workflows from the shared release workflow for `@trizum/mobile@*` releases.
- Publishes Android production releases with `release_status: completed` and submits iOS releases with automatic release after App Store approval.
- Builds the signed Android APK separately, downloads it with the production AAB artifact, and attaches both assets to the GitHub release.
- Makes the screenshots workflow artifact name configurable so concurrent Android and iOS deploys do not collide.
- Documents the automated mobile release path and required Play Store JSON secret.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [x] Other (CI/release automation)

## Checklist

- [ ] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [ ] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

`vp run build` was attempted locally. The PWA and mobile copy steps completed, but the build failed during iOS native dependency sync because local system Ruby could not satisfy Bundler `2.7.2` from `packages/mobile/ios/App/Gemfile.lock`:

```text
Could not find 'bundler' (2.7.2) required by packages/mobile/ios/App/Gemfile.lock
```

The GitHub workflows install Ruby 3.2 and Bundler 2.7.2 via `ruby/setup-ruby`, so this appears to be a local native toolchain gap rather than a workflow syntax issue.
