### PR TITLE
fix(mobile): guard Android app update checks

### DIFF
--- a/.changeset/quiet-android-updates.md
+++ b/.changeset/quiet-android-updates.md
@@ -1,0 +1,6 @@
+---
+"@trizum/mobile": patch
+"@trizum/pwa": patch
+---
+
+Prevent Android startup from invoking Google Play in-app update checks on unsupported installs or devices without Google Play support.

--- a/.github/workflows/android-internal-testing.yml
+++ b/.github/workflows/android-internal-testing.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: android-internal-testing-pr-${{ github.event.pull_request.number }}
@@ -74,6 +75,11 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           GOOGLE_PLAY_JSON_KEY_FILE: ${{ github.workspace }}/packages/mobile/android/play-store-key.json
         run: bundle exec fastlane deploy_internal_testing
+
+      - name: Remove internal testing label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "android:internal-testing"
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/android-internal-testing.yml
+++ b/.github/workflows/android-internal-testing.yml
@@ -77,12 +77,95 @@ jobs:
           GOOGLE_PLAY_JSON_KEY_FILE: ${{ github.workspace }}/packages/mobile/android/play-store-key.json
         run: bundle exec fastlane deploy_internal_testing
 
+      - name: Collect Android artifact metadata
+        id: android_artifacts
+        run: |
+          apk_path="$(find packages/mobile/android/app/build/outputs/apk/release -type f -name "*.apk" | sort | head -n 1)"
+          aab_path="$(find packages/mobile/android/app/build/outputs/bundle/release -type f -name "*.aab" | sort | head -n 1)"
+
+          if [ -z "$apk_path" ]; then
+            echo "Missing release APK" >&2
+            exit 1
+          fi
+
+          if [ -z "$aab_path" ]; then
+            echo "Missing release AAB" >&2
+            exit 1
+          fi
+
+          build_tools_dir="$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
+          version_code="$("$build_tools_dir/aapt" dump badging "$apk_path" | sed -n "s/.*versionCode='\([^']*\)'.*/\1/p")"
+
+          if [ -z "$version_code" ]; then
+            echo "Unable to determine APK versionCode" >&2
+            exit 1
+          fi
+
+          echo "apk_path=$apk_path" >> "$GITHUB_OUTPUT"
+          echo "aab_path=$aab_path" >> "$GITHUB_OUTPUT"
+          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK artifact
+        id: upload_apk_artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: android-internal-testing-apk
+          path: ${{ steps.android_artifacts.outputs.apk_path }}
+          retention-days: 14
+
       - name: Upload AAB artifact
+        id: upload_aab_artifact
         uses: actions/upload-artifact@v6
         with:
           name: android-internal-testing-aab
-          path: packages/mobile/android/app/build/outputs/bundle/**/*.aab
+          path: ${{ steps.android_artifacts.outputs.aab_path }}
           retention-days: 14
