### PR TITLE
fix(pwa): open Android camera for receipt capture

### DIFF
--- a/.changeset/android-camera-capture.md
+++ b/.changeset/android-camera-capture.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Fix Android expense and avatar camera buttons opening the gallery instead of camera capture.

--- a/packages/mobile/android/app/capacitor.build.gradle
+++ b/packages/mobile/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':capacitor-camera')
     implementation project(':capacitor-share')
     implementation project(':capacitor-splash-screen')
     implementation project(':capawesome-capacitor-app-update')

--- a/packages/mobile/android/capacitor.settings.gradle
+++ b/packages/mobile/android/capacitor.settings.gradle
@@ -5,6 +5,9 @@ project(':capacitor-android').projectDir = new File('../../../node_modules/.pnpm
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../../../node_modules/.pnpm/@capacitor+app@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/app/android')
 
+include ':capacitor-camera'
+project(':capacitor-camera').projectDir = new File('../../../node_modules/.pnpm/@capacitor+camera@8.2.0_@capacitor+core@8.0.1/node_modules/@capacitor/camera/android')
+
 include ':capacitor-share'
 project(':capacitor-share').projectDir = new File('../../../node_modules/.pnpm/@capacitor+share@8.0.0_@capacitor+core@8.0.1/node_modules/@capacitor/share/android')
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@capacitor/android": "8.0.1",
     "@capacitor/app": "8.0.0",
+    "@capacitor/camera": "8.2.0",
     "@capacitor/core": "8.0.1",
     "@capacitor/ios": "8.0.1",
     "@capacitor/share": "8.0.0",

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -142,7 +142,7 @@ msgstr "Align QR code here"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:358
+#: src/components/ExpenseEditor.tsx:367
 msgid "Amount"
 msgstr "Amount"
 
@@ -150,11 +150,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:665
+#: src/components/ExpenseEditor.tsx:674
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:348
+#: src/components/ExpenseEditor.tsx:357
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -227,7 +227,7 @@ msgstr "Attachments"
 msgid "Australian Dollar"
 msgstr "Australian Dollar"
 
-#: src/components/ExpenseEditor.tsx:258
+#: src/components/ExpenseEditor.tsx:267
 #: src/routes/settings.tsx:212
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -240,11 +240,11 @@ msgstr "Automatically open the calculator when focusing amount fields"
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Automatically open the last visited party when you open the app"
 
-#: src/components/AvatarPicker.tsx:82
+#: src/components/AvatarPicker.tsx:97
 msgid "Avatar removed"
 msgstr "Avatar removed"
 
-#: src/components/AvatarPicker.tsx:66
+#: src/components/AvatarPicker.tsx:71
 msgid "Avatar updated successfully"
 msgstr "Avatar updated successfully"
 
@@ -595,7 +595,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:408
+#: src/components/ExpenseEditor.tsx:417
 msgid "Date"
 msgstr "Date"
 
@@ -755,7 +755,7 @@ msgstr "Exact"
 msgid "Expense added"
 msgstr "Expense added"
 
-#: src/components/ExpenseEditor.tsx:147
+#: src/components/ExpenseEditor.tsx:156
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
@@ -775,6 +775,8 @@ msgstr "Expenses"
 msgid "Expenses counted"
 msgstr "Expenses counted"
 
+#: src/components/AvatarPicker.tsx:112
+#: src/components/ExpenseEditor.tsx:885
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -815,11 +817,11 @@ msgstr "Failed to transfer debt"
 msgid "Failed to update expense"
 msgstr "Failed to update expense"
 
-#: src/components/AvatarPicker.tsx:71
+#: src/components/AvatarPicker.tsx:76
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:847
+#: src/components/ExpenseEditor.tsx:860
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -920,7 +922,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:753
+#: src/components/ExpenseEditor.tsx:762
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -977,7 +979,7 @@ msgstr "Icelandic Króna"
 msgid "ID is required"
 msgstr "ID is required"
 
-#: src/components/AvatarPicker.tsx:48
+#: src/components/AvatarPicker.tsx:53
 msgid "Image must be smaller than 10MB"
 msgstr "Image must be smaller than 10MB"
 
@@ -1005,7 +1007,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:437
+#: src/components/ExpenseEditor.tsx:446
 msgid "Include all"
 msgstr "Include all"
 
@@ -1225,7 +1227,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:249
+#: src/components/ExpenseEditor.tsx:258
 #: src/routes/index.tsx:112
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:92
 #: src/routes/party.$partyId.tsx:206
@@ -1459,7 +1461,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:261
+#: src/components/ExpenseEditor.tsx:270
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1500,7 +1502,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:383
+#: src/components/ExpenseEditor.tsx:392
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:221
 msgid "Paid by"
 msgstr "Paid by"
@@ -1674,7 +1676,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:771
+#: src/components/ExpenseEditor.tsx:780
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -1686,7 +1688,7 @@ msgstr "Please don't close the app while we migrate your data"
 msgid "Please paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or key"
 msgstr "Please paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or key"
 
-#: src/components/AvatarPicker.tsx:41
+#: src/components/AvatarPicker.tsx:46
 msgid "Please select an image file"
 msgstr "Please select an image file"
 
@@ -1743,11 +1745,11 @@ msgstr "Reload"
 msgid "Remove"
 msgstr "Remove"
 
-#: src/components/AvatarPicker.tsx:114
+#: src/components/AvatarPicker.tsx:145
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:948
+#: src/components/ExpenseEditor.tsx:981
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -1803,7 +1805,7 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:279
+#: src/components/ExpenseEditor.tsx:288
 #: src/routes/migrate_.tricount.tsx:160
 #: src/routes/new.tsx:148
 #: src/routes/party_.$partyId.settings.tsx:127
@@ -1881,7 +1883,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:627
+#: src/components/ExpenseEditor.tsx:636
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -1889,7 +1891,7 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:757
+#: src/components/ExpenseEditor.tsx:766
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
@@ -1974,7 +1976,7 @@ msgstr "Stats"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:279
+#: src/components/ExpenseEditor.tsx:288
 #: src/routes/migrate_.tricount.tsx:160
 #: src/routes/new.tsx:148
 #: src/routes/party_.$partyId.settings.tsx:127
@@ -2020,11 +2022,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:651
+#: src/components/ExpenseEditor.tsx:660
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:652
+#: src/components/ExpenseEditor.tsx:661
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2057,10 +2059,10 @@ msgstr "System (fallbacks to {DEFAULT_LOCALE})"
 msgid "Tajikistani Somoni"
 msgstr "Tajikistani Somoni"
 
-#: src/components/AvatarPicker.tsx:128
-#: src/components/AvatarPicker.tsx:143
-#: src/components/ExpenseEditor.tsx:872
-#: src/components/ExpenseEditor.tsx:886
+#: src/components/AvatarPicker.tsx:159
+#: src/components/AvatarPicker.tsx:174
+#: src/components/ExpenseEditor.tsx:905
+#: src/components/ExpenseEditor.tsx:919
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2135,7 +2137,7 @@ msgstr "This project uses various open source libraries and tools."
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:324
+#: src/components/ExpenseEditor.tsx:333
 msgid "Title"
 msgstr "Title"
 
@@ -2283,18 +2285,18 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:796
+#: src/components/ExpenseEditor.tsx:805
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
-#: src/components/AvatarPicker.tsx:137
-#: src/components/AvatarPicker.tsx:155
-#: src/components/ExpenseEditor.tsx:881
-#: src/components/ExpenseEditor.tsx:898
+#: src/components/AvatarPicker.tsx:168
+#: src/components/AvatarPicker.tsx:186
+#: src/components/ExpenseEditor.tsx:914
+#: src/components/ExpenseEditor.tsx:931
 msgid "Upload photo"
 msgstr "Upload photo"
 
-#: src/components/AvatarPicker.tsx:53
+#: src/components/AvatarPicker.tsx:58
 msgid "Uploading avatar..."
 msgstr "Uploading avatar..."
 
@@ -2303,7 +2305,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:832
+#: src/components/ExpenseEditor.tsx:845
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2367,7 +2369,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:933
+#: src/components/ExpenseEditor.tsx:966
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:285
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -134,7 +134,7 @@ msgstr "Alinea el código QR aquí"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:358
+#: src/components/ExpenseEditor.tsx:367
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -142,11 +142,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:665
+#: src/components/ExpenseEditor.tsx:674
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:348
+#: src/components/ExpenseEditor.tsx:357
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -215,7 +215,7 @@ msgstr "Adjuntos"
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
-#: src/components/ExpenseEditor.tsx:258
+#: src/components/ExpenseEditor.tsx:267
 #: src/routes/settings.tsx:212
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -228,11 +228,11 @@ msgstr "Abrir automáticamente la calculadora al enfocar campos de importe"
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Abrir automáticamente el último grupo visitado cuando abras la app"
 
-#: src/components/AvatarPicker.tsx:82
+#: src/components/AvatarPicker.tsx:97
 msgid "Avatar removed"
 msgstr "Avatar eliminado"
 
-#: src/components/AvatarPicker.tsx:66
+#: src/components/AvatarPicker.tsx:71
 msgid "Avatar updated successfully"
 msgstr "Avatar actualizado correctamente"
 
@@ -567,7 +567,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:408
+#: src/components/ExpenseEditor.tsx:417
 msgid "Date"
 msgstr "Fecha"
 
@@ -719,7 +719,7 @@ msgstr "Por ahora todo está archivado. Puedes reabrir cualquier grupo desde la 
 msgid "Expense added"
 msgstr "Gasto añadido"
 
-#: src/components/ExpenseEditor.tsx:147
+#: src/components/ExpenseEditor.tsx:156
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
@@ -735,6 +735,8 @@ msgstr "Gastos"
 msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
+#: src/components/AvatarPicker.tsx:112
+#: src/components/ExpenseEditor.tsx:885
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -771,11 +773,11 @@ msgstr "No se pudo transferir la deuda"
 msgid "Failed to update expense"
 msgstr "Error al actualizar el gasto"
 
-#: src/components/AvatarPicker.tsx:71
+#: src/components/AvatarPicker.tsx:76
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:847
+#: src/components/ExpenseEditor.tsx:860
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -872,7 +874,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:753
+#: src/components/ExpenseEditor.tsx:762
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -925,7 +927,7 @@ msgstr "Corona Islandesa"
 msgid "ID is required"
 msgstr "Se requiere un ID"
 
-#: src/components/AvatarPicker.tsx:48
+#: src/components/AvatarPicker.tsx:53
 msgid "Image must be smaller than 10MB"
 msgstr "La imagen debe ser menor de 10MB"
 
@@ -957,7 +959,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:437
+#: src/components/ExpenseEditor.tsx:446
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1173,7 +1175,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:249
+#: src/components/ExpenseEditor.tsx:258
 #: src/routes/index.tsx:112
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:92
 #: src/routes/party.$partyId.tsx:206
@@ -1403,7 +1405,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:261
+#: src/components/ExpenseEditor.tsx:270
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1440,7 +1442,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:383
+#: src/components/ExpenseEditor.tsx:392
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:221
 msgid "Paid by"
 msgstr "Pagado por"
@@ -1606,7 +1608,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:771
+#: src/components/ExpenseEditor.tsx:780
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -1618,7 +1620,7 @@ msgstr "Por favor, no cierres la aplicación mientras migramos tus datos"
 msgid "Please paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or key"
 msgstr "Por favor, pega el mensaje de compartir de Tricount, la URL (p. ej., https://tricount.com/abc123), o la clave"
 
-#: src/components/AvatarPicker.tsx:41
+#: src/components/AvatarPicker.tsx:46
 msgid "Please select an image file"
 msgstr "Por favor, selecciona un archivo de imagen"
 
@@ -1671,11 +1673,11 @@ msgstr "Recargar"
 msgid "Remove"
 msgstr "Eliminar"
 
-#: src/components/AvatarPicker.tsx:114
+#: src/components/AvatarPicker.tsx:145
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:948
+#: src/components/ExpenseEditor.tsx:981
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -1731,7 +1733,7 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:279
+#: src/components/ExpenseEditor.tsx:288
 #: src/routes/migrate_.tricount.tsx:160
 #: src/routes/new.tsx:148
 #: src/routes/party_.$partyId.settings.tsx:127
@@ -1809,7 +1811,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:627
+#: src/components/ExpenseEditor.tsx:636
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -1817,7 +1819,7 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:757
+#: src/components/ExpenseEditor.tsx:766
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
@@ -1898,7 +1900,7 @@ msgstr "Estadísticas"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:279
+#: src/components/ExpenseEditor.tsx:288
 #: src/routes/migrate_.tricount.tsx:160
 #: src/routes/new.tsx:148
 #: src/routes/party_.$partyId.settings.tsx:127
@@ -1944,11 +1946,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:651
+#: src/components/ExpenseEditor.tsx:660
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:652
+#: src/components/ExpenseEditor.tsx:661
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -1981,10 +1983,10 @@ msgstr "Sistema (por defecto {DEFAULT_LOCALE})"
 msgid "Tajikistani Somoni"
 msgstr "Somoni Tayiko"
 
-#: src/components/AvatarPicker.tsx:128
-#: src/components/AvatarPicker.tsx:143
-#: src/components/ExpenseEditor.tsx:872
-#: src/components/ExpenseEditor.tsx:886
+#: src/components/AvatarPicker.tsx:159
+#: src/components/AvatarPicker.tsx:174
+#: src/components/ExpenseEditor.tsx:905
+#: src/components/ExpenseEditor.tsx:919
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2059,7 +2061,7 @@ msgstr "Este proyecto utiliza varias bibliotecas y herramientas de código abier
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:324
+#: src/components/ExpenseEditor.tsx:333
 msgid "Title"
 msgstr "Título"
 
@@ -2195,22 +2197,22 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:796
+#: src/components/ExpenseEditor.tsx:805
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
-#: src/components/AvatarPicker.tsx:137
-#: src/components/AvatarPicker.tsx:155
-#: src/components/ExpenseEditor.tsx:881
-#: src/components/ExpenseEditor.tsx:898
+#: src/components/AvatarPicker.tsx:168
+#: src/components/AvatarPicker.tsx:186
+#: src/components/ExpenseEditor.tsx:914
+#: src/components/ExpenseEditor.tsx:931
 msgid "Upload photo"
 msgstr "Subir foto"
 
-#: src/components/AvatarPicker.tsx:53
+#: src/components/AvatarPicker.tsx:58
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:832
+#: src/components/ExpenseEditor.tsx:845
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2270,7 +2272,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:933
+#: src/components/ExpenseEditor.tsx:966
 #: src/routes/party_.$partyId.expense.$expenseId.tsx:285
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -20,6 +20,7 @@
     "@automerge/automerge-repo-network-websocket": "2.5.3",
     "@automerge/automerge-repo-storage-indexeddb": "2.5.3",
     "@capacitor/app": "8.0.0",
+    "@capacitor/camera": "8.2.0",
     "@capacitor/core": "8.0.1",
     "@capacitor/share": "^8.0.0",
     "@capacitor/splash-screen": "8.0.0",

--- a/packages/pwa/src/components/AvatarPicker.tsx
+++ b/packages/pwa/src/components/AvatarPicker.tsx
@@ -8,9 +8,15 @@ import { getImageUploadErrorMessage, useMediaFileActions } from "#src/hooks/useM
 import { useMediaFile } from "#src/hooks/useMediaFile.js";
 import {
   compressionPresets,
+  imageCaptureAccept,
   imageUploadAccept,
   isSupportedImageFile,
 } from "#src/lib/imageCompression.js";
+import {
+  getNativeCameraCaptureFile,
+  isNativeCameraCancel,
+  shouldUseNativeCameraCapture,
+} from "#src/lib/nativeCamera.ts";
 import { getLogger } from "#src/lib/log.ts";
 import { Suspense, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -32,8 +38,7 @@ export function AvatarPicker({ value, name, onChange, className }: AvatarPickerP
   const { createMediaFile } = useMediaFileActions();
   const [isUploading, setIsUploading] = useState(false);
 
-  async function onFileChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
+  async function updateAvatarFromFile(file: File) {
     if (!file) return;
 
     // Validate file type
@@ -72,6 +77,16 @@ export function AvatarPicker({ value, name, onChange, className }: AvatarPickerP
       );
     } finally {
       setIsUploading(false);
+    }
+  }
+
+  async function onFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      await updateAvatarFromFile(file);
+    } finally {
       // Reset the input value to allow selecting the same file again
       event.target.value = "";
     }
@@ -82,8 +97,24 @@ export function AvatarPicker({ value, name, onChange, className }: AvatarPickerP
     toast.success(t`Avatar removed`);
   }
 
-  function openCamera() {
-    cameraInputRef.current?.click();
+  async function openCamera() {
+    if (!shouldUseNativeCameraCapture()) {
+      cameraInputRef.current?.click();
+      return;
+    }
+
+    let file: File;
+    try {
+      file = await getNativeCameraCaptureFile();
+    } catch (error) {
+      if (!isNativeCameraCancel(error)) {
+        logger.error("Failed to capture avatar", { error });
+        toast.error(t`Failed to access camera`);
+      }
+      return;
+    }
+
+    await updateAvatarFromFile(file);
   }
 
   function openGallery() {
@@ -120,7 +151,7 @@ export function AvatarPicker({ value, name, onChange, className }: AvatarPickerP
 
       <div className="flex h-32 w-max flex-shrink-0 flex-col gap-2">
         <Button
-          onPress={openCamera}
+          onPress={() => void openCamera()}
           color="input-like"
           className="flex flex-1 flex-col items-center justify-center gap-1.5 rounded-xl px-3 text-xs"
         >
@@ -142,7 +173,7 @@ export function AvatarPicker({ value, name, onChange, className }: AvatarPickerP
         type="file"
         aria-label={t`Take photo`}
         className="sr-only"
-        accept={imageUploadAccept}
+        accept={imageCaptureAccept}
         capture="environment"
         multiple={false}
         onChange={(event) => void onFileChange(event)}

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -32,7 +32,16 @@ import { useMediaFile } from "#src/hooks/useMediaFile.ts";
 import { Skeleton } from "#src/ui/Skeleton.tsx";
 import type { MediaFile } from "#src/models/media.ts";
 import { getImageUploadErrorMessage, useMediaFileActions } from "#src/hooks/useMediaFileActions.ts";
-import { compressionPresets, imageUploadAccept } from "#src/lib/imageCompression.ts";
+import {
+  compressionPresets,
+  imageCaptureAccept,
+  imageUploadAccept,
+} from "#src/lib/imageCompression.ts";
+import {
+  getNativeCameraCaptureFile,
+  isNativeCameraCancel,
+  shouldUseNativeCameraCapture,
+} from "#src/lib/nativeCamera.ts";
 import { getLogger } from "#src/lib/log.ts";
 import { MediaGalleryContext } from "./MediaGalleryContext";
 
@@ -828,12 +837,16 @@ function AddPhotoButton({ onPhoto }: AddPhotoButtonProps) {
   const galleryInputRef = useRef<HTMLInputElement>(null);
   const { createMediaFile } = useMediaFileActions();
 
-  async function onFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+  async function addPhotoFiles(files: Blob[]) {
+    if (files.length === 0) {
+      return;
+    }
+
     const toastId: string | number = toast.loading(t`Uploading...`);
 
     try {
       const photoIds = await Promise.all(
-        Array.from(event.target.files ?? []).map(async (blob) => {
+        files.map(async (blob) => {
           const [mediaFileId] = await createMediaFile(blob, {}, compressionPresets.balanced);
           return mediaFileId;
         }),
@@ -848,13 +861,33 @@ function AddPhotoButton({ onPhoto }: AddPhotoButtonProps) {
         id: toastId,
       });
     }
+  }
+
+  async function onFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    await addPhotoFiles(Array.from(event.target.files ?? []));
 
     // Reset the input value to allow the user to add more photos
     event.target.value = "";
   }
 
-  function openCamera() {
-    cameraInputRef.current?.click();
+  async function openCamera() {
+    if (!shouldUseNativeCameraCapture()) {
+      cameraInputRef.current?.click();
+      return;
+    }
+
+    let file: File;
+    try {
+      file = await getNativeCameraCaptureFile();
+    } catch (error) {
+      if (!isNativeCameraCancel(error)) {
+        logger.error("Failed to capture expense attachment", { error });
+        toast.error(t`Failed to access camera`);
+      }
+      return;
+    }
+
+    await addPhotoFiles([file]);
   }
 
   function openGallery() {
@@ -864,7 +897,7 @@ function AddPhotoButton({ onPhoto }: AddPhotoButtonProps) {
   return (
     <div className="flex h-32 w-max flex-shrink-0 flex-col gap-2">
       <Button
-        onPress={openCamera}
+        onPress={() => void openCamera()}
         color="input-like"
         className="flex flex-1 flex-col items-center justify-center gap-1.5 rounded-xl px-3 text-xs"
       >
@@ -885,7 +918,7 @@ function AddPhotoButton({ onPhoto }: AddPhotoButtonProps) {
         type="file"
         aria-label={t`Take photo`}
         className="sr-only"
-        accept={imageUploadAccept}
+        accept={imageCaptureAccept}
         capture="environment"
         multiple={false}
         onChange={(event) => void onFileChange(event)}

--- a/packages/pwa/src/lib/imageCompression.test.ts
+++ b/packages/pwa/src/lib/imageCompression.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vite-plus/test";
-import { imageUploadAccept, isHeicImageFile, isSupportedImageFile } from "./imageCompression";
+import {
+  imageCaptureAccept,
+  imageUploadAccept,
+  isHeicImageFile,
+  isSupportedImageFile,
+} from "./imageCompression";
 
 describe("image upload helpers", () => {
   test("detects HEIC and HEIF files from MIME type or extension", () => {
@@ -51,5 +56,9 @@ describe("image upload helpers", () => {
     expect(imageUploadAccept).toContain(".heif");
     expect(imageUploadAccept).toContain("image/heic");
     expect(imageUploadAccept).toContain("image/heif");
+  });
+
+  test("keeps camera capture accept narrow for Android WebView", () => {
+    expect(imageCaptureAccept).toBe("image/*");
   });
 });

--- a/packages/pwa/src/lib/imageCompression.ts
+++ b/packages/pwa/src/lib/imageCompression.ts
@@ -49,6 +49,7 @@ const logger = getLogger("lib", "imageCompression");
 
 export const imageUploadAccept =
   "image/*,.heic,.heif,image/heic,image/heif,image/heic-sequence,image/heif-sequence";
+export const imageCaptureAccept = "image/*";
 
 export type ImageProcessingErrorCode = "heic_conversion_failed";
 

--- a/packages/pwa/src/lib/nativeCamera.ts
+++ b/packages/pwa/src/lib/nativeCamera.ts
@@ -1,0 +1,64 @@
+import { Camera, CameraResultType, CameraSource } from "@capacitor/camera";
+import { Capacitor } from "@capacitor/core";
+
+export function shouldUseNativeCameraCapture() {
+  return Capacitor.isNativePlatform() && Capacitor.getPlatform() === "android";
+}
+
+export function isNativeCameraCancel(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return /cancel|cancelled|canceled/i.test(error.message);
+}
+
+export async function getNativeCameraCaptureFile() {
+  const photo = await Camera.getPhoto({
+    quality: 90,
+    resultType: CameraResultType.Uri,
+    source: CameraSource.Camera,
+  });
+
+  if (!photo.webPath) {
+    throw new Error("Native camera did not return a readable image path");
+  }
+
+  const response = await fetch(photo.webPath);
+  const blob = await response.blob();
+  const mimeType = blob.type || getMimeTypeForPhotoFormat(photo.format);
+  const extension = getFileExtensionForMimeType(mimeType);
+
+  return new File([blob], `camera-${Date.now()}${extension}`, {
+    type: mimeType,
+  });
+}
+
+function getMimeTypeForPhotoFormat(format: string) {
+  switch (format.toLowerCase()) {
+    case "png":
+      return "image/png";
+    case "webp":
+      return "image/webp";
+    case "gif":
+      return "image/gif";
+    case "jpeg":
+    case "jpg":
+    default:
+      return "image/jpeg";
+  }
+}
+
+function getFileExtensionForMimeType(mimeType: string) {
+  switch (mimeType.toLowerCase()) {
+    case "image/png":
+      return ".png";
+    case "image/webp":
+      return ".webp";
+    case "image/gif":
+      return ".gif";
+    case "image/jpeg":
+    default:
+      return ".jpg";
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@capacitor/app':
         specifier: 8.0.0
         version: 8.0.0(@capacitor/core@8.0.1)
+      '@capacitor/camera':
+        specifier: 8.2.0
+        version: 8.2.0(@capacitor/core@8.0.1)
       '@capacitor/core':
         specifier: 8.0.1
         version: 8.0.1
@@ -180,6 +183,9 @@ importers:
       '@capacitor/app':
         specifier: 8.0.0
         version: 8.0.0(@capacitor/core@8.0.1)
+      '@capacitor/camera':
+        specifier: 8.2.0
+        version: 8.2.0(@capacitor/core@8.0.1)
       '@capacitor/core':
         specifier: 8.0.1
         version: 8.0.1
@@ -1148,6 +1154,11 @@ packages:
     resolution: {integrity: sha512-ohz/OUq61Y1Fc6aVSt0uDrUdeOA7oTH4pkWDbv/8I3UrPjH7oPkzYhShuDRUjekNp9RBi198VSFdt0CetpEOzw==}
     engines: {node: '>=10.3.0'}
     hasBin: true
+
+  '@capacitor/camera@8.2.0':
+    resolution: {integrity: sha512-hYfrT6xpL936qoEkIpJzSnb0fQCaTkOux1cXzGBfH8QLOGqr6gSLiWZlZz/fqMPmMKJMNRBqlTQkj5fuMhVZog==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
 
   '@capacitor/cli@5.7.8':
     resolution: {integrity: sha512-qN8LDlREMhrYhOvVXahoJVNkP8LP55/YPRJrzTAFrMqlNJC18L3CzgWYIblFPnuwfbH/RxbfoZT/ydkwgVpMrw==}
@@ -10303,6 +10314,10 @@ snapshots:
       - react-native-b4a
       - supports-color
       - typescript
+
+  '@capacitor/camera@8.2.0(@capacitor/core@8.0.1)':
+    dependencies:
+      '@capacitor/core': 8.0.1
 
   '@capacitor/cli@5.7.8':
     dependencies:


### PR DESCRIPTION
## Description

Fixes Android receipt/avatar camera capture opening the gallery picker by using Capacitor Camera on Android native builds while keeping the existing file input path for browser and iOS.

This also registers the native Camera plugin in the Android wrapper and keeps gallery upload support for HEIC/HEIF files.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Android emulator verification completed on `trizum_no_gms_api35` / `emulator-5554`:

- Before the native camera fix, tapping `Take photo` opened `com.android.providers.media.module/.PhotoPickerGetContentActivity`.
- After the fix, tapping `Take photo` opened `com.android.camera2/com.android.camera.CaptureActivity`.
- Capturing and accepting a photo returned to trizum with the attachment preview visible in the expense editor.

## Additional Notes

Validation run locally:

- `vp run --filter @trizum/pwa check`
- `vp run --filter @trizum/pwa test`
- `vp run --filter @trizum/pwa lingui:extract`
- `vp run --filter @trizum/pwa build`
- `vp run --filter @trizum/mobile check`
- `vp exec cap sync android`
- `vp exec cap run android --target emulator-5554`

`@trizum/mobile build` was not used for the Android device test because local iOS sync requires Bundler 2.7.2; Android-specific Capacitor sync/run completed successfully.
