### PR TITLE
chore(pwa): add minor changeset

### DIFF
--- a/.changeset/brisk-pwa-minor.md
+++ b/.changeset/brisk-pwa-minor.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": minor
+---
+
+Release the next minor version of the PWA.


### PR DESCRIPTION
## What changed

Added a changeset that bumps `@trizum/pwa` at the `minor` level.

## Why

This intentionally triggers the next minor release for the PWA package. Because `@trizum/pwa` and `@trizum/mobile` are fixed together in the Changesets config, the release plan reports both packages at minor.

## Validation

- `vp exec changeset status`
- pre-commit hook ran `vp check --fix`
- pre-commit hook ran `vp run lingui:extract`