+
+      - name: Comment with Android artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          APK_ARTIFACT_URL: ${{ steps.upload_apk_artifact.outputs.artifact-url }}
+          AAB_ARTIFACT_URL: ${{ steps.upload_aab_artifact.outputs.artifact-url }}
+          VERSION_CODE: ${{ steps.android_artifacts.outputs.version_code }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          marker="<!-- trizum-android-internal-testing-artifacts -->"
+          body_file="$(mktemp)"
+
+          cat > "$body_file" <<EOF
+          $marker
+          Android internal testing build is ready.
+
+          - APK: [download artifact]($APK_ARTIFACT_URL)
+          - AAB: [download artifact]($AAB_ARTIFACT_URL)
+          - Play Store track: internal testing
+          - Version code: \`$VERSION_CODE\`
+          - Workflow run: [#${GITHUB_RUN_NUMBER}]($RUN_URL)
+
+          Artifacts are retained for 14 days and require GitHub access to this repository.
+          EOF
+
+          comment_id="$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --paginate \
+              --jq '.[] | select(.body | contains("<!-- trizum-android-internal-testing-artifacts -->")) | .id' \
+              | tail -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              --field body="$(cat "$body_file")" \
+              --silent
+          else
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --field body="$(cat "$body_file")" \
+              --silent
+          fi
 
       - name: Remove internal testing label
         env:

--- a/.github/workflows/android-internal-testing.yml
+++ b/.github/workflows/android-internal-testing.yml
@@ -1,0 +1,89 @@
+name: Android Internal Testing
+
+run-name: "Android internal testing for PR #${{ github.event.pull_request.number }}"
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-internal-testing-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy PR build to Play Store internal testing
+    if: >-
+      !github.event.pull_request.head.repo.fork &&
+      contains(github.event.pull_request.labels.*.name, 'android:internal-testing')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler: "2.7.2"
+          bundler-cache: true
+          cache-version: android-0
+          working-directory: packages/mobile/android
+
+      - name: Build mobile web assets
+        run: vp run --filter @trizum/mobile build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Decode Android keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > packages/mobile/android/app/release.keystore
+
+      - name: Decode Google Play JSON key
+        env:
+          GOOGLE_PLAY_JSON_KEY_BASE64: ${{ secrets.GOOGLE_PLAY_JSON_KEY_BASE64 }}
+        run: |
+          echo "$GOOGLE_PLAY_JSON_KEY_BASE64" | base64 -d > packages/mobile/android/play-store-key.json
+
+      - name: Deploy to Play Store internal testing
+        working-directory: packages/mobile/android
+        env:
+          ANDROID_KEYSTORE_FILE: ${{ github.workspace }}/packages/mobile/android/app/release.keystore
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          GOOGLE_PLAY_JSON_KEY_FILE: ${{ github.workspace }}/packages/mobile/android/play-store-key.json
+        run: bundle exec fastlane deploy_internal_testing
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: android-internal-testing-aab
+          path: packages/mobile/android/app/build/outputs/bundle/**/*.aab
+          retention-days: 14
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: |
+          rm -f packages/mobile/android/play-store-key.json
+          rm -f packages/mobile/android/app/release.keystore

--- a/.github/workflows/android-internal-testing.yml
+++ b/.github/workflows/android-internal-testing.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 concurrency:
   group: android-internal-testing-pr-${{ github.event.pull_request.number }}
@@ -76,17 +77,28 @@ jobs:
           GOOGLE_PLAY_JSON_KEY_FILE: ${{ github.workspace }}/packages/mobile/android/play-store-key.json
         run: bundle exec fastlane deploy_internal_testing
 
-      - name: Remove internal testing label
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "android:internal-testing"
-
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v6
         with:
           name: android-internal-testing-aab
           path: packages/mobile/android/app/build/outputs/bundle/**/*.aab
           retention-days: 14
+
+      - name: Remove internal testing label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if ! gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
+            --jq '.[].name' | grep -qx "android:internal-testing"; then
+            echo "android:internal-testing label is already absent."
+            exit 0
+          fi
+
+          gh api \
+            --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/android%3Ainternal-testing" \
+            --silent
 
       - name: Cleanup sensitive files
         if: always()

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,0 +1,139 @@
+name: iOS TestFlight
+
+run-name: "iOS TestFlight for PR #${{ github.event.pull_request.number }}"
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ios-testflight-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy PR build to TestFlight
+    if: >-
+      !github.event.pull_request.head.repo.fork &&
+      contains(github.event.pull_request.labels.*.name, 'ios:testflight')
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler: "2.7.2"
+          bundler-cache: true
+          cache-version: ios-0
+          working-directory: packages/mobile/ios/App
+
+      - name: Build mobile web assets
+        run: vp run --filter @trizum/mobile build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Deploy to TestFlight
+        working-directory: packages/mobile/ios/App
+        env:
+          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APPSTORE_PROVISIONING_PROFILE_BASE64 }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+        run: bundle exec fastlane deploy_pr_testflight
+
+      - name: Collect TestFlight metadata
+        id: testflight
+        run: |
+          version="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" packages/mobile/ios/App/App/Info.plist)"
+          build_number="$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" packages/mobile/ios/App/App/Info.plist)"
+
+          if [ -z "$version" ]; then
+            echo "Unable to determine iOS version" >&2
+            exit 1
+          fi
+
+          if [ -z "$build_number" ]; then
+            echo "Unable to determine iOS build number" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
+
+      - name: Comment with TestFlight availability
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERSION: ${{ steps.testflight.outputs.version }}
+          BUILD_NUMBER: ${{ steps.testflight.outputs.build_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          marker="<!-- trizum-ios-testflight -->"
+          body_file="$(mktemp)"
+
+          cat > "$body_file" <<EOF
+          $marker
+          This PR is available on TestFlight.
+
+          - Version: \`$VERSION\`
+          - Build: \`$BUILD_NUMBER\`
+          - Workflow run: [#${GITHUB_RUN_NUMBER}]($RUN_URL)
+
+          The TestFlight build was uploaded from this PR head and may require App Store Connect access depending on tester permissions.
+          EOF
+
+          comment_id="$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --paginate \
+              --jq '.[] | select(.body | contains("<!-- trizum-ios-testflight -->")) | .id' \
+              | tail -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              --field body="$(cat "$body_file")" \
+              --silent
+          else
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --field body="$(cat "$body_file")" \
+              --silent
+          fi
+
+      - name: Remove TestFlight label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if ! gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
+            --jq '.[].name' | grep -qx "ios:testflight"; then
+            echo "ios:testflight label is already absent."
+            exit 0
+          fi
+
+          gh api \
+            --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/ios%3Atestflight" \
+            --silent

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -319,10 +319,12 @@ comment, the workflow removes the label.
 
 Add the `ios:testflight` label to a non-fork pull request to build a signed iOS
 release from the PR head and upload it to TestFlight. The workflow computes a
-temporary iOS build number from the highest TestFlight build already present
-for the current app version and fails before it reaches the next release
-build-number range. After a successful TestFlight upload, the workflow comments
-on the PR with the TestFlight version/build details and removes the label.
+temporary iOS version/build pair from the next patch TestFlight train, then
+fails before it reaches the following patch's build-number range. This avoids
+uploading to a released App Store train that App Store Connect has already
+closed for new pre-release builds. After a successful TestFlight upload, the
+workflow comments on the PR with the TestFlight version/build details and
+removes the label.
 
 Published, non-prerelease GitHub releases tagged as `@trizum/mobile@*` also
 trigger the shared release workflow. That path reuses the mobile build and

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -308,6 +308,13 @@ A `workflow_dispatch` workflow is available for building mobile apps in CI. Navi
 - **Android artifact**: `apk` or `aab` (for release builds)
 - **iOS export method**: `app-store` or `ad-hoc` (for release builds)
 
+Add the `android:internal-testing` label to a non-fork pull request to build a
+signed Android App Bundle from the PR head and upload it to the Google Play
+internal testing track. The workflow computes a temporary Android `versionCode`
+from the highest version code already present in Play Store tracks and fails
+before it reaches the next release version-code range, so PR uploads do not
+silently block the next production patch release.
+
 Published, non-prerelease GitHub releases tagged as `@trizum/mobile@*` also
 trigger the shared release workflow. That path reuses the mobile build and
 store deployment workflows to generate store screenshots, publish Android to the

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -317,6 +317,13 @@ reaches the next release version-code range, so PR uploads do not silently block
 the next production patch release. After a successful internal release and PR
 comment, the workflow removes the label.
 
+Add the `ios:testflight` label to a non-fork pull request to build a signed iOS
+release from the PR head and upload it to TestFlight. The workflow computes a
+temporary iOS build number from the highest TestFlight build already present
+for the current app version and fails before it reaches the next release
+build-number range. After a successful TestFlight upload, the workflow comments
+on the PR with the TestFlight version/build details and removes the label.
+
 Published, non-prerelease GitHub releases tagged as `@trizum/mobile@*` also
 trigger the shared release workflow. That path reuses the mobile build and
 store deployment workflows to generate store screenshots, publish Android to the

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -308,12 +308,14 @@ A `workflow_dispatch` workflow is available for building mobile apps in CI. Navi
 - **Android artifact**: `apk` or `aab` (for release builds)
 - **iOS export method**: `app-store` or `ad-hoc` (for release builds)
 
-Add the `android:internal-testing` label to a non-fork pull request to build a
-signed Android App Bundle from the PR head and upload it to the Google Play
-internal testing track. The workflow computes a temporary Android `versionCode`
-from the highest version code already present in Play Store tracks and fails
-before it reaches the next release version-code range, so PR uploads do not
-silently block the next production patch release.
+Add the `android:internal-testing` label to a non-fork pull request to build
+signed Android APK and AAB artifacts from the PR head, upload the AAB to the
+Google Play internal testing track, and comment on the PR with links to both
+artifacts. The workflow computes a temporary Android `versionCode` from the
+highest version code already present in Play Store tracks and fails before it
+reaches the next release version-code range, so PR uploads do not silently block
+the next production patch release. After a successful internal release and PR
+comment, the workflow removes the label.
 
 Published, non-prerelease GitHub releases tagged as `@trizum/mobile@*` also
 trigger the shared release workflow. That path reuses the mobile build and

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "com.google.android.play:app-update:$androidPlayAppUpdateVersion"
+    implementation "com.google.android.gms:play-services-base:$androidPlayServicesBaseVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 
+def trizumVersionCodeOverride = findProperty("trizumVersionCode")
+
 android {
     namespace "app.trizum.capacitor"
     compileSdk rootProject.ext.compileSdkVersion
@@ -8,6 +10,9 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 10080000
+        if (trizumVersionCodeOverride != null) {
+            versionCode trizumVersionCodeOverride.toString().toInteger()
+        }
         versionName "1.8.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <package android:name="com.android.vending" />
+        <package android:name="com.google.android.gms" />
+    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/packages/mobile/android/app/src/main/java/app/trizum/capacitor/MainActivity.java
+++ b/packages/mobile/android/app/src/main/java/app/trizum/capacitor/MainActivity.java
@@ -1,5 +1,12 @@
 package app.trizum.capacitor;
 
+import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        registerPlugin(NativeUpdateEnvironmentPlugin.class);
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/packages/mobile/android/app/src/main/java/app/trizum/capacitor/NativeUpdateEnvironmentPlugin.java
+++ b/packages/mobile/android/app/src/main/java/app/trizum/capacitor/NativeUpdateEnvironmentPlugin.java
@@ -1,0 +1,313 @@
+package app.trizum.capacitor;
+
+import static android.app.Activity.RESULT_CANCELED;
+import static android.app.Activity.RESULT_OK;
+import static com.google.android.play.core.install.model.ActivityResult.RESULT_IN_APP_UPDATE_FAILED;
+
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.IntentSenderRequest;
+import androidx.activity.result.contract.ActivityResultContracts;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.tasks.Task;
+import com.google.android.play.core.appupdate.AppUpdateInfo;
+import com.google.android.play.core.appupdate.AppUpdateManager;
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory;
+import com.google.android.play.core.appupdate.AppUpdateOptions;
+import com.google.android.play.core.install.model.AppUpdateType;
+import com.google.android.play.core.install.model.UpdateAvailability;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "NativeUpdateEnvironment")
+public class NativeUpdateEnvironmentPlugin extends Plugin {
+
+    private static final String TAG = "NativeUpdateEnvironment";
+    private static final String GOOGLE_PLAY_SERVICES_PACKAGE = "com.google.android.gms";
+    private static final String GOOGLE_PLAY_STORE_PACKAGE = "com.android.vending";
+    private static final int UPDATE_OK = 0;
+    private static final int UPDATE_CANCELED = 1;
+    private static final int UPDATE_FAILED = 2;
+    private static final int UPDATE_NOT_AVAILABLE = 3;
+    private static final int UPDATE_NOT_ALLOWED = 4;
+
+    private AppUpdateManager appUpdateManager;
+    private ActivityResultLauncher<IntentSenderRequest> immediateUpdateLauncher;
+    private PluginCall savedImmediateUpdateCall;
+
+    @Override
+    public void load() {
+        this.appUpdateManager = AppUpdateManagerFactory.create(this.getContext());
+        this.immediateUpdateLauncher = bridge.registerForActivityResult(
+                new ActivityResultContracts.StartIntentSenderForResult(),
+                result -> this.handleImmediateUpdateResult(result)
+            );
+    }
+
+    @PluginMethod
+    public void getAndroidUpdateSupport(PluginCall call) {
+        AndroidUpdateSupport support = this.getAndroidUpdateSupport();
+
+        JSObject ret = new JSObject();
+        ret.put("hasGooglePlayServices", support.hasGooglePlayServices);
+        ret.put("hasAvailableGooglePlayServices", support.hasAvailableGooglePlayServices);
+        ret.put("hasGooglePlayStore", support.hasGooglePlayStore);
+        ret.put("wasInstalledByGooglePlayStore", support.wasInstalledByGooglePlayStore);
+        ret.put("supportsGooglePlayInAppUpdates", support.supportsGooglePlayInAppUpdates);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void getAndroidAppUpdateInfo(PluginCall call) {
+        try {
+            AndroidUpdateSupport support = this.getAndroidUpdateSupport();
+            if (!support.supportsGooglePlayInAppUpdates) {
+                this.resolveUnavailableAppUpdateInfo(call);
+                return;
+            }
+
+            Task<AppUpdateInfo> appUpdateInfoTask = this.appUpdateManager.getAppUpdateInfo();
+            appUpdateInfoTask.addOnSuccessListener(appUpdateInfo -> this.resolveAppUpdateInfo(call, appUpdateInfo));
+            appUpdateInfoTask.addOnFailureListener(failure -> call.reject(failure.getMessage()));
+        } catch (Exception exception) {
+            Logger.error(TAG, exception.getMessage(), exception);
+            call.reject(exception.getMessage());
+        }
+    }
+
+    @PluginMethod
+    public void performAndroidImmediateUpdate(PluginCall call) {
+        try {
+            if (this.savedImmediateUpdateCall != null) {
+                this.resolveUpdateResult(call, UPDATE_NOT_ALLOWED);
+                return;
+            }
+
+            AndroidUpdateSupport support = this.getAndroidUpdateSupport();
+            if (!support.supportsGooglePlayInAppUpdates) {
+                this.resolveUpdateResult(call, UPDATE_NOT_AVAILABLE);
+                return;
+            }
+
+            Task<AppUpdateInfo> appUpdateInfoTask = this.appUpdateManager.getAppUpdateInfo();
+            appUpdateInfoTask.addOnSuccessListener(appUpdateInfo -> this.performAndroidImmediateUpdate(call, appUpdateInfo));
+            appUpdateInfoTask.addOnFailureListener(failure -> call.reject(failure.getMessage()));
+        } catch (Exception exception) {
+            Logger.error(TAG, exception.getMessage(), exception);
+            call.reject(exception.getMessage());
+        }
+    }
+
+    private void performAndroidImmediateUpdate(PluginCall call, AppUpdateInfo appUpdateInfo) {
+        try {
+            int updateAvailability = appUpdateInfo.updateAvailability();
+            if (updateAvailability != UpdateAvailability.UPDATE_AVAILABLE && updateAvailability != UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
+                this.resolveUpdateResult(call, UPDATE_NOT_AVAILABLE);
+                return;
+            }
+
+            if (
+                updateAvailability == UpdateAvailability.UPDATE_AVAILABLE &&
+                !appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+            ) {
+                this.resolveUpdateResult(call, UPDATE_NOT_ALLOWED);
+                return;
+            }
+
+            if (this.savedImmediateUpdateCall != null) {
+                this.resolveUpdateResult(call, UPDATE_NOT_ALLOWED);
+                return;
+            }
+
+            this.savedImmediateUpdateCall = call;
+            AppUpdateOptions appUpdateOptions = AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build();
+            boolean started = this.appUpdateManager.startUpdateFlowForResult(
+                    appUpdateInfo,
+                    this.immediateUpdateLauncher,
+                    appUpdateOptions
+                );
+            if (!started) {
+                this.savedImmediateUpdateCall = null;
+                this.resolveUpdateResult(call, UPDATE_FAILED);
+            }
+        } catch (Exception exception) {
+            Logger.error(TAG, exception.getMessage(), exception);
+            this.savedImmediateUpdateCall = null;
+            call.reject(exception.getMessage());
+        }
+    }
+
+    private void handleImmediateUpdateResult(ActivityResult result) {
+        try {
+            if (this.savedImmediateUpdateCall == null) {
+                return;
+            }
+
+            int resultCode = result.getResultCode();
+            if (resultCode == RESULT_OK) {
+                this.resolveUpdateResult(this.savedImmediateUpdateCall, UPDATE_OK);
+            } else if (resultCode == RESULT_CANCELED) {
+                this.resolveUpdateResult(this.savedImmediateUpdateCall, UPDATE_CANCELED);
+            } else if (resultCode == RESULT_IN_APP_UPDATE_FAILED) {
+                this.resolveUpdateResult(this.savedImmediateUpdateCall, UPDATE_FAILED);
+            } else {
+                this.resolveUpdateResult(this.savedImmediateUpdateCall, UPDATE_FAILED);
+            }
+            this.savedImmediateUpdateCall = null;
+        } catch (Exception exception) {
+            Logger.error(TAG, exception.getMessage(), exception);
+            if (this.savedImmediateUpdateCall != null) {
+                this.savedImmediateUpdateCall.reject(exception.getMessage());
+                this.savedImmediateUpdateCall = null;
+            }
+        }
+    }
+
+    private void resolveAppUpdateInfo(PluginCall call, AppUpdateInfo appUpdateInfo) {
+        try {
+            PackageInfo packageInfo = this.getPackageInfo();
+            JSObject ret = new JSObject();
+            ret.put("currentVersionName", packageInfo.versionName);
+            ret.put("currentVersionCode", this.getVersionCode(packageInfo));
+            ret.put("availableVersionCode", String.valueOf(appUpdateInfo.availableVersionCode()));
+            ret.put("updateAvailability", appUpdateInfo.updateAvailability());
+            ret.put("updatePriority", appUpdateInfo.updatePriority());
+            ret.put("immediateUpdateAllowed", appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE));
+            ret.put("flexibleUpdateAllowed", appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE));
+            Integer clientVersionStalenessDays = appUpdateInfo.clientVersionStalenessDays();
+            if (clientVersionStalenessDays != null) {
+                ret.put("clientVersionStalenessDays", clientVersionStalenessDays);
+            }
+            ret.put("installStatus", appUpdateInfo.installStatus());
+            call.resolve(ret);
+        } catch (PackageManager.NameNotFoundException exception) {
+            call.reject("Unable to get app info.");
+        }
+    }
+
+    private void resolveUnavailableAppUpdateInfo(PluginCall call) {
+        try {
+            PackageInfo packageInfo = this.getPackageInfo();
+            JSObject ret = new JSObject();
+            ret.put("currentVersionName", packageInfo.versionName);
+            ret.put("currentVersionCode", this.getVersionCode(packageInfo));
+            ret.put("updateAvailability", UpdateAvailability.UPDATE_NOT_AVAILABLE);
+            ret.put("immediateUpdateAllowed", false);
+            ret.put("flexibleUpdateAllowed", false);
+            call.resolve(ret);
+        } catch (PackageManager.NameNotFoundException exception) {
+            call.reject("Unable to get app info.");
+        }
+    }
+
+    private void resolveUpdateResult(PluginCall call, int code) {
+        JSObject ret = new JSObject();
+        ret.put("code", code);
+        call.resolve(ret);
+    }
+
+    private AndroidUpdateSupport getAndroidUpdateSupport() {
+        boolean hasGooglePlayServices = this.isPackageAvailable(GOOGLE_PLAY_SERVICES_PACKAGE);
+        boolean hasGooglePlayStore = this.isPackageAvailable(GOOGLE_PLAY_STORE_PACKAGE);
+        boolean wasInstalledByGooglePlayStore = this.wasInstalledByGooglePlayStore();
+        boolean hasAvailableGooglePlayServices =
+            hasGooglePlayServices &&
+            hasGooglePlayStore &&
+            wasInstalledByGooglePlayStore &&
+            this.isGooglePlayServicesAvailable();
+
+        return new AndroidUpdateSupport(
+            hasGooglePlayServices,
+            hasAvailableGooglePlayServices,
+            hasGooglePlayStore,
+            wasInstalledByGooglePlayStore
+        );
+    }
+
+    private boolean isPackageAvailable(String packageName) {
+        try {
+            PackageInfo packageInfo = this.getContext().getPackageManager().getPackageInfo(packageName, 0);
+            return packageInfo.applicationInfo != null && packageInfo.applicationInfo.enabled;
+        } catch (PackageManager.NameNotFoundException exception) {
+            return false;
+        }
+    }
+
+    private boolean isGooglePlayServicesAvailable() {
+        return (
+            GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(this.getContext()) ==
+            ConnectionResult.SUCCESS
+        );
+    }
+
+    private boolean wasInstalledByGooglePlayStore() {
+        String installerPackageName = this.getInstallerPackageName();
+        return GOOGLE_PLAY_STORE_PACKAGE.equals(installerPackageName);
+    }
+
+    @SuppressWarnings("deprecation")
+    private String getInstallerPackageName() {
+        PackageManager packageManager = this.getContext().getPackageManager();
+        String packageName = this.getContext().getPackageName();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                return packageManager.getInstallSourceInfo(packageName).getInstallingPackageName();
+            } catch (PackageManager.NameNotFoundException exception) {
+                return null;
+            }
+        }
+
+        return packageManager.getInstallerPackageName(packageName);
+    }
+
+    private PackageInfo getPackageInfo() throws PackageManager.NameNotFoundException {
+        String packageName = this.getContext().getPackageName();
+        PackageManager packageManager = this.getContext().getPackageManager();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0));
+        }
+
+        return packageManager.getPackageInfo(packageName, 0);
+    }
+
+    @SuppressWarnings("deprecation")
+    private String getVersionCode(PackageInfo packageInfo) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return String.valueOf(packageInfo.getLongVersionCode());
+        }
+
+        return String.valueOf(packageInfo.versionCode);
+    }
+
+    private static class AndroidUpdateSupport {
+
+        private final boolean hasGooglePlayServices;
+        private final boolean hasAvailableGooglePlayServices;
+        private final boolean hasGooglePlayStore;
+        private final boolean wasInstalledByGooglePlayStore;
+        private final boolean supportsGooglePlayInAppUpdates;
+
+        private AndroidUpdateSupport(
+            boolean hasGooglePlayServices,
+            boolean hasAvailableGooglePlayServices,
+            boolean hasGooglePlayStore,
+            boolean wasInstalledByGooglePlayStore
+        ) {
+            this.hasGooglePlayServices = hasGooglePlayServices;
+            this.hasAvailableGooglePlayServices = hasAvailableGooglePlayServices;
+            this.hasGooglePlayStore = hasGooglePlayStore;
+            this.wasInstalledByGooglePlayStore = wasInstalledByGooglePlayStore;
+            this.supportsGooglePlayInAppUpdates =
+                hasAvailableGooglePlayServices && hasGooglePlayStore && wasInstalledByGooglePlayStore;
+        }
+    }
+}

--- a/packages/mobile/android/capacitor.settings.gradle
+++ b/packages/mobile/android/capacitor.settings.gradle
@@ -12,7 +12,7 @@ include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/splash-screen/android')
 
 include ':capawesome-capacitor-app-update'
-project(':capawesome-capacitor-app-update').projectDir = new File('../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.1_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-app-update/android')
+project(':capawesome-capacitor-app-update').projectDir = new File('../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.3_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-app-update/android')
 
 include ':capacitor-plugin-safe-area'
 project(':capacitor-plugin-safe-area').projectDir = new File('../../../node_modules/.pnpm/capacitor-plugin-safe-area@5.0.0_@capacitor+core@8.0.1/node_modules/capacitor-plugin-safe-area/android')

--- a/packages/mobile/android/fastlane/Fastfile
+++ b/packages/mobile/android/fastlane/Fastfile
@@ -37,12 +37,17 @@ platform :android do
   end
 
   desc "Build release AAB (Android App Bundle)"
-  lane :build_aab do
+  lane :build_aab do |options|
+    properties = signing_properties
+    if options[:version_code]
+      properties["trizumVersionCode"] = options[:version_code].to_s
+    end
+
     gradle(
       task: "bundle",
       build_type: "Release",
       print_command: true,
-      properties: signing_properties
+      properties: properties
     )
   end
 
@@ -57,6 +62,21 @@ platform :android do
       track: "internal",
       release_status: "draft",
       aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+    )
+  end
+
+  desc "Build and upload PR build to Google Play internal testing"
+  lane :deploy_internal_testing do
+    version_code = next_internal_testing_version_code
+    build_aab(version_code: version_code)
+    upload_to_play_store(
+      track: "internal",
+      release_status: "completed",
+      aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
     )
   end
 
@@ -223,13 +243,43 @@ platform :android do
     # Read version from build.gradle
     build_gradle = File.read("../app/build.gradle")
     version_name = build_gradle.match(/versionName\s+"([^"]+)"/)[1]
-    version_code = build_gradle.match(/versionCode\s+(\d+)/)[1]
+    version_code = release_version_code
     UI.success("Current version: #{version_name} (#{version_code})")
   end
 
   # ============================================
   # Private Helper Methods
   # ============================================
+
+  private_lane :release_version_code do
+    build_gradle = File.read("../app/build.gradle")
+    build_gradle.match(/versionCode\s+(\d+)/)[1].to_i
+  end
+
+  private_lane :next_internal_testing_version_code do
+    base_version_code = release_version_code
+    next_release_version_code = base_version_code + 100
+    tracks = ["internal", "alpha", "beta", "production"]
+    track_version_codes = tracks.flat_map do |track|
+      google_play_track_version_codes(track: track).map(&:to_i)
+    end
+    highest_play_version_code = track_version_codes.max || base_version_code
+    version_code = [highest_play_version_code + 1, base_version_code + 1].max
+
+    if version_code >= next_release_version_code
+      UI.user_error!(
+        "Next internal testing versionCode #{version_code} would reach " \
+        "the next release range #{next_release_version_code}. " \
+        "Bump the mobile version before uploading more internal testing builds."
+      )
+    end
+
+    UI.message(
+      "Using Android internal testing versionCode #{version_code} " \
+      "(release base #{base_version_code}, next release range #{next_release_version_code})"
+    )
+    version_code
+  end
 
   private_lane :signing_properties do
     properties = {}

--- a/packages/mobile/android/fastlane/Fastfile
+++ b/packages/mobile/android/fastlane/Fastfile
@@ -80,6 +80,7 @@ platform :android do
       track: "internal",
       release_status: "completed",
       aab: aab_path,
+      skip_upload_apk: true,
       skip_upload_metadata: true,
       skip_upload_changelogs: true,
       skip_upload_images: true,

--- a/packages/mobile/android/fastlane/Fastfile
+++ b/packages/mobile/android/fastlane/Fastfile
@@ -27,12 +27,17 @@ platform :android do
   end
 
   desc "Build release APK"
-  lane :build_release do
+  lane :build_release do |options|
+    properties = signing_properties
+    if options[:version_code]
+      properties["trizumVersionCode"] = options[:version_code].to_s
+    end
+
     gradle(
       task: "assemble",
       build_type: "Release",
       print_command: true,
-      properties: signing_properties
+      properties: properties
     )
   end
 
@@ -69,10 +74,12 @@ platform :android do
   lane :deploy_internal_testing do
     version_code = next_internal_testing_version_code
     build_aab(version_code: version_code)
+    aab_path = lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+    build_release(version_code: version_code)
     upload_to_play_store(
       track: "internal",
       release_status: "completed",
-      aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
+      aab: aab_path,
       skip_upload_metadata: true,
       skip_upload_changelogs: true,
       skip_upload_images: true,

--- a/packages/mobile/android/variables.gradle
+++ b/packages/mobile/android/variables.gradle
@@ -13,4 +13,6 @@ ext {
     androidxJunitVersion = '1.2.1'
     androidxEspressoCoreVersion = '3.6.1'
     cordovaAndroidVersion = '10.1.1'
+    androidPlayAppUpdateVersion = '2.1.0'
+    androidPlayServicesBaseVersion = '18.9.0'
 }

--- a/packages/mobile/ios/App/Podfile
+++ b/packages/mobile/ios/App/Podfile
@@ -14,7 +14,7 @@ def capacitor_pods
   pod 'CapacitorApp', :path => '../../../../node_modules/.pnpm/@capacitor+app@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/app'
   pod 'CapacitorShare', :path => '../../../../node_modules/.pnpm/@capacitor+share@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/share'
   pod 'CapacitorSplashScreen', :path => '../../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/splash-screen'
-  pod 'CapawesomeCapacitorAppUpdate', :path => '../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.1_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-app-update'
+  pod 'CapawesomeCapacitorAppUpdate', :path => '../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.3_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-app-update'
   pod 'CapacitorPluginSafeArea', :path => '../../../../node_modules/.pnpm/capacitor-plugin-safe-area@5.0.0_@capacitor+core@8.0.1/node_modules/capacitor-plugin-safe-area'
 end
 

--- a/packages/mobile/ios/App/Podfile.lock
+++ b/packages/mobile/ios/App/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - Capacitor
   - CapacitorSplashScreen (8.0.0):
     - Capacitor
-  - CapawesomeCapacitorAppUpdate (8.0.1):
+  - CapawesomeCapacitorAppUpdate (8.0.3):
     - Capacitor
 
 DEPENDENCIES:
@@ -20,7 +20,7 @@ DEPENDENCIES:
   - "CapacitorPluginSafeArea (from `../../../../node_modules/.pnpm/capacitor-plugin-safe-area@5.0.0_@capacitor+core@8.0.1/node_modules/capacitor-plugin-safe-area`)"
   - "CapacitorShare (from `../../../../node_modules/.pnpm/@capacitor+share@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/share`)"
   - "CapacitorSplashScreen (from `../../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/splash-screen`)"
-  - "CapawesomeCapacitorAppUpdate (from `../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.1_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-app-update`)"
+  - "CapawesomeCapacitorAppUpdate (from `../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.3_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-app-update`)"
 
 EXTERNAL SOURCES:
   Capacitor:
@@ -36,7 +36,7 @@ EXTERNAL SOURCES:
   CapacitorSplashScreen:
     :path: "../../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/splash-screen"
   CapawesomeCapacitorAppUpdate:
-    :path: "../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.1_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-app-update"
+    :path: "../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.3_@capacitor+core@8.0.1/node_modules/@capawesome/capacitor-app-update"
 
 SPEC CHECKSUMS:
   Capacitor: ff35b0f66370b84aa238251b35b91886a3207c16
@@ -45,8 +45,8 @@ SPEC CHECKSUMS:
   CapacitorPluginSafeArea: 9d0682951c011bf0b36e513a89103c5fbff7ac49
   CapacitorShare: 12f1d192170cbcf9f108fd675ac8e343761a4638
   CapacitorSplashScreen: 422880d7117605c30699eb4b21644b62db42e86c
-  CapawesomeCapacitorAppUpdate: b51cf29f28f664ef942feb12a76116d87eee62f0
+  CapawesomeCapacitorAppUpdate: 3a7537c6a6696837b51d06f26b2e909fd7b9226f
 
-PODFILE CHECKSUM: 056ec261bc54f6ac6e378c27ef5567f13b345d0e
+PODFILE CHECKSUM: 8b7ae295054fdc39c14ab12f5c0061db0b61d83f
 
 COCOAPODS: 1.16.2

--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -186,6 +186,17 @@ platform :ios do
     )
   end
 
+  desc "Build and upload PR build to TestFlight"
+  lane :deploy_pr_testflight do
+    build_number = next_pr_testflight_build_number
+    build_release(build_number: build_number)
+    upload_to_testflight(
+      app_identifier: "app.trizum.capacitor",
+      skip_waiting_for_build_processing: false,
+      uses_non_exempt_encryption: false
+    )
+  end
+
   desc "Upload to App Store (binary only, no metadata)"
   lane :deploy_appstore do |options|
     build_release(build_number: options[:build_number])
@@ -343,5 +354,34 @@ platform :ios do
     version = get_version_number(xcodeproj: "App.xcodeproj")
     build = get_build_number(xcodeproj: "App.xcodeproj")
     UI.success("Current version: #{version} (#{build})")
+  end
+
+  private_lane :next_pr_testflight_build_number do
+    load_api_key
+
+    version = get_version_number(xcodeproj: "App.xcodeproj")
+    base_build_number = get_build_number(xcodeproj: "App.xcodeproj").to_i
+    next_release_build_number = base_build_number + 100
+    latest_testflight_build = latest_testflight_build_number(
+      app_identifier: "app.trizum.capacitor",
+      version: version,
+      initial_build_number: base_build_number
+    ).to_i
+    build_number = [latest_testflight_build + 1, base_build_number + 1].max
+
+    if build_number >= next_release_build_number
+      UI.user_error!(
+        "Next TestFlight build number #{build_number} would reach " \
+        "the next release range #{next_release_build_number}. " \
+        "Bump the mobile version before uploading more PR TestFlight builds."
+      )
+    end
+
+    UI.message(
+      "Using iOS TestFlight build number #{build_number} " \
+      "(version #{version}, release base #{base_build_number}, " \
+      "next release range #{next_release_build_number})"
+    )
+    build_number
   end
 end

--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -188,7 +188,12 @@ platform :ios do
 
   desc "Build and upload PR build to TestFlight"
   lane :deploy_pr_testflight do
-    build_number = next_pr_testflight_build_number
+    version = next_pr_testflight_version
+    build_number = next_pr_testflight_build_number(version: version)
+    increment_version_number(
+      version_number: version,
+      xcodeproj: "App.xcodeproj"
+    )
     build_release(build_number: build_number)
     upload_to_testflight(
       app_identifier: "app.trizum.capacitor",
@@ -356,11 +361,17 @@ platform :ios do
     UI.success("Current version: #{version} (#{build})")
   end
 
-  private_lane :next_pr_testflight_build_number do
+  private_lane :next_pr_testflight_version do
+    release_version = get_version_number(xcodeproj: "App.xcodeproj")
+    major, minor, patch = version_segments(release_version)
+    "#{major}.#{minor}.#{patch + 1}"
+  end
+
+  private_lane :next_pr_testflight_build_number do |options|
     load_api_key
 
-    version = get_version_number(xcodeproj: "App.xcodeproj")
-    base_build_number = get_build_number(xcodeproj: "App.xcodeproj").to_i
+    version = options[:version] || next_pr_testflight_version
+    base_build_number = build_number_base_for_version(version: version)
     next_release_build_number = base_build_number + 100
     latest_testflight_build = latest_testflight_build_number(
       app_identifier: "app.trizum.capacitor",
@@ -383,5 +394,19 @@ platform :ios do
       "next release range #{next_release_build_number})"
     )
     build_number
+  end
+
+  private_lane :build_number_base_for_version do |options|
+    major, minor, patch = version_segments(options[:version])
+    major * 10_000_000 + minor * 10_000 + patch * 100
+  end
+
+  def version_segments(version)
+    segments = version.to_s.split(".")
+    if segments.length != 3 || segments.any? { |segment| !segment.match?(/\A\d+\z/) }
+      UI.user_error!("Expected semantic version with three numeric parts, got #{version.inspect}")
+    end
+
+    segments.map(&:to_i)
   end
 end

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -43,7 +43,7 @@
     "@capacitor/ios": "8.0.1",
     "@capacitor/share": "8.0.0",
     "@capacitor/splash-screen": "8.0.0",
-    "@capawesome/capacitor-app-update": "8.0.1",
+    "@capawesome/capacitor-app-update": "8.0.3",
     "@trizum/logging": "workspace:*",
     "@trizum/pwa": "workspace:*",
     "capacitor-plugin-safe-area": "5.0.0"

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -63,7 +63,7 @@ msgid "A name for the participant is required"
 msgstr "A name for the participant is required"
 
 #: src/routes/about.tsx:21
-#: src/routes/index.tsx:150
+#: src/routes/index.tsx:156
 msgid "About"
 msgstr "About"
 
@@ -100,7 +100,7 @@ msgstr "Add an expense"
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Add expenses to this party to unlock totals, rankings, and individual spend."
 
-#: src/routes/index.tsx:198
+#: src/routes/index.tsx:204
 #: src/routes/party.$partyId.tsx:382
 msgid "Add or create"
 msgstr "Add or create"
@@ -110,7 +110,7 @@ msgstr "Add or create"
 msgid "Add participant"
 msgstr "Add participant"
 
-#: src/routes/index.tsx:482
+#: src/routes/index.tsx:488
 msgid "Add your name so others know who you are and how to pay you"
 msgstr "Add your name so others know who you are and how to pay you"
 
@@ -174,7 +174,7 @@ msgstr "Archive a party from the home screen when you want to clear some space w
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archive participants who left to keep balances clean."
 
-#: src/routes/index.tsx:267
+#: src/routes/index.tsx:273
 msgid "Archive party"
 msgstr "Archive party"
 
@@ -186,7 +186,7 @@ msgstr "Archived"
 msgid "Archived participants"
 msgstr "Archived participants"
 
-#: src/routes/index.tsx:128
+#: src/routes/index.tsx:134
 msgid "Archived parties"
 msgstr "Archived parties"
 
@@ -416,7 +416,7 @@ msgstr "CFP Franc"
 msgid "Changes sync automatically across all your devices"
 msgstr "Changes sync automatically across all your devices"
 
-#: src/routes/index.tsx:139
+#: src/routes/index.tsx:145
 msgid "Check for updates"
 msgstr "Check for updates"
 
@@ -497,11 +497,11 @@ msgstr "Comorian Franc"
 msgid "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 msgstr "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 
-#: src/routes/index.tsx:479
+#: src/routes/index.tsx:485
 msgid "Complete your profile"
 msgstr "Complete your profile"
 
-#: src/routes/index.tsx:447
+#: src/routes/index.tsx:453
 msgid "Configure Profile"
 msgstr "Configure Profile"
 
@@ -539,8 +539,8 @@ msgstr "Copy the phone number and pay through Bizum using your bank app."
 msgid "Costa Rican Colón"
 msgstr "Costa Rican Colón"
 
-#: src/routes/index.tsx:215
-#: src/routes/index.tsx:363
+#: src/routes/index.tsx:221
+#: src/routes/index.tsx:369
 msgid "Create a new Party"
 msgstr "Create a new Party"
 
@@ -699,7 +699,7 @@ msgstr "End date"
 msgid "English"
 msgstr "English"
 
-#: src/routes/index.tsx:394
+#: src/routes/index.tsx:400
 msgid "Enter a party link or code to join"
 msgstr "Enter a party link or code to join"
 
@@ -743,7 +743,7 @@ msgstr "European Unit of Account 17"
 msgid "European Unit of Account 9"
 msgstr "European Unit of Account 9"
 
-#: src/routes/index.tsx:303
+#: src/routes/index.tsx:309
 msgid "Everything is archived for now. You can reopen any party from the archived screen whenever you need it."
 msgstr "Everything is archived for now. You can reopen any party from the archived screen whenever you need it."
 
@@ -989,7 +989,7 @@ msgstr "Impact on my balance: <0/>"
 msgid "Import attachments"
 msgstr "Import attachments"
 
-#: src/routes/index.tsx:422
+#: src/routes/index.tsx:428
 msgid "Import your existing Tricount data"
 msgstr "Import your existing Tricount data"
 
@@ -1075,8 +1075,8 @@ msgstr "Join {0} on trizum!"
 msgid "Join {partyName} on trizum!"
 msgstr "Join {partyName} on trizum!"
 
-#: src/routes/index.tsx:209
-#: src/routes/index.tsx:391
+#: src/routes/index.tsx:215
+#: src/routes/index.tsx:397
 msgid "Join a Party"
 msgstr "Join a Party"
 
@@ -1226,7 +1226,7 @@ msgid "Me"
 msgstr "Me"
 
 #: src/components/ExpenseEditor.tsx:249
-#: src/routes/index.tsx:106
+#: src/routes/index.tsx:112
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:92
 #: src/routes/party.$partyId.tsx:206
 msgid "Menu"
@@ -1240,8 +1240,8 @@ msgstr "Mexican Investment Unit"
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
-#: src/routes/index.tsx:221
-#: src/routes/index.tsx:419
+#: src/routes/index.tsx:227
+#: src/routes/index.tsx:425
 #: src/routes/migrate_.tricount.tsx:149
 msgid "Migrate from Tricount"
 msgstr "Migrate from Tricount"
@@ -1358,7 +1358,7 @@ msgstr "Nicaraguan Córdoba"
 msgid "Nigerian Naira"
 msgstr "Nigerian Naira"
 
-#: src/routes/index.tsx:300
+#: src/routes/index.tsx:306
 msgid "No active parties right now"
 msgstr "No active parties right now"
 
@@ -1451,7 +1451,7 @@ msgstr "Only show your expenses"
 msgid "Only your own debt can be transferred"
 msgstr "Only your own debt can be transferred"
 
-#: src/routes/index.tsx:321
+#: src/routes/index.tsx:327
 msgid "Open archived parties"
 msgstr "Open archived parties"
 
@@ -1557,7 +1557,7 @@ msgstr "Participants"
 msgid "Party actions"
 msgstr "Party actions"
 
-#: src/routes/index.tsx:288
+#: src/routes/index.tsx:294
 msgid "Party archived"
 msgstr "Party archived"
 
@@ -1581,7 +1581,7 @@ msgstr "Party leaderboard"
 msgid "Party link copied to clipboard!"
 msgstr "Party link copied to clipboard!"
 
-#: src/routes/index.tsx:280
+#: src/routes/index.tsx:286
 msgid "Party pinned"
 msgstr "Party pinned"
 
@@ -1605,7 +1605,7 @@ msgstr "Party shared!"
 msgid "Party stats"
 msgstr "Party stats"
 
-#: src/routes/index.tsx:280
+#: src/routes/index.tsx:286
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
@@ -1650,7 +1650,7 @@ msgstr "Phone number is required"
 msgid "Phone number must be less than 20 characters"
 msgstr "Phone number must be less than 20 characters"
 
-#: src/routes/index.tsx:261
+#: src/routes/index.tsx:267
 msgid "Pin party"
 msgstr "Pin party"
 
@@ -1734,7 +1734,7 @@ msgstr "Receipt Attachments"
 msgid "Recommended match"
 msgstr "Recommended match"
 
-#: src/components/UpdateController.tsx:28
+#: src/components/UpdateController.tsx:29
 msgid "Reload"
 msgstr "Reload"
 
@@ -1841,11 +1841,11 @@ msgstr "Send us an email and we'll get back to you as soon as possible."
 msgid "Serbian Dinar"
 msgstr "Serbian Dinar"
 
-#: src/routes/index.tsx:450
+#: src/routes/index.tsx:456
 msgid "Set up your username, avatar, and preferences"
 msgstr "Set up your username, avatar, and preferences"
 
-#: src/routes/index.tsx:117
+#: src/routes/index.tsx:123
 #: src/routes/party.$partyId.tsx:295
 #: src/routes/settings.tsx:88
 msgid "Settings"
@@ -1941,7 +1941,7 @@ msgstr "South Sudanese Pound"
 msgid "Special Drawing Rights"
 msgstr "Special Drawing Rights"
 
-#: src/routes/index.tsx:335
+#: src/routes/index.tsx:341
 msgid "Split bills with friends and family. Track expenses, calculate balances, and settle up together."
 msgstr "Split bills with friends and family. Track expenses, calculate balances, and settle up together."
 
@@ -1962,7 +1962,7 @@ msgstr "Sri Lankan Rupee"
 msgid "Start date"
 msgstr "Start date"
 
-#: src/routes/index.tsx:366
+#: src/routes/index.tsx:372
 msgid "Start tracking expenses with your group"
 msgstr "Start tracking expenses with your group"
 
@@ -2250,14 +2250,26 @@ msgstr "Ukrainian Hryvnia"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/index.tsx:261
+#: src/routes/index.tsx:267
 msgid "Unpin party"
 msgstr "Unpin party"
 
-#: src/components/UpdateController.tsx:26
-#: src/routes/index.tsx:91
+#: src/components/UpdateController.tsx:27
+#: src/routes/index.tsx:92
 msgid "Update available"
 msgstr "Update available"
+
+#: src/lib/updateResultFeedback.ts:18
+msgid "Update can't be installed right now."
+msgstr "Update can't be installed right now."
+
+#: src/lib/updateResultFeedback.ts:14
+msgid "Update failed. Please try again."
+msgstr "Update failed. Please try again."
+
+#: src/lib/updateResultFeedback.ts:22
+msgid "Update is no longer available."
+msgstr "Update is no longer available."
 
 #: src/routes/party_.$partyId.who.tsx:135
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
@@ -2267,7 +2279,7 @@ msgstr "Update who you are in this party so that we can show you the expenses an
 msgid "Updating expense..."
 msgstr "Updating expense..."
 
-#: src/components/UpdateController.tsx:37
+#: src/components/UpdateController.tsx:38
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
@@ -2384,7 +2396,7 @@ msgstr "Welcome to the party, {0}!"
 msgid "Welcome to the party, {participantName}!"
 msgstr "Welcome to the party, {participantName}!"
 
-#: src/routes/index.tsx:332
+#: src/routes/index.tsx:338
 msgid "Welcome to trizum"
 msgstr "Welcome to trizum"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -59,7 +59,7 @@ msgid "A name for the participant is required"
 msgstr "Se requiere un nombre para el participante"
 
 #: src/routes/about.tsx:21
-#: src/routes/index.tsx:150
+#: src/routes/index.tsx:156
 msgid "About"
 msgstr "Acerca de"
 
@@ -96,7 +96,7 @@ msgstr "Añadir un gasto"
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto individual."
 
-#: src/routes/index.tsx:198
+#: src/routes/index.tsx:204
 #: src/routes/party.$partyId.tsx:382
 msgid "Add or create"
 msgstr "Añadir o crear"
@@ -106,7 +106,7 @@ msgstr "Añadir o crear"
 msgid "Add participant"
 msgstr "Añadir participante"
 
-#: src/routes/index.tsx:482
+#: src/routes/index.tsx:488
 msgid "Add your name so others know who you are and how to pay you"
 msgstr "Añade tu nombre para que otros sepan quién eres y cómo pagarte"
 
@@ -166,7 +166,7 @@ msgstr "Archiva un grupo desde la pantalla de inicio cuando quieras despejar esp
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archiva a los participantes que se fueron para mantener el balance limpio."
 
-#: src/routes/index.tsx:267
+#: src/routes/index.tsx:273
 msgid "Archive party"
 msgstr "Archivar grupo"
 
@@ -178,7 +178,7 @@ msgstr "Archivado"
 msgid "Archived participants"
 msgstr "Participantes archivados"
 
-#: src/routes/index.tsx:128
+#: src/routes/index.tsx:134
 msgid "Archived parties"
 msgstr "Grupos archivados"
 
@@ -396,7 +396,7 @@ msgstr "Franco CFP"
 msgid "Changes sync automatically across all your devices"
 msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 
-#: src/routes/index.tsx:139
+#: src/routes/index.tsx:145
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
@@ -473,11 +473,11 @@ msgstr "Franco Comorense"
 msgid "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 msgstr "Compara cuánto ha pagado cada persona en distintos períodos. Las transferencias de saldos no se incluyen en estos totales."
 
-#: src/routes/index.tsx:479
+#: src/routes/index.tsx:485
 msgid "Complete your profile"
 msgstr "Completa tu perfil"
 
-#: src/routes/index.tsx:447
+#: src/routes/index.tsx:453
 msgid "Configure Profile"
 msgstr "Configurar perfil"
 
@@ -515,8 +515,8 @@ msgstr "Copia el número de teléfono y paga mediante Bizum usando la aplicació
 msgid "Costa Rican Colón"
 msgstr "Colón Costarricense"
 
-#: src/routes/index.tsx:215
-#: src/routes/index.tsx:363
+#: src/routes/index.tsx:221
+#: src/routes/index.tsx:369
 msgid "Create a new Party"
 msgstr "Crear un nuevo Grupo"
 
@@ -671,7 +671,7 @@ msgstr "Fecha de fin"
 msgid "English"
 msgstr "Inglés"
 
-#: src/routes/index.tsx:394
+#: src/routes/index.tsx:400
 msgid "Enter a party link or code to join"
 msgstr "Introduce un enlace o código de grupo para unirte"
 
@@ -711,7 +711,7 @@ msgstr "Unidad de Cuenta Europea 17"
 msgid "European Unit of Account 9"
 msgstr "Unidad de Cuenta Europea 9"
 
-#: src/routes/index.tsx:303
+#: src/routes/index.tsx:309
 msgid "Everything is archived for now. You can reopen any party from the archived screen whenever you need it."
 msgstr "Por ahora todo está archivado. Puedes reabrir cualquier grupo desde la pantalla de archivados cuando lo necesites."
 
@@ -941,7 +941,7 @@ msgstr "Impacto en mi balance: <0/>"
 msgid "Import attachments"
 msgstr "Importar adjuntos"
 
-#: src/routes/index.tsx:422
+#: src/routes/index.tsx:428
 msgid "Import your existing Tricount data"
 msgstr "Importa tu grupo de Tricount"
 
@@ -1027,8 +1027,8 @@ msgstr "¡Únete a {0} en trizum!"
 msgid "Join {partyName} on trizum!"
 msgstr "¡Únete a {partyName} en trizum!"
 
-#: src/routes/index.tsx:209
-#: src/routes/index.tsx:391
+#: src/routes/index.tsx:215
+#: src/routes/index.tsx:397
 msgid "Join a Party"
 msgstr "Unirse a un Grupo"
 
@@ -1174,7 +1174,7 @@ msgid "Me"
 msgstr "Yo"
 
 #: src/components/ExpenseEditor.tsx:249
-#: src/routes/index.tsx:106
+#: src/routes/index.tsx:112
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:92
 #: src/routes/party.$partyId.tsx:206
 msgid "Menu"
@@ -1188,8 +1188,8 @@ msgstr "Unidad de Inversión Mexicana"
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
-#: src/routes/index.tsx:221
-#: src/routes/index.tsx:419
+#: src/routes/index.tsx:227
+#: src/routes/index.tsx:425
 #: src/routes/migrate_.tricount.tsx:149
 msgid "Migrate from Tricount"
 msgstr "Migrar desde Tricount"
@@ -1306,7 +1306,7 @@ msgstr "Córdoba Nicaragüense"
 msgid "Nigerian Naira"
 msgstr "Naira Nigeriano"
 
-#: src/routes/index.tsx:300
+#: src/routes/index.tsx:306
 msgid "No active parties right now"
 msgstr "Ahora mismo no hay grupos activos"
 
@@ -1395,7 +1395,7 @@ msgstr "Mostrar solo tus gastos"
 msgid "Only your own debt can be transferred"
 msgstr "Solo puedes transferir tus propias deudas"
 
-#: src/routes/index.tsx:321
+#: src/routes/index.tsx:327
 msgid "Open archived parties"
 msgstr "Abrir grupos archivados"
 
@@ -1497,7 +1497,7 @@ msgstr "Participantes"
 msgid "Party actions"
 msgstr "Acciones del grupo"
 
-#: src/routes/index.tsx:288
+#: src/routes/index.tsx:294
 msgid "Party archived"
 msgstr "Grupo archivado"
 
@@ -1513,7 +1513,7 @@ msgstr "Clasificación del grupo"
 msgid "Party link copied to clipboard!"
 msgstr "¡Enlace del grupo copiado al portapapeles!"
 
-#: src/routes/index.tsx:280
+#: src/routes/index.tsx:286
 msgid "Party pinned"
 msgstr "Grupo fijado"
 
@@ -1537,7 +1537,7 @@ msgstr "¡Grupo compartido!"
 msgid "Party stats"
 msgstr "Estadísticas del grupo"
 
-#: src/routes/index.tsx:280
+#: src/routes/index.tsx:286
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
@@ -1582,7 +1582,7 @@ msgstr "Se requiere el número de teléfono"
 msgid "Phone number must be less than 20 characters"
 msgstr "El número de teléfono debe tener menos de 20 caracteres"
 
-#: src/routes/index.tsx:261
+#: src/routes/index.tsx:267
 msgid "Pin party"
 msgstr "Fijar grupo"
 
@@ -1662,7 +1662,7 @@ msgstr "Sincronización en Tiempo Real"
 msgid "Recommended match"
 msgstr "Coincidencia recomendada"
 
-#: src/components/UpdateController.tsx:28
+#: src/components/UpdateController.tsx:29
 msgid "Reload"
 msgstr "Recargar"
 
@@ -1769,11 +1769,11 @@ msgstr "Envíanos un email y te responderemos lo antes posible."
 msgid "Serbian Dinar"
 msgstr "Dinar Serbio"
 
-#: src/routes/index.tsx:450
+#: src/routes/index.tsx:456
 msgid "Set up your username, avatar, and preferences"
 msgstr "Configura tu nombre de usuario, avatar y preferencias"
 
-#: src/routes/index.tsx:117
+#: src/routes/index.tsx:123
 #: src/routes/party.$partyId.tsx:295
 #: src/routes/settings.tsx:88
 msgid "Settings"
@@ -1865,7 +1865,7 @@ msgstr "Libra Sursudanesa"
 msgid "Special Drawing Rights"
 msgstr "Derechos Especiales de Giro"
 
-#: src/routes/index.tsx:335
+#: src/routes/index.tsx:341
 msgid "Split bills with friends and family. Track expenses, calculate balances, and settle up together."
 msgstr "Divide facturas con amigos y familia. Registra, calcula y salda gastos juntos."
 
@@ -1886,7 +1886,7 @@ msgstr "Rupia de Sri Lanka"
 msgid "Start date"
 msgstr "Fecha de inicio"
 
-#: src/routes/index.tsx:366
+#: src/routes/index.tsx:372
 msgid "Start tracking expenses with your group"
 msgstr "Comienza a registrar gastos con tu grupo"
 
@@ -2162,14 +2162,26 @@ msgstr "Grivna Ucraniana"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/index.tsx:261
+#: src/routes/index.tsx:267
 msgid "Unpin party"
 msgstr "Desfijar grupo"
 
-#: src/components/UpdateController.tsx:26
-#: src/routes/index.tsx:91
+#: src/components/UpdateController.tsx:27
+#: src/routes/index.tsx:92
 msgid "Update available"
 msgstr "Actualización disponible"
+
+#: src/lib/updateResultFeedback.ts:18
+msgid "Update can't be installed right now."
+msgstr "No se puede instalar la actualización ahora mismo."
+
+#: src/lib/updateResultFeedback.ts:14
+msgid "Update failed. Please try again."
+msgstr "No se ha podido actualizar. Inténtalo de nuevo."
+
+#: src/lib/updateResultFeedback.ts:22
+msgid "Update is no longer available."
+msgstr "La actualización ya no está disponible."
 
 #: src/routes/party_.$partyId.who.tsx:135
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
@@ -2179,7 +2191,7 @@ msgstr "Actualiza quién eres en este grupo para que podamos mostrarte los gasto
 msgid "Updating expense..."
 msgstr "Actualizando gasto..."
 
-#: src/components/UpdateController.tsx:37
+#: src/components/UpdateController.tsx:38
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
@@ -2283,7 +2295,7 @@ msgstr "¡Bienvenido al grupo, {0}!"
 msgid "Welcome to the party, {participantName}!"
 msgstr "¡Bienvenido al grupo, {participantName}!"
 
-#: src/routes/index.tsx:332
+#: src/routes/index.tsx:338
 msgid "Welcome to trizum"
 msgstr "Bienvenid@ a trizum"
 

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -23,7 +23,7 @@
     "@capacitor/core": "8.0.1",
     "@capacitor/share": "^8.0.0",
     "@capacitor/splash-screen": "8.0.0",
-    "@capawesome/capacitor-app-update": "8.0.1",
+    "@capawesome/capacitor-app-update": "8.0.3",
     "@fontsource-variable/fira-code": "5.2.7",
     "@fontsource-variable/inter": "5.2.8",
     "@horus.dev/tw-dynamic-themes": "0.0.3",

--- a/packages/pwa/src/components/UpdateContext.tsx
+++ b/packages/pwa/src/components/UpdateContext.tsx
@@ -1,13 +1,17 @@
 import { createContext } from "react";
 
+export type UpdateResult = {
+  status: "canceled" | "failed" | "not-allowed" | "started" | "unavailable";
+};
+
 interface UpdateContextType {
   isUpdateAvailable: boolean;
-  update: () => void;
+  update: () => Promise<UpdateResult>;
   checkForUpdate: () => void;
 }
 
 export const UpdateContext = createContext<UpdateContextType>({
   isUpdateAvailable: false,
-  update: () => {},
+  update: () => Promise.resolve({ status: "unavailable" }),
   checkForUpdate: () => {},
 });

--- a/packages/pwa/src/components/UpdateController.tsx
+++ b/packages/pwa/src/components/UpdateController.tsx
@@ -1,6 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { useRegisterSW } from "virtual:pwa-register/react";
-import { UpdateContext } from "./UpdateContext";
+import { showUpdateResultFeedback } from "#src/lib/updateResultFeedback.ts";
+import { type UpdateResult, UpdateContext } from "./UpdateContext";
 import { useRef } from "react";
 import { toast } from "sonner";
 
@@ -26,18 +27,24 @@ export function UpdateController({ children }: { children: React.ReactNode }) {
       toast(t`Update available`, {
         action: {
           label: t`Reload`,
-          onClick: () => update(),
+          onClick: () => void update().then(showUpdateResultFeedback),
         },
         id: UPDATE_TOAST_ID,
       });
     },
   });
 
-  function update() {
+  async function update(): Promise<UpdateResult> {
     toast.loading(t`Updating trizum...`, {
       id: UPDATE_TOAST_ID,
     });
-    void updateServiceWorker(true);
+    try {
+      await updateServiceWorker(true);
+      return { status: "started" };
+    } catch {
+      toast.dismiss(UPDATE_TOAST_ID);
+      return { status: "failed" };
+    }
   }
 
   return (

--- a/packages/pwa/src/components/UpdateControllerNative.tsx
+++ b/packages/pwa/src/components/UpdateControllerNative.tsx
@@ -1,38 +1,50 @@
-import { Capacitor } from "@capacitor/core";
-import { AppUpdate, AppUpdateAvailability } from "@capawesome/capacitor-app-update";
 import { UpdateContext } from "./UpdateContext";
+import {
+  getNativeAppUpdateState,
+  performNativeAppUpdate,
+  resumeNativeAppUpdate,
+} from "#src/lib/nativeAppUpdate.ts";
+import { App } from "@capacitor/app";
 import { useCallback, useEffect, useState } from "react";
 
 export function UpdateControllerNative({ children }: { children: React.ReactNode }) {
   const [isUpdateAvailable, setIsUpdateAvailable] = useState(false);
 
-  const update = useCallback(() => {
-    const platform = Capacitor.getPlatform();
-    if (platform === "ios") {
-      void AppUpdate.openAppStore({
-        appId: "6755971747",
-      });
-    }
-
-    if (platform === "android") {
-      void AppUpdate.performImmediateUpdate();
-    }
-  }, []);
-
   const checkForUpdate = useCallback(async () => {
-    const result = await AppUpdate.getAppUpdateInfo();
-
-    if (result.updateAvailability === AppUpdateAvailability.UPDATE_AVAILABLE) {
-      setIsUpdateAvailable(true);
-    } else {
-      setIsUpdateAvailable(false);
-    }
+    const result = await getNativeAppUpdateState();
+    setIsUpdateAvailable(result.isUpdateAvailable);
   }, []);
+
+  const update = useCallback(async () => {
+    const result = await performNativeAppUpdate();
+    await checkForUpdate();
+    return result;
+  }, [checkForUpdate]);
+
+  const resumeUpdate = useCallback(async () => {
+    const result = await resumeNativeAppUpdate();
+    if (result.status === "started") {
+      await checkForUpdate();
+    }
+  }, [checkForUpdate]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- This is intentional
     void checkForUpdate();
   }, [checkForUpdate]);
+
+  useEffect(() => {
+    void resumeUpdate();
+    const listener = App.addListener("appStateChange", ({ isActive }) => {
+      if (isActive) {
+        void resumeUpdate();
+      }
+    });
+
+    return () => {
+      void listener.then((handle) => handle.remove());
+    };
+  }, [resumeUpdate]);
 
   return (
     <UpdateContext

--- a/packages/pwa/src/lib/nativeAppUpdate.test.ts
+++ b/packages/pwa/src/lib/nativeAppUpdate.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+import {
+  type AppUpdateInfo,
+  AppUpdateAvailability,
+  type AppUpdateResult,
+  AppUpdateResultCode,
+  type AppUpdatePlugin,
+} from "@capawesome/capacitor-app-update";
+import {
+  getNativeAppUpdateState,
+  performNativeAppUpdate,
+  resumeNativeAppUpdate,
+} from "./nativeAppUpdate.ts";
+
+vi.mock("#src/lib/log.ts", () => ({
+  getLogger: () => ({
+    warning() {},
+  }),
+}));
+
+describe("native app updates", () => {
+  test("does not call Play update APIs when Android has no Google Play support", async () => {
+    const getAppUpdateInfo = createGetAppUpdateInfoMock();
+    const appUpdate = createAppUpdate({ getAppUpdateInfo });
+    const getAndroidAppUpdateInfo = createGetAndroidAppUpdateInfoMock();
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      getAndroidAppUpdateInfo,
+      support: createUnsupportedAndroidUpdateSupport(),
+    });
+
+    await expect(
+      getNativeAppUpdateState({
+        appUpdate,
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ isUpdateAvailable: false });
+
+    expect(getAppUpdateInfo).not.toHaveBeenCalled();
+    expect(getAndroidAppUpdateInfo).not.toHaveBeenCalled();
+  });
+
+  test("treats native update check failures as unavailable updates", async () => {
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      getAndroidAppUpdateInfo: vi.fn<() => Promise<AppUpdateInfo>>(() =>
+        Promise.reject(new Error("Google Play unavailable")),
+      ),
+    });
+
+    await expect(
+      getNativeAppUpdateState({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ isUpdateAvailable: false });
+  });
+
+  test("detects available native updates when Play update APIs succeed", async () => {
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: true,
+        updateAvailability: AppUpdateAvailability.UPDATE_AVAILABLE,
+      }),
+    });
+
+    await expect(
+      getNativeAppUpdateState({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ isUpdateAvailable: true });
+  });
+
+  test("detects in-progress Android immediate updates", async () => {
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: false,
+        updateAvailability: AppUpdateAvailability.UPDATE_IN_PROGRESS,
+      }),
+    });
+
+    await expect(
+      getNativeAppUpdateState({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ isUpdateAvailable: true });
+  });
+
+  test("does not report Android updates when immediate updates are not allowed", async () => {
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: false,
+        updateAvailability: AppUpdateAvailability.UPDATE_AVAILABLE,
+      }),
+    });
+
+    await expect(
+      getNativeAppUpdateState({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ isUpdateAvailable: false });
+  });
+
+  test("does not start Android updates when Google Play support is missing", async () => {
+    const performAndroidImmediateUpdate = createPerformAndroidImmediateUpdateMock();
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      performAndroidImmediateUpdate,
+      support: createUnsupportedAndroidUpdateSupport(),
+    });
+
+    await expect(
+      performNativeAppUpdate({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ status: "unavailable" });
+
+    expect(performAndroidImmediateUpdate).not.toHaveBeenCalled();
+  });
+
+  test("does not start Android updates when immediate updates are not allowed", async () => {
+    const performAndroidImmediateUpdate = createPerformAndroidImmediateUpdateMock();
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: false,
+        updateAvailability: AppUpdateAvailability.UPDATE_AVAILABLE,
+      }),
+      performAndroidImmediateUpdate,
+    });
+
+    await expect(
+      performNativeAppUpdate({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ status: "not-allowed" });
+
+    expect(performAndroidImmediateUpdate).not.toHaveBeenCalled();
+  });
+
+  test("starts Android immediate updates when they are allowed", async () => {
+    const performAndroidImmediateUpdate = createPerformAndroidImmediateUpdateMock();
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: true,
+        updateAvailability: AppUpdateAvailability.UPDATE_AVAILABLE,
+      }),
+      performAndroidImmediateUpdate,
+    });
+
+    await expect(
+      performNativeAppUpdate({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ status: "started" });
+
+    expect(performAndroidImmediateUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("shares one Android immediate update start across concurrent requests", async () => {
+    const immediateUpdateResult = createDeferred<AppUpdateResult>();
+    const performAndroidImmediateUpdate = vi.fn<() => Promise<AppUpdateResult>>(
+      () => immediateUpdateResult.promise,
+    );
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: true,
+        updateAvailability: AppUpdateAvailability.UPDATE_IN_PROGRESS,
+      }),
+      performAndroidImmediateUpdate,
+    });
+
+    const manualUpdate = performNativeAppUpdate({
+      appUpdate: createAppUpdate(),
+      nativeUpdateEnvironment,
+      platform: "android",
+    });
+    const resumedUpdate = resumeNativeAppUpdate({
+      nativeUpdateEnvironment,
+      platform: "android",
+    });
+
+    await waitUntil(() => expect(performAndroidImmediateUpdate).toHaveBeenCalledTimes(1));
+    immediateUpdateResult.resolve({ code: AppUpdateResultCode.OK });
+
+    await expect(Promise.all([manualUpdate, resumedUpdate])).resolves.toStrictEqual([
+      { status: "started" },
+      { status: "started" },
+    ]);
+    expect(performAndroidImmediateUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("maps non-OK Android immediate update results", async () => {
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: true,
+        updateAvailability: AppUpdateAvailability.UPDATE_AVAILABLE,
+      }),
+      performAndroidImmediateUpdate: createPerformAndroidImmediateUpdateMock(
+        AppUpdateResultCode.NOT_ALLOWED,
+      ),
+    });
+
+    await expect(
+      performNativeAppUpdate({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ status: "not-allowed" });
+  });
+
+  test("returns failed when Android immediate updates reject", async () => {
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: true,
+        updateAvailability: AppUpdateAvailability.UPDATE_AVAILABLE,
+      }),
+      performAndroidImmediateUpdate: vi.fn<() => Promise<AppUpdateResult>>(() =>
+        Promise.reject(new Error("Update failed")),
+      ),
+    });
+
+    await expect(
+      performNativeAppUpdate({
+        appUpdate: createAppUpdate(),
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ status: "failed" });
+  });
+
+  test("resumes in-progress Android immediate updates", async () => {
+    const performAndroidImmediateUpdate = createPerformAndroidImmediateUpdateMock();
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: false,
+        updateAvailability: AppUpdateAvailability.UPDATE_IN_PROGRESS,
+      }),
+      performAndroidImmediateUpdate,
+    });
+
+    await expect(
+      resumeNativeAppUpdate({
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ status: "started" });
+
+    expect(performAndroidImmediateUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not resume newly available Android immediate updates", async () => {
+    const performAndroidImmediateUpdate = createPerformAndroidImmediateUpdateMock();
+    const nativeUpdateEnvironment = createNativeUpdateEnvironment({
+      appUpdateInfo: createAppUpdateInfo({
+        immediateUpdateAllowed: true,
+        updateAvailability: AppUpdateAvailability.UPDATE_AVAILABLE,
+      }),
+      performAndroidImmediateUpdate,
+    });
+
+    await expect(
+      resumeNativeAppUpdate({
+        nativeUpdateEnvironment,
+        platform: "android",
+      }),
+    ).resolves.toStrictEqual({ status: "unavailable" });
+
+    expect(performAndroidImmediateUpdate).not.toHaveBeenCalled();
+  });
+
+  test("opens the App Store for iOS updates", async () => {
+    const openAppStore = vi.fn<AppUpdatePlugin["openAppStore"]>(() => Promise.resolve());
+    const appUpdate = createAppUpdate({ openAppStore });
+
+    await expect(
+      performNativeAppUpdate({
+        appUpdate,
+        nativeUpdateEnvironment: createNativeUpdateEnvironment(),
+        platform: "ios",
+      }),
+    ).resolves.toStrictEqual({ status: "started" });
+
+    expect(openAppStore).toHaveBeenCalledWith({ appId: "6755971747" });
+  });
+});
+
+function createSupportedAndroidUpdateSupport() {
+  return {
+    hasAvailableGooglePlayServices: true,
+    hasGooglePlayServices: true,
+    hasGooglePlayStore: true,
+    supportsGooglePlayInAppUpdates: true,
+    wasInstalledByGooglePlayStore: true,
+  };
+}
+
+function createUnsupportedAndroidUpdateSupport() {
+  return {
+    hasAvailableGooglePlayServices: false,
+    hasGooglePlayServices: false,
+    hasGooglePlayStore: false,
+    supportsGooglePlayInAppUpdates: false,
+    wasInstalledByGooglePlayStore: false,
+  };
+}
+
+function createNativeUpdateEnvironment({
+  appUpdateInfo = createAppUpdateInfo(),
+  getAndroidAppUpdateInfo = createGetAndroidAppUpdateInfoMock(appUpdateInfo),
+  performAndroidImmediateUpdate = createPerformAndroidImmediateUpdateMock(),
+  support = createSupportedAndroidUpdateSupport(),
+}: {
+  appUpdateInfo?: AppUpdateInfo;
+  getAndroidAppUpdateInfo?: () => Promise<AppUpdateInfo>;
+  performAndroidImmediateUpdate?: () => Promise<AppUpdateResult>;
+  support?: {
+    hasAvailableGooglePlayServices: boolean;
+    hasGooglePlayServices: boolean;
+    hasGooglePlayStore: boolean;
+    supportsGooglePlayInAppUpdates: boolean;
+    wasInstalledByGooglePlayStore: boolean;
+  };
+} = {}) {
+  return {
+    getAndroidAppUpdateInfo,
+    getAndroidUpdateSupport: vi.fn<() => Promise<typeof support>>(() => Promise.resolve(support)),
+    performAndroidImmediateUpdate,
+  };
+}
+
+function createAppUpdateInfo(overrides: Partial<AppUpdateInfo> = {}): AppUpdateInfo {
+  return {
+    currentVersionCode: "1",
+    currentVersionName: "1.0.0",
+    immediateUpdateAllowed: false,
+    updateAvailability: AppUpdateAvailability.UPDATE_NOT_AVAILABLE,
+    ...overrides,
+  };
+}
+
+function createGetAndroidAppUpdateInfoMock(appUpdateInfo: AppUpdateInfo = createAppUpdateInfo()) {
+  return vi.fn<() => Promise<AppUpdateInfo>>(() => Promise.resolve(appUpdateInfo));
+}
+
+function createPerformAndroidImmediateUpdateMock(code = AppUpdateResultCode.OK) {
+  return vi.fn<() => Promise<AppUpdateResult>>(() => Promise.resolve({ code }));
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+
+  return { promise, resolve };
+}
+
+async function waitUntil(assertion: () => void) {
+  let error: unknown;
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (nextError) {
+      error = nextError;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  throw error;
+}
+
+function createAppUpdate(overrides: Partial<AppUpdatePlugin> = {}): AppUpdatePlugin {
+  return {
+    addListener: vi.fn<AppUpdatePlugin["addListener"]>(() =>
+      Promise.resolve({ remove: () => Promise.resolve() }),
+    ),
+    completeFlexibleUpdate: vi.fn<AppUpdatePlugin["completeFlexibleUpdate"]>(() =>
+      Promise.resolve(),
+    ),
+    getAppUpdateInfo: createGetAppUpdateInfoMock(),
+    openAppStore: vi.fn<AppUpdatePlugin["openAppStore"]>(() => Promise.resolve()),
+    performImmediateUpdate: vi.fn<AppUpdatePlugin["performImmediateUpdate"]>(() =>
+      Promise.resolve({ code: AppUpdateResultCode.OK }),
+    ),
+    removeAllListeners: vi.fn<AppUpdatePlugin["removeAllListeners"]>(() => Promise.resolve()),
+    startFlexibleUpdate: vi.fn<AppUpdatePlugin["startFlexibleUpdate"]>(() =>
+      Promise.resolve({ code: AppUpdateResultCode.OK }),
+    ),
+    ...overrides,
+  };
+}
+
+function createGetAppUpdateInfoMock() {
+  return vi.fn<AppUpdatePlugin["getAppUpdateInfo"]>(() =>
+    Promise.resolve({
+      currentVersionCode: "1",
+      currentVersionName: "1.0.0",
+      immediateUpdateAllowed: false,
+      updateAvailability: AppUpdateAvailability.UPDATE_NOT_AVAILABLE,
+    }),
+  );
+}

--- a/packages/pwa/src/lib/nativeAppUpdate.ts
+++ b/packages/pwa/src/lib/nativeAppUpdate.ts
@@ -1,0 +1,242 @@
+import { Capacitor, registerPlugin } from "@capacitor/core";
+import {
+  AppUpdate,
+  AppUpdateAvailability,
+  AppUpdateResultCode,
+  type AppUpdateInfo,
+  type AppUpdateResult,
+  type AppUpdatePlugin,
+} from "@capawesome/capacitor-app-update";
+import { getLogger } from "#src/lib/log.ts";
+
+const logger = getLogger("lib", "nativeAppUpdate");
+
+export interface NativeAppUpdateState {
+  isUpdateAvailable: boolean;
+}
+
+export interface NativeAppUpdateResult {
+  status: "canceled" | "failed" | "not-allowed" | "started" | "unavailable";
+}
+
+interface AndroidUpdateSupport {
+  hasAvailableGooglePlayServices: boolean;
+  hasGooglePlayServices: boolean;
+  hasGooglePlayStore: boolean;
+  supportsGooglePlayInAppUpdates: boolean;
+  wasInstalledByGooglePlayStore: boolean;
+}
+
+interface NativeUpdateEnvironmentPlugin {
+  getAndroidAppUpdateInfo: () => Promise<AppUpdateInfo>;
+  getAndroidUpdateSupport: () => Promise<AndroidUpdateSupport>;
+  performAndroidImmediateUpdate: () => Promise<AppUpdateResult>;
+}
+
+const NativeUpdateEnvironment =
+  registerPlugin<NativeUpdateEnvironmentPlugin>("NativeUpdateEnvironment");
+
+let pendingAndroidImmediateUpdate: Promise<NativeAppUpdateResult> | null = null;
+
+export async function getNativeAppUpdateState({
+  platform = Capacitor.getPlatform(),
+  appUpdate = AppUpdate,
+  nativeUpdateEnvironment = NativeUpdateEnvironment,
+}: {
+  platform?: string;
+  appUpdate?: AppUpdatePlugin;
+  nativeUpdateEnvironment?: NativeUpdateEnvironmentPlugin;
+} = {}): Promise<NativeAppUpdateState> {
+  if (platform === "android") {
+    const androidUpdateSupport = await getAndroidUpdateSupport(nativeUpdateEnvironment);
+    if (!androidUpdateSupport.supportsGooglePlayInAppUpdates) {
+      return { isUpdateAvailable: false };
+    }
+
+    try {
+      const result = await nativeUpdateEnvironment.getAndroidAppUpdateInfo();
+      return {
+        isUpdateAvailable: isNativeUpdateAvailable(result, platform),
+      };
+    } catch (error) {
+      logger.warning("Native Android app update check failed", { error });
+      return { isUpdateAvailable: false };
+    }
+  }
+
+  try {
+    const result = await appUpdate.getAppUpdateInfo();
+    return {
+      isUpdateAvailable: isNativeUpdateAvailable(result, platform),
+    };
+  } catch (error) {
+    logger.warning("Native app update check failed", { error });
+    return { isUpdateAvailable: false };
+  }
+}
+
+export async function performNativeAppUpdate({
+  platform = Capacitor.getPlatform(),
+  appUpdate = AppUpdate,
+  nativeUpdateEnvironment = NativeUpdateEnvironment,
+}: {
+  platform?: string;
+  appUpdate?: AppUpdatePlugin;
+  nativeUpdateEnvironment?: NativeUpdateEnvironmentPlugin;
+} = {}): Promise<NativeAppUpdateResult> {
+  try {
+    if (platform === "ios") {
+      await appUpdate.openAppStore({
+        appId: "6755971747",
+      });
+      return { status: "started" };
+    }
+
+    if (platform === "android") {
+      const androidUpdateSupport = await getAndroidUpdateSupport(nativeUpdateEnvironment);
+      if (!androidUpdateSupport.supportsGooglePlayInAppUpdates) {
+        return { status: "unavailable" };
+      }
+
+      const result = await nativeUpdateEnvironment.getAndroidAppUpdateInfo();
+      const readiness = getAndroidImmediateUpdateReadiness(result);
+      if (readiness === "not-allowed") {
+        return { status: "not-allowed" };
+      }
+      if (readiness === "unavailable") {
+        return { status: "unavailable" };
+      }
+
+      return await performAndroidImmediateUpdate(nativeUpdateEnvironment);
+    }
+  } catch (error) {
+    logger.warning("Native app update failed", { error });
+  }
+
+  return { status: "failed" };
+}
+
+export async function resumeNativeAppUpdate({
+  platform = Capacitor.getPlatform(),
+  nativeUpdateEnvironment = NativeUpdateEnvironment,
+}: {
+  platform?: string;
+  nativeUpdateEnvironment?: NativeUpdateEnvironmentPlugin;
+} = {}): Promise<NativeAppUpdateResult> {
+  if (platform !== "android") {
+    return { status: "unavailable" };
+  }
+
+  try {
+    const androidUpdateSupport = await getAndroidUpdateSupport(nativeUpdateEnvironment);
+    if (!androidUpdateSupport.supportsGooglePlayInAppUpdates) {
+      return { status: "unavailable" };
+    }
+
+    const result = await nativeUpdateEnvironment.getAndroidAppUpdateInfo();
+    if (result.updateAvailability !== AppUpdateAvailability.UPDATE_IN_PROGRESS) {
+      return { status: "unavailable" };
+    }
+
+    return await performAndroidImmediateUpdate(nativeUpdateEnvironment);
+  } catch (error) {
+    logger.warning("Native app update resume failed", { error });
+    return { status: "failed" };
+  }
+}
+
+async function getAndroidUpdateSupport(
+  nativeUpdateEnvironment: NativeUpdateEnvironmentPlugin,
+): Promise<AndroidUpdateSupport> {
+  try {
+    return await nativeUpdateEnvironment.getAndroidUpdateSupport();
+  } catch (error) {
+    logger.warning("Android update support check failed", { error });
+    return {
+      hasAvailableGooglePlayServices: false,
+      hasGooglePlayServices: false,
+      hasGooglePlayStore: false,
+      supportsGooglePlayInAppUpdates: false,
+      wasInstalledByGooglePlayStore: false,
+    };
+  }
+}
+
+function performAndroidImmediateUpdate(
+  nativeUpdateEnvironment: NativeUpdateEnvironmentPlugin,
+): Promise<NativeAppUpdateResult> {
+  if (pendingAndroidImmediateUpdate != null) {
+    return pendingAndroidImmediateUpdate;
+  }
+
+  pendingAndroidImmediateUpdate = nativeUpdateEnvironment
+    .performAndroidImmediateUpdate()
+    .then(mapAppUpdateResult)
+    .catch((error: unknown) => {
+      logger.warning("Native Android immediate update failed", { error });
+      return { status: "failed" } satisfies NativeAppUpdateResult;
+    })
+    .finally(() => {
+      pendingAndroidImmediateUpdate = null;
+    });
+
+  return pendingAndroidImmediateUpdate;
+}
+
+function isNativeUpdateAvailable(result: AppUpdateInfo, platform: string): boolean {
+  if (
+    platform === "android" &&
+    result.updateAvailability === AppUpdateAvailability.UPDATE_IN_PROGRESS
+  ) {
+    return true;
+  }
+
+  if (result.updateAvailability !== AppUpdateAvailability.UPDATE_AVAILABLE) {
+    return false;
+  }
+
+  if (platform === "android") {
+    return result.immediateUpdateAllowed === true;
+  }
+
+  return true;
+}
+
+function getAndroidImmediateUpdateReadiness(
+  result: AppUpdateInfo,
+): "ready" | "not-allowed" | "unavailable" {
+  if (result.updateAvailability === AppUpdateAvailability.UPDATE_IN_PROGRESS) {
+    return "ready";
+  }
+
+  if (result.updateAvailability !== AppUpdateAvailability.UPDATE_AVAILABLE) {
+    return "unavailable";
+  }
+
+  if (result.immediateUpdateAllowed !== true) {
+    return "not-allowed";
+  }
+
+  return "ready";
+}
+
+function mapAppUpdateResult(result: AppUpdateResult): NativeAppUpdateResult {
+  if (result.code === AppUpdateResultCode.OK) {
+    return { status: "started" };
+  }
+
+  if (result.code === AppUpdateResultCode.CANCELED) {
+    return { status: "canceled" };
+  }
+
+  if (result.code === AppUpdateResultCode.NOT_AVAILABLE) {
+    return { status: "unavailable" };
+  }
+
+  if (result.code === AppUpdateResultCode.NOT_ALLOWED) {
+    return { status: "not-allowed" };
+  }
+
+  logger.warning("Native app update did not start", { result });
+  return { status: "failed" };
+}

--- a/packages/pwa/src/lib/updateResultFeedback.test.ts
+++ b/packages/pwa/src/lib/updateResultFeedback.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, test } from "vite-plus/test";
+import { i18n } from "@lingui/core";
+import { getUpdateResultFeedbackMessage } from "./updateResultFeedback.ts";
+
+describe("update result feedback", () => {
+  beforeEach(() => {
+    i18n.load("en", {});
+    i18n.activate("en");
+  });
+
+  test("returns no feedback for started or canceled updates", () => {
+    expect(getUpdateResultFeedbackMessage({ status: "started" })).toBeNull();
+    expect(getUpdateResultFeedbackMessage({ status: "canceled" })).toBeNull();
+  });
+
+  test("returns user feedback for updates that do not start", () => {
+    expect(getUpdateResultFeedbackMessage({ status: "failed" })).toBe(
+      "Update failed. Please try again.",
+    );
+    expect(getUpdateResultFeedbackMessage({ status: "not-allowed" })).toBe(
+      "Update can't be installed right now.",
+    );
+    expect(getUpdateResultFeedbackMessage({ status: "unavailable" })).toBe(
+      "Update is no longer available.",
+    );
+  });
+});

--- a/packages/pwa/src/lib/updateResultFeedback.ts
+++ b/packages/pwa/src/lib/updateResultFeedback.ts
@@ -1,0 +1,26 @@
+import { t } from "@lingui/core/macro";
+import type { UpdateResult } from "#src/components/UpdateContext.tsx";
+import { toast } from "sonner";
+
+export function showUpdateResultFeedback(result: UpdateResult): void {
+  const message = getUpdateResultFeedbackMessage(result);
+  if (message) {
+    toast.error(message);
+  }
+}
+
+export function getUpdateResultFeedbackMessage(result: UpdateResult): string | null {
+  if (result.status === "failed") {
+    return t`Update failed. Please try again.`;
+  }
+
+  if (result.status === "not-allowed") {
+    return t`Update can't be installed right now.`;
+  }
+
+  if (result.status === "unavailable") {
+    return t`Update is no longer available.`;
+  }
+
+  return null;
+}

--- a/packages/pwa/src/routes/index.tsx
+++ b/packages/pwa/src/routes/index.tsx
@@ -17,6 +17,7 @@ import { documentCache } from "#src/lib/automerge/suspense-hooks.js";
 import { use, useState } from "react";
 import { toast } from "sonner";
 import { UpdateContext } from "#src/components/UpdateContext.tsx";
+import { showUpdateResultFeedback } from "#src/lib/updateResultFeedback.ts";
 
 let hasRedirectedThisSession = false;
 
@@ -89,9 +90,14 @@ function Index() {
             <IconButton
               icon={isUpdating ? "lucide.refresh-cw" : "lucide.circle-arrow-down"}
               aria-label={t`Update available`}
-              onPress={() => {
+              onPress={async () => {
                 setIsUpdating(true);
-                update();
+                try {
+                  const result = await update();
+                  showUpdateResultFeedback(result);
+                } finally {
+                  setIsUpdating(false);
+                }
               }}
               className="mr-2"
               iconClassName={cn(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0(@capacitor/core@8.0.1)
       '@capawesome/capacitor-app-update':
-        specifier: 8.0.1
-        version: 8.0.1(@capacitor/core@8.0.1)
+        specifier: 8.0.3
+        version: 8.0.3(@capacitor/core@8.0.1)
       '@trizum/logging':
         specifier: workspace:*
         version: link:../logging
@@ -190,8 +190,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0(@capacitor/core@8.0.1)
       '@capawesome/capacitor-app-update':
-        specifier: 8.0.1
-        version: 8.0.1(@capacitor/core@8.0.1)
+        specifier: 8.0.3
+        version: 8.0.3(@capacitor/core@8.0.1)
       '@fontsource-variable/fira-code':
         specifier: 5.2.7
         version: 5.2.7
@@ -1177,8 +1177,8 @@ packages:
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
-  '@capawesome/capacitor-app-update@8.0.1':
-    resolution: {integrity: sha512-NE7J2igAUuXdB7kCdfm4SnCae58PmesITBYXF152NjPItBefznPVUu09p+xg4+rJ2JmKCJa0fBGi/YGB8xvwUg==}
+  '@capawesome/capacitor-app-update@8.0.3':
+    resolution: {integrity: sha512-5pS9I+i2TuUl8b6L3h2WsWF/PE68exzoc9CciXK/I2SdB2fIkdxObrYBeYS2Z09ndCGqJgx4iwZJmhXwVcMh4w==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
@@ -10364,7 +10364,7 @@ snapshots:
     dependencies:
       '@capacitor/core': 8.0.1
 
-  '@capawesome/capacitor-app-update@8.0.1(@capacitor/core@8.0.1)':
+  '@capawesome/capacitor-app-update@8.0.3(@capacitor/core@8.0.1)':
     dependencies:
       '@capacitor/core': 8.0.1
 
@@ -13729,7 +13729,7 @@ snapshots:
       '@capacitor/core': 8.0.1
       '@capacitor/share': 8.0.0(@capacitor/core@8.0.1)
       '@capacitor/splash-screen': 8.0.0(@capacitor/core@8.0.1)
-      '@capawesome/capacitor-app-update': 8.0.1(@capacitor/core@8.0.1)
+      '@capawesome/capacitor-app-update': 8.0.3(@capacitor/core@8.0.1)
       '@fontsource-variable/fira-code': 5.2.7
       '@fontsource-variable/inter': 5.2.8
       '@horus.dev/tw-dynamic-themes': 0.0.3


### PR DESCRIPTION
## Description

Upgrades `@capawesome/capacitor-app-update` to `8.0.3` and adds an Android-native update environment bridge so startup checks do not call Play Core app-update APIs on unsupported installs or devices without Google Play Services / Play Store support.

The PWA now routes native update state through guarded helpers, resumes interrupted Android immediate updates, serializes duplicate immediate-update starts, and shows translated feedback when an update cannot start. This prevents the Google Play Services dependency dialog path on no-GMS devices while keeping Play-installed Android update flows available.

This PR also adds label-driven PR deployment workflows:

- `android:internal-testing` builds signed Android APK and AAB artifacts from the PR head, uploads the AAB to Google Play internal testing, comments with links to both artifacts, and removes the label after success.
- `ios:testflight` builds a signed iOS release from the PR head, uploads it to TestFlight using the next patch TestFlight train and guarded build-number range, comments with the TestFlight version/build details, and removes the label after success.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

Validation:

- `vp run check`
- `vp run test`
- `vp run build`
- `./gradlew assembleDebug`
- `vp run lingui:extract` via pre-commit hook
- `pnpm view @capawesome/capacitor-app-update version` returned `8.0.3`
- `vp exec capver get`
- `mise exec -- bundle exec fastlane lanes`
- `./gradlew :app:processDebugMainManifest -PtrizumVersionCode=10080001`
- `./gradlew :app:assembleDebug -PtrizumVersionCode=10080001`
- `aapt dump badging app-debug.apk` confirmed `versionCode='10080001'`
- Android label workflow run `27198365097`: uploaded APK/AAB artifacts, published Google Play internal testing build `10080003`, commented on the PR, and removed `android:internal-testing`.
- iOS label workflow run `27199311758`: uploaded TestFlight build `1.8.1 (10080101)`, waited for processing, commented on the PR, and removed `ios:testflight`.
- AOSP `trizum_no_gms_api35` emulator smoke test: no `com.google.android.gms` or `com.android.vending`; app launched; only `NativeUpdateEnvironment.getAndroidUpdateSupport` was called; no Play Core `getAndroidAppUpdateInfo` / `getAppUpdateInfo` calls and no Google Play Services dialog/error logs.

Review loop:

- First no-context reviewer round found two PWA issues; both were fixed.
- Second no-context reviewer round had no findings across Android native, PWA flow/tests, and package/release sync.

Known build warnings are pre-existing: large client chunks, stale Browserslist data, missing `SENTRY_AUTH_TOKEN` for sourcemap upload, Gradle `flatDir` / deprecation warnings, and Fastlane warning that Ruby 3.2 support will be removed in a future Fastlane release.
