### PR TITLE
feat(pwa): add party activity log

### DIFF
--- a/.changeset/party-activity-log.md
+++ b/.changeset/party-activity-log.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": minor
+---
+
+Add a party log tab that records party creation, settings changes, participant updates, expenses, and debt transfer operations.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -15,12 +15,12 @@ msgstr ""
 
 #: src/routes/party_.$partyId.pay.tsx:101
 #: src/routes/party_.$partyId.pay.tsx:107
-#: src/routes/party.$partyId.tsx:886
-#: src/routes/party.$partyId.tsx:892
+#: src/routes/party.$partyId.tsx:898
+#: src/routes/party.$partyId.tsx:904
 msgid "(me)"
 msgstr "(me)"
 
-#: src/routes/party.$partyId.tsx:399
+#: src/routes/party.$partyId.tsx:411
 msgid "[DEV] Create expenses"
 msgstr "[DEV] Create expenses"
 
@@ -30,6 +30,30 @@ msgstr "[DEV] Create expenses"
 msgid "{0, plural, one {and # other} other {and # others}}"
 msgstr "{0, plural, one {and # other} other {and # others}}"
 
+#: src/routes/party.$partyId.tsx:450
+msgid "{0} started tracking shared expenses."
+msgstr "{0} started tracking shared expenses."
+
+#: src/routes/party.$partyId.tsx:419
+msgid "{0} was added"
+msgstr "{0} was added"
+
+#: src/routes/party.$partyId.tsx:423
+msgid "{0} was archived"
+msgstr "{0} was archived"
+
+#: src/routes/party.$partyId.tsx:427
+msgid "{0} was removed"
+msgstr "{0} was removed"
+
+#: src/routes/party.$partyId.tsx:425
+msgid "{0} was restored"
+msgstr "{0} was restored"
+
+#: src/routes/party.$partyId.tsx:421
+msgid "{0} was updated"
+msgstr "{0} was updated"
+
 #: src/routes/migrate_.tricount.tsx:377
 msgid "{message}"
 msgstr "{message}"
@@ -37,6 +61,30 @@ msgstr "{message}"
 #: src/routes/migrate_.tricount.tsx:321
 msgid "{name}"
 msgstr "{name}"
+
+#: src/routes/party_.$partyId.log.tsx:141
+msgid "{participantName} was added"
+msgstr "{participantName} was added"
+
+#: src/routes/party_.$partyId.log.tsx:145
+msgid "{participantName} was archived"
+msgstr "{participantName} was archived"
+
+#: src/routes/party_.$partyId.log.tsx:149
+msgid "{participantName} was removed"
+msgstr "{participantName} was removed"
+
+#: src/routes/party_.$partyId.log.tsx:147
+msgid "{participantName} was restored"
+msgstr "{participantName} was restored"
+
+#: src/routes/party_.$partyId.log.tsx:143
+msgid "{participantName} was updated"
+msgstr "{participantName} was updated"
+
+#: src/routes/party_.$partyId.log.tsx:174
+msgid "{partyName} started tracking shared expenses."
+msgstr "{partyName} started tracking shared expenses."
 
 #: src/routes/about.tsx:158
 msgid "© {0} trizum"
@@ -83,7 +131,7 @@ msgstr "Across the selected timeframe"
 msgid "Active"
 msgstr "Active"
 
-#: src/routes/new.tsx:573
+#: src/routes/new.tsx:584
 msgid "ADB Unit of Account"
 msgstr "ADB Unit of Account"
 
@@ -91,8 +139,8 @@ msgstr "ADB Unit of Account"
 msgid "Add"
 msgstr "Add"
 
-#: src/routes/party.$partyId.tsx:411
-#: src/routes/party.$partyId.tsx:419
+#: src/routes/party.$partyId.tsx:423
+#: src/routes/party.$partyId.tsx:431
 msgid "Add an expense"
 msgstr "Add an expense"
 
@@ -101,11 +149,11 @@ msgid "Add expenses to this party to unlock totals, rankings, and individual spe
 msgstr "Add expenses to this party to unlock totals, rankings, and individual spend."
 
 #: src/routes/index.tsx:204
-#: src/routes/party.$partyId.tsx:382
+#: src/routes/party.$partyId.tsx:394
 msgid "Add or create"
 msgstr "Add or create"
 
-#: src/routes/new.tsx:374
+#: src/routes/new.tsx:385
 #: src/routes/party_.$partyId.settings.tsx:382
 msgid "Add participant"
 msgstr "Add participant"
@@ -122,15 +170,15 @@ msgstr "Adding expense..."
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/routes/new.tsx:430
+#: src/routes/new.tsx:441
 msgid "Afghan Afghani"
 msgstr "Afghan Afghani"
 
-#: src/routes/new.tsx:431
+#: src/routes/new.tsx:442
 msgid "Albanian Lek"
 msgstr "Albanian Lek"
 
-#: src/routes/new.tsx:465
+#: src/routes/new.tsx:476
 msgid "Algerian Dinar"
 msgstr "Algerian Dinar"
 
@@ -158,7 +206,7 @@ msgstr "Amount for {participantName}"
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
-#: src/routes/new.tsx:434
+#: src/routes/new.tsx:445
 msgid "Angolan Kwanza"
 msgstr "Angolan Kwanza"
 
@@ -198,19 +246,19 @@ msgstr "Archived Parties"
 msgid "Archived parties live here until you restore them to the home screen."
 msgstr "Archived parties live here until you restore them to the home screen."
 
-#: src/routes/new.tsx:435
+#: src/routes/new.tsx:446
 msgid "Argentine Peso"
 msgstr "Argentine Peso"
 
-#: src/routes/new.tsx:432
+#: src/routes/new.tsx:443
 msgid "Armenian Dram"
 msgstr "Armenian Dram"
 
-#: src/routes/new.tsx:436
+#: src/routes/new.tsx:447
 msgid "Aruban Florin"
 msgstr "Aruban Florin"
 
-#: src/routes/new.tsx:269
+#: src/routes/new.tsx:280
 #: src/routes/party_.$partyId.settings.tsx:234
 msgid "At least one participant is required"
 msgstr "At least one participant is required"
@@ -223,7 +271,7 @@ msgstr "Attach photos of receipts to your expenses"
 msgid "Attachments"
 msgstr "Attachments"
 
-#: src/routes/new.tsx:404
+#: src/routes/new.tsx:415
 msgid "Australian Dollar"
 msgstr "Australian Dollar"
 
@@ -240,6 +288,10 @@ msgstr "Automatically open the calculator when focusing amount fields"
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Automatically open the last visited party when you open the app"
 
+#: src/routes/party_.$partyId.log.tsx:237
+msgid "Avatar"
+msgstr "Avatar"
+
 #: src/components/AvatarPicker.tsx:97
 msgid "Avatar removed"
 msgstr "Avatar removed"
@@ -248,7 +300,7 @@ msgstr "Avatar removed"
 msgid "Avatar updated successfully"
 msgstr "Avatar updated successfully"
 
-#: src/routes/new.tsx:437
+#: src/routes/new.tsx:448
 msgid "Azerbaijani Manat"
 msgstr "Azerbaijani Manat"
 
@@ -260,11 +312,11 @@ msgstr "Back to home"
 msgid "Backspace"
 msgstr "Backspace"
 
-#: src/routes/new.tsx:447
+#: src/routes/new.tsx:458
 msgid "Bahamian Dollar"
 msgstr "Bahamian Dollar"
 
-#: src/routes/new.tsx:441
+#: src/routes/new.tsx:452
 msgid "Bahraini Dinar"
 msgstr "Bahraini Dinar"
 
@@ -276,31 +328,31 @@ msgstr "Balance, Highest First"
 msgid "Balance, Lowest First"
 msgstr "Balance, Lowest First"
 
-#: src/routes/party.$partyId.tsx:324
+#: src/routes/party.$partyId.tsx:336
 msgid "Balances"
 msgstr "Balances"
 
-#: src/routes/new.tsx:440
+#: src/routes/new.tsx:451
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
-#: src/routes/new.tsx:439
+#: src/routes/new.tsx:450
 msgid "Barbadian Dollar"
 msgstr "Barbadian Dollar"
 
-#: src/routes/new.tsx:450
+#: src/routes/new.tsx:461
 msgid "Belarusian Ruble"
 msgstr "Belarusian Ruble"
 
-#: src/routes/new.tsx:451
+#: src/routes/new.tsx:462
 msgid "Belize Dollar"
 msgstr "Belize Dollar"
 
-#: src/routes/new.tsx:443
+#: src/routes/new.tsx:454
 msgid "Bermudan Dollar"
 msgstr "Bermudan Dollar"
 
-#: src/routes/new.tsx:448
+#: src/routes/new.tsx:459
 msgid "Bhutanese Ngultrum"
 msgstr "Bhutanese Ngultrum"
 
@@ -308,31 +360,31 @@ msgstr "Bhutanese Ngultrum"
 msgid "Biggest spenders"
 msgstr "Biggest spenders"
 
-#: src/routes/new.tsx:445
+#: src/routes/new.tsx:456
 msgid "Bolivian Boliviano"
 msgstr "Bolivian Boliviano"
 
-#: src/routes/new.tsx:446
+#: src/routes/new.tsx:457
 msgid "Bolivian Mvdol"
 msgstr "Bolivian Mvdol"
 
-#: src/routes/new.tsx:438
+#: src/routes/new.tsx:449
 msgid "Bosnia-Herzegovina Convertible Mark"
 msgstr "Bosnia-Herzegovina Convertible Mark"
 
-#: src/routes/new.tsx:449
+#: src/routes/new.tsx:460
 msgid "Botswanan Pula"
 msgstr "Botswanan Pula"
 
-#: src/routes/new.tsx:408
+#: src/routes/new.tsx:419
 msgid "Brazilian Real"
 msgstr "Brazilian Real"
 
-#: src/routes/new.tsx:400
+#: src/routes/new.tsx:411
 msgid "British Pound"
 msgstr "British Pound"
 
-#: src/routes/new.tsx:444
+#: src/routes/new.tsx:455
 msgid "Brunei Dollar"
 msgstr "Brunei Dollar"
 
@@ -344,11 +396,11 @@ msgstr "Bug Reports"
 msgid "Built With"
 msgstr "Built With"
 
-#: src/routes/new.tsx:417
+#: src/routes/new.tsx:428
 msgid "Bulgarian Lev"
 msgstr "Bulgarian Lev"
 
-#: src/routes/new.tsx:442
+#: src/routes/new.tsx:453
 msgid "Burundian Franc"
 msgstr "Burundian Franc"
 
@@ -364,7 +416,7 @@ msgstr "Calculator"
 msgid "Calculator expression"
 msgstr "Calculator expression"
 
-#: src/routes/new.tsx:488
+#: src/routes/new.tsx:499
 msgid "Cambodian Riel"
 msgstr "Cambodian Riel"
 
@@ -384,11 +436,11 @@ msgstr "Can I use trizum without an account?"
 msgid "Can't add an expense to a party that doesn't exist"
 msgstr "Can't add an expense to a party that doesn't exist"
 
-#: src/routes/new.tsx:403
+#: src/routes/new.tsx:414
 msgid "Canadian Dollar"
 msgstr "Canadian Dollar"
 
-#: src/routes/new.tsx:462
+#: src/routes/new.tsx:473
 msgid "Cape Verdean Escudo"
 msgstr "Cape Verdean Escudo"
 
@@ -396,21 +448,25 @@ msgstr "Cape Verdean Escudo"
 msgid "Cash or other ways"
 msgstr "Cash or other ways"
 
-#: src/routes/new.tsx:492
+#: src/routes/new.tsx:503
 msgid "Cayman Islands Dollar"
 msgstr "Cayman Islands Dollar"
 
-#: src/routes/new.tsx:567
+#: src/routes/new.tsx:578
 msgid "CFA Franc BCEAO"
 msgstr "CFA Franc BCEAO"
 
-#: src/routes/new.tsx:558
+#: src/routes/new.tsx:569
 msgid "CFA Franc BEAC"
 msgstr "CFA Franc BEAC"
 
-#: src/routes/new.tsx:569
+#: src/routes/new.tsx:580
 msgid "CFP Franc"
 msgstr "CFP Franc"
+
+#: src/routes/party_.$partyId.log.tsx:77
+msgid "Changes made from now on will show up here."
+msgstr "Changes made from now on will show up here."
 
 #: src/routes/about.tsx:68
 msgid "Changes sync automatically across all your devices"
@@ -424,15 +480,15 @@ msgstr "Check for updates"
 msgid "Checking for updates..."
 msgstr "Checking for updates..."
 
-#: src/routes/new.tsx:456
+#: src/routes/new.tsx:467
 msgid "Chilean Peso"
 msgstr "Chilean Peso"
 
-#: src/routes/new.tsx:455
+#: src/routes/new.tsx:466
 msgid "Chilean Unit of Account (UF)"
 msgstr "Chilean Unit of Account (UF)"
 
-#: src/routes/new.tsx:405
+#: src/routes/new.tsx:416
 msgid "Chinese Yuan"
 msgstr "Chinese Yuan"
 
@@ -440,7 +496,7 @@ msgstr "Chinese Yuan"
 msgid "Choose a destination party"
 msgstr "Choose a destination party"
 
-#: src/routes/new.tsx:236
+#: src/routes/new.tsx:247
 msgid "Choose the currency for expenses in this party"
 msgstr "Choose the currency for expenses in this party"
 
@@ -473,15 +529,15 @@ msgstr "Close calculator"
 msgid "Close parenthesis"
 msgstr "Close parenthesis"
 
-#: src/routes/new.tsx:572
+#: src/routes/new.tsx:583
 msgid "Code for testing"
 msgstr "Code for testing"
 
-#: src/routes/new.tsx:457
+#: src/routes/new.tsx:468
 msgid "Colombian Peso"
 msgstr "Colombian Peso"
 
-#: src/routes/new.tsx:458
+#: src/routes/new.tsx:469
 msgid "Colombian Real Value Unit"
 msgstr "Colombian Real Value Unit"
 
@@ -489,7 +545,7 @@ msgstr "Colombian Real Value Unit"
 msgid "Color"
 msgstr "Color"
 
-#: src/routes/new.tsx:489
+#: src/routes/new.tsx:500
 msgid "Comorian Franc"
 msgstr "Comorian Franc"
 
@@ -515,7 +571,7 @@ msgstr "Confirm transfer"
 msgid "Confirming..."
 msgstr "Confirming..."
 
-#: src/routes/new.tsx:452
+#: src/routes/new.tsx:463
 msgid "Congolese Franc"
 msgstr "Congolese Franc"
 
@@ -535,7 +591,7 @@ msgstr "Copy party link"
 msgid "Copy the phone number and pay through Bizum using your bank app."
 msgstr "Copy the phone number and pay through Bizum using your bank app."
 
-#: src/routes/new.tsx:459
+#: src/routes/new.tsx:470
 msgid "Costa Rican Colón"
 msgstr "Costa Rican Colón"
 
@@ -556,19 +612,19 @@ msgstr "Creditor"
 msgid "Credits"
 msgstr "Credits"
 
-#: src/routes/new.tsx:418
+#: src/routes/new.tsx:429
 msgid "Croatian Kuna"
 msgstr "Croatian Kuna"
 
-#: src/routes/new.tsx:460
+#: src/routes/new.tsx:471
 msgid "Cuban Convertible Peso"
 msgstr "Cuban Convertible Peso"
 
-#: src/routes/new.tsx:461
+#: src/routes/new.tsx:472
 msgid "Cuban Peso"
 msgstr "Cuban Peso"
 
-#: src/routes/new.tsx:235
+#: src/routes/new.tsx:246
 msgid "Currency"
 msgstr "Currency"
 
@@ -587,11 +643,11 @@ msgstr "Current year"
 msgid "Custom range"
 msgstr "Custom range"
 
-#: src/routes/new.tsx:414
+#: src/routes/new.tsx:425
 msgid "Czech Koruna"
 msgstr "Czech Koruna"
 
-#: src/routes/new.tsx:412
+#: src/routes/new.tsx:423
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
@@ -619,6 +675,7 @@ msgstr "Debt transfer from another party"
 msgid "Debt transfer to another party"
 msgstr "Debt transfer to another party"
 
+#: src/routes/party_.$partyId.log.tsx:157
 #: src/routes/party_.$partyId.transfer-debt.tsx:325
 #: src/routes/party_.$partyId.transfer-debt.tsx:906
 msgid "Debt transferred"
@@ -632,7 +689,8 @@ msgstr "Decimal point"
 msgid "Delete"
 msgstr "Delete"
 
-#: src/routes/new.tsx:218
+#: src/routes/new.tsx:229
+#: src/routes/party_.$partyId.log.tsx:226
 #: src/routes/party_.$partyId.settings.tsx:197
 msgid "Description"
 msgstr "Description"
@@ -653,15 +711,15 @@ msgstr "Did you know?"
 msgid "Divide"
 msgstr "Divide"
 
-#: src/routes/new.tsx:463
+#: src/routes/new.tsx:474
 msgid "Djiboutian Franc"
 msgstr "Djiboutian Franc"
 
-#: src/routes/new.tsx:464
+#: src/routes/new.tsx:475
 msgid "Dominican Peso"
 msgstr "Dominican Peso"
 
-#: src/routes/new.tsx:565
+#: src/routes/new.tsx:576
 msgid "East Caribbean Dollar"
 msgstr "East Caribbean Dollar"
 
@@ -677,7 +735,7 @@ msgstr "Editing {0}"
 msgid "Editing {expenseName}"
 msgstr "Editing {expenseName}"
 
-#: src/routes/new.tsx:466
+#: src/routes/new.tsx:477
 msgid "Egyptian Pound"
 msgstr "Egyptian Pound"
 
@@ -711,7 +769,7 @@ msgstr "Enter the key of the Tricount account you want to migrate from"
 msgid "Enter the link or code of the trizum party you want to join"
 msgstr "Enter the link or code of the trizum party you want to join"
 
-#: src/routes/new.tsx:467
+#: src/routes/new.tsx:478
 msgid "Eritrean Nakfa"
 msgstr "Eritrean Nakfa"
 
@@ -719,27 +777,27 @@ msgstr "Eritrean Nakfa"
 msgid "Español"
 msgstr "Español"
 
-#: src/routes/new.tsx:468
+#: src/routes/new.tsx:479
 msgid "Ethiopian Birr"
 msgstr "Ethiopian Birr"
 
-#: src/routes/new.tsx:398
+#: src/routes/new.tsx:409
 msgid "Euro"
 msgstr "Euro"
 
-#: src/routes/new.tsx:561
+#: src/routes/new.tsx:572
 msgid "European Composite Unit"
 msgstr "European Composite Unit"
 
-#: src/routes/new.tsx:562
+#: src/routes/new.tsx:573
 msgid "European Monetary Unit"
 msgstr "European Monetary Unit"
 
-#: src/routes/new.tsx:564
+#: src/routes/new.tsx:575
 msgid "European Unit of Account 17"
 msgstr "European Unit of Account 17"
 
-#: src/routes/new.tsx:563
+#: src/routes/new.tsx:574
 msgid "European Unit of Account 9"
 msgstr "European Unit of Account 9"
 
@@ -752,6 +810,7 @@ msgid "Exact"
 msgstr "Exact"
 
 #: src/routes/party_.$partyId.add.tsx:86
+#: src/routes/party_.$partyId.log.tsx:151
 msgid "Expense added"
 msgstr "Expense added"
 
@@ -759,15 +818,20 @@ msgstr "Expense added"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
+#: src/routes/party_.$partyId.log.tsx:155
+msgid "Expense deleted"
+msgstr "Expense deleted"
+
 #: src/components/ExpenseEditor.tsx:257
 msgid "Expense Split Mode"
 msgstr "Expense Split Mode"
 
 #: src/routes/party_.$partyId.expense.$expenseId_.edit.tsx:150
+#: src/routes/party_.$partyId.log.tsx:153
 msgid "Expense updated"
 msgstr "Expense updated"
 
-#: src/routes/party.$partyId.tsx:318
+#: src/routes/party.$partyId.tsx:330
 msgid "Expenses"
 msgstr "Expenses"
 
@@ -825,7 +889,7 @@ msgstr "Failed to upload avatar. Please try again."
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
-#: src/routes/new.tsx:470
+#: src/routes/new.tsx:481
 msgid "Falkland Islands Pound"
 msgstr "Falkland Islands Pound"
 
@@ -837,7 +901,7 @@ msgstr "Feature Requests"
 msgid "Features"
 msgstr "Features"
 
-#: src/routes/new.tsx:469
+#: src/routes/new.tsx:480
 msgid "Fijian Dollar"
 msgstr "Fijian Dollar"
 
@@ -857,11 +921,11 @@ msgstr "Found a bug? Let us know on GitHub and we'll fix it."
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: src/routes/new.tsx:474
+#: src/routes/new.tsx:485
 msgid "Gambian Dalasi"
 msgstr "Gambian Dalasi"
 
-#: src/routes/new.tsx:471
+#: src/routes/new.tsx:482
 msgid "Georgian Lari"
 msgstr "Georgian Lari"
 
@@ -869,11 +933,11 @@ msgstr "Georgian Lari"
 msgid "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 msgstr "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 
-#: src/routes/new.tsx:472
+#: src/routes/new.tsx:483
 msgid "Ghanaian Cedi"
 msgstr "Ghanaian Cedi"
 
-#: src/routes/new.tsx:473
+#: src/routes/new.tsx:484
 msgid "Gibraltar Pound"
 msgstr "Gibraltar Pound"
 
@@ -894,7 +958,7 @@ msgstr "Go back and try again from the balances list."
 msgid "Go back to home"
 msgstr "Go back to home"
 
-#: src/routes/new.tsx:560
+#: src/routes/new.tsx:571
 msgid "Gold (troy ounce)"
 msgstr "Gold (troy ounce)"
 
@@ -902,19 +966,19 @@ msgstr "Gold (troy ounce)"
 msgid "Group expense sharing made simple. Track, split and settle shared costs effortlessly."
 msgstr "Group expense sharing made simple. Track, split and settle shared costs effortlessly."
 
-#: src/routes/new.tsx:476
+#: src/routes/new.tsx:487
 msgid "Guatemalan Quetzal"
 msgstr "Guatemalan Quetzal"
 
-#: src/routes/new.tsx:475
+#: src/routes/new.tsx:486
 msgid "Guinean Franc"
 msgstr "Guinean Franc"
 
-#: src/routes/new.tsx:477
+#: src/routes/new.tsx:488
 msgid "Guyanaese Dollar"
 msgstr "Guyanaese Dollar"
 
-#: src/routes/new.tsx:479
+#: src/routes/new.tsx:490
 msgid "Haitian Gourde"
 msgstr "Haitian Gourde"
 
@@ -926,7 +990,7 @@ msgstr "Have an idea to improve trizum? We'd love to hear it."
 msgid "Heads up!"
 msgstr "Heads up!"
 
-#: src/routes/party.$partyId.tsx:713
+#: src/routes/party.$partyId.tsx:725
 msgid "Here is a list of operations you and other party members can do to balance your position."
 msgstr "Here is a list of operations you and other party members can do to balance your position."
 
@@ -938,11 +1002,11 @@ msgstr "Here's a list of ways you can pay, once done, press the button above to 
 msgid "Home"
 msgstr "Home"
 
-#: src/routes/new.tsx:478
+#: src/routes/new.tsx:489
 msgid "Honduran Lempira"
 msgstr "Honduran Lempira"
 
-#: src/routes/new.tsx:423
+#: src/routes/new.tsx:434
 msgid "Hong Kong Dollar"
 msgstr "Hong Kong Dollar"
 
@@ -950,7 +1014,7 @@ msgstr "Hong Kong Dollar"
 msgid "How do you want to call this expense ?"
 msgstr "How do you want to call this expense ?"
 
-#: src/routes/new.tsx:177
+#: src/routes/new.tsx:188
 #: src/routes/party_.$partyId.settings.tsx:156
 msgid "How do you want to call this party?"
 msgstr "How do you want to call this party?"
@@ -959,7 +1023,7 @@ msgstr "How do you want to call this party?"
 msgid "How does offline sync work?"
 msgstr "How does offline sync work?"
 
-#: src/routes/party.$partyId.tsx:709
+#: src/routes/party.$partyId.tsx:721
 msgid "How should I balance?"
 msgstr "How should I balance?"
 
@@ -967,11 +1031,11 @@ msgstr "How should I balance?"
 msgid "How to pay?"
 msgstr "How to pay?"
 
-#: src/routes/new.tsx:415
+#: src/routes/new.tsx:426
 msgid "Hungarian Forint"
 msgstr "Hungarian Forint"
 
-#: src/routes/new.tsx:483
+#: src/routes/new.tsx:494
 msgid "Icelandic Króna"
 msgstr "Icelandic Króna"
 
@@ -983,7 +1047,7 @@ msgstr "ID is required"
 msgid "Image must be smaller than 10MB"
 msgstr "Image must be smaller than 10MB"
 
-#: src/routes/party.$partyId.tsx:602
+#: src/routes/party.$partyId.tsx:614
 msgid "Impact on my balance: <0/>"
 msgstr "Impact on my balance: <0/>"
 
@@ -1011,7 +1075,7 @@ msgstr "Importing Tricount data..."
 msgid "Include all"
 msgstr "Include all"
 
-#: src/routes/new.tsx:406
+#: src/routes/new.tsx:417
 msgid "Indian Rupee"
 msgstr "Indian Rupee"
 
@@ -1019,7 +1083,7 @@ msgstr "Indian Rupee"
 msgid "Individual totals"
 msgstr "Individual totals"
 
-#: src/routes/new.tsx:480
+#: src/routes/new.tsx:491
 msgid "Indonesian Rupiah"
 msgstr "Indonesian Rupiah"
 
@@ -1041,11 +1105,11 @@ msgstr "Invalid trizum party code"
 msgid "Invalid trizum party link"
 msgstr "Invalid trizum party link"
 
-#: src/routes/new.tsx:482
+#: src/routes/new.tsx:493
 msgid "Iranian Rial"
 msgstr "Iranian Rial"
 
-#: src/routes/new.tsx:481
+#: src/routes/new.tsx:492
 msgid "Iraqi Dinar"
 msgstr "Iraqi Dinar"
 
@@ -1053,15 +1117,15 @@ msgstr "Iraqi Dinar"
 msgid "Is my data secure?"
 msgstr "Is my data secure?"
 
-#: src/routes/new.tsx:426
+#: src/routes/new.tsx:437
 msgid "Israeli Shekel"
 msgstr "Israeli Shekel"
 
-#: src/routes/new.tsx:484
+#: src/routes/new.tsx:495
 msgid "Jamaican Dollar"
 msgstr "Jamaican Dollar"
 
-#: src/routes/new.tsx:401
+#: src/routes/new.tsx:412
 msgid "Japanese Yen"
 msgstr "Japanese Yen"
 
@@ -1090,7 +1154,7 @@ msgstr "Join a trizum"
 msgid "Joined {0}!"
 msgstr "Joined {0}!"
 
-#: src/routes/new.tsx:485
+#: src/routes/new.tsx:496
 msgid "Jordanian Dinar"
 msgstr "Jordanian Dinar"
 
@@ -1098,19 +1162,19 @@ msgstr "Jordanian Dinar"
 msgid "Jump back into the groups you use most"
 msgstr "Jump back into the groups you use most"
 
-#: src/routes/new.tsx:493
+#: src/routes/new.tsx:504
 msgid "Kazakhstani Tenge"
 msgstr "Kazakhstani Tenge"
 
-#: src/routes/new.tsx:486
+#: src/routes/new.tsx:497
 msgid "Kenyan Shilling"
 msgstr "Kenyan Shilling"
 
-#: src/routes/new.tsx:491
+#: src/routes/new.tsx:502
 msgid "Kuwaiti Dinar"
 msgstr "Kuwaiti Dinar"
 
-#: src/routes/new.tsx:487
+#: src/routes/new.tsx:498
 msgid "Kyrgystani Som"
 msgstr "Kyrgystani Som"
 
@@ -1118,7 +1182,7 @@ msgstr "Kyrgystani Som"
 msgid "Language"
 msgstr "Language"
 
-#: src/routes/new.tsx:494
+#: src/routes/new.tsx:505
 msgid "Laotian Kip"
 msgstr "Laotian Kip"
 
@@ -1130,23 +1194,23 @@ msgstr "Last used"
 msgid "Last year"
 msgstr "Last year"
 
-#: src/routes/party.$partyId.tsx:302
+#: src/routes/party.$partyId.tsx:314
 msgid "Leave party"
 msgstr "Leave party"
 
-#: src/routes/new.tsx:495
+#: src/routes/new.tsx:506
 msgid "Lebanese Pound"
 msgstr "Lebanese Pound"
 
-#: src/routes/new.tsx:498
+#: src/routes/new.tsx:509
 msgid "Lesotho Loti"
 msgstr "Lesotho Loti"
 
-#: src/routes/new.tsx:497
+#: src/routes/new.tsx:508
 msgid "Liberian Dollar"
 msgstr "Liberian Dollar"
 
-#: src/routes/new.tsx:499
+#: src/routes/new.tsx:510
 msgid "Libyan Dinar"
 msgstr "Libyan Dinar"
 
@@ -1166,31 +1230,36 @@ msgstr "Links"
 msgid "Loading licenses..."
 msgstr "Loading licenses..."
 
+#: src/routes/party_.$partyId.log.tsx:50
+#: src/routes/party.$partyId.tsx:283
+msgid "Log"
+msgstr "Log"
+
 #: src/components/PartyListCard.tsx:89
 msgid "Long press for party actions"
 msgstr "Long press for party actions"
 
-#: src/routes/new.tsx:506
+#: src/routes/new.tsx:517
 msgid "Macanese Pataca"
 msgstr "Macanese Pataca"
 
-#: src/routes/new.tsx:503
+#: src/routes/new.tsx:514
 msgid "Macedonian Denar"
 msgstr "Macedonian Denar"
 
-#: src/routes/new.tsx:502
+#: src/routes/new.tsx:513
 msgid "Malagasy Ariary"
 msgstr "Malagasy Ariary"
 
-#: src/routes/new.tsx:510
+#: src/routes/new.tsx:521
 msgid "Malawian Kwacha"
 msgstr "Malawian Kwacha"
 
-#: src/routes/new.tsx:512
+#: src/routes/new.tsx:523
 msgid "Malaysian Ringgit"
 msgstr "Malaysian Ringgit"
 
-#: src/routes/new.tsx:509
+#: src/routes/new.tsx:520
 msgid "Maldivian Rufiyaa"
 msgstr "Maldivian Rufiyaa"
 
@@ -1204,7 +1273,7 @@ msgstr "Manage the participants list. Existing members can only be archived."
 
 #: src/routes/party_.$partyId.pay.tsx:93
 #: src/routes/party_.$partyId.pay.tsx:118
-#: src/routes/party.$partyId.tsx:919
+#: src/routes/party.$partyId.tsx:931
 msgid "Mark as paid"
 msgstr "Mark as paid"
 
@@ -1212,11 +1281,11 @@ msgstr "Mark as paid"
 msgid "Marking expense as paid..."
 msgstr "Marking expense as paid..."
 
-#: src/routes/new.tsx:507
+#: src/routes/new.tsx:518
 msgid "Mauritanian Ouguiya"
 msgstr "Mauritanian Ouguiya"
 
-#: src/routes/new.tsx:508
+#: src/routes/new.tsx:519
 msgid "Mauritian Rupee"
 msgstr "Mauritian Rupee"
 
@@ -1234,11 +1303,11 @@ msgstr "Me"
 msgid "Menu"
 msgstr "Menu"
 
-#: src/routes/new.tsx:511
+#: src/routes/new.tsx:522
 msgid "Mexican Investment Unit"
 msgstr "Mexican Investment Unit"
 
-#: src/routes/new.tsx:407
+#: src/routes/new.tsx:418
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
@@ -1261,15 +1330,15 @@ msgstr "Migration successful"
 msgid "Missing search params"
 msgstr "Missing search params"
 
-#: src/routes/new.tsx:501
+#: src/routes/new.tsx:512
 msgid "Moldovan Leu"
 msgstr "Moldovan Leu"
 
-#: src/routes/new.tsx:505
+#: src/routes/new.tsx:516
 msgid "Mongolian Tugrik"
 msgstr "Mongolian Tugrik"
 
-#: src/routes/new.tsx:500
+#: src/routes/new.tsx:511
 msgid "Moroccan Dirham"
 msgstr "Moroccan Dirham"
 
@@ -1285,7 +1354,7 @@ msgstr "Move cursor right"
 msgid "Moved to"
 msgstr "Moved to"
 
-#: src/routes/new.tsx:513
+#: src/routes/new.tsx:524
 msgid "Mozambican Metical"
 msgstr "Mozambican Metical"
 
@@ -1297,11 +1366,13 @@ msgstr "Multi-Party Splitting"
 msgid "Multiply"
 msgstr "Multiply"
 
-#: src/routes/new.tsx:504
+#: src/routes/new.tsx:515
 msgid "Myanma Kyat"
 msgstr "Myanma Kyat"
 
-#: src/routes/new.tsx:176
+#: src/routes/new.tsx:187
+#: src/routes/party_.$partyId.log.tsx:222
+#: src/routes/party_.$partyId.log.tsx:233
 #: src/routes/party_.$partyId.settings.tsx:155
 #: src/routes/party.$partyId.tsx:160
 msgid "Name"
@@ -1311,7 +1382,7 @@ msgstr "Name"
 msgid "Name must be less than 50 characters"
 msgstr "Name must be less than 50 characters"
 
-#: src/routes/new.tsx:514
+#: src/routes/new.tsx:525
 msgid "Namibian Dollar"
 msgstr "Namibian Dollar"
 
@@ -1319,11 +1390,11 @@ msgstr "Namibian Dollar"
 msgid "Need help with trizum? We're here to assist you."
 msgstr "Need help with trizum? We're here to assist you."
 
-#: src/routes/new.tsx:517
+#: src/routes/new.tsx:528
 msgid "Nepalese Rupee"
 msgstr "Nepalese Rupee"
 
-#: src/routes/new.tsx:433
+#: src/routes/new.tsx:444
 msgid "Netherlands Antillean Guilder"
 msgstr "Netherlands Antillean Guilder"
 
@@ -1331,20 +1402,20 @@ msgstr "Netherlands Antillean Guilder"
 msgid "New expense"
 msgstr "New expense"
 
-#: src/routes/new.tsx:328
+#: src/routes/new.tsx:339
 #: src/routes/party_.$partyId.settings.tsx:336
 msgid "New participant name"
 msgstr "New participant name"
 
-#: src/routes/new.tsx:545
+#: src/routes/new.tsx:556
 msgid "New Taiwan Dollar"
 msgstr "New Taiwan Dollar"
 
-#: src/routes/new.tsx:137
+#: src/routes/new.tsx:148
 msgid "New trizum"
 msgstr "New trizum"
 
-#: src/routes/new.tsx:421
+#: src/routes/new.tsx:432
 msgid "New Zealand Dollar"
 msgstr "New Zealand Dollar"
 
@@ -1352,11 +1423,11 @@ msgstr "New Zealand Dollar"
 msgid "Next"
 msgstr "Next"
 
-#: src/routes/new.tsx:516
+#: src/routes/new.tsx:527
 msgid "Nicaraguan Córdoba"
 msgstr "Nicaraguan Córdoba"
 
-#: src/routes/new.tsx:515
+#: src/routes/new.tsx:526
 msgid "Nigerian Naira"
 msgstr "Nigerian Naira"
 
@@ -1372,7 +1443,7 @@ msgstr "No archived parties"
 msgid "No camera found on this device"
 msgstr "No camera found on this device"
 
-#: src/routes/new.tsx:574
+#: src/routes/new.tsx:585
 msgid "No currency"
 msgstr "No currency"
 
@@ -1383,6 +1454,10 @@ msgstr "No destination party available"
 #: src/components/EmojiPicker.tsx:319
 msgid "No emoji found"
 msgstr "No emoji found"
+
+#: src/routes/party_.$partyId.log.tsx:74
+msgid "No log entries yet"
+msgstr "No log entries yet"
 
 #: src/components/PartyStatsView.tsx:299
 #: src/components/PartyStatsView.tsx:513
@@ -1405,7 +1480,7 @@ msgstr "No updates available"
 msgid "Nobody else is available in this party"
 msgstr "Nobody else is available in this party"
 
-#: src/routes/party.$partyId.tsx:776
+#: src/routes/party.$partyId.tsx:788
 msgid "Nobody owes you money!"
 msgstr "Nobody owes you money!"
 
@@ -1417,11 +1492,11 @@ msgstr "Nobody yet"
 msgid "Non-transfer expenses in this timeframe"
 msgstr "Non-transfer expenses in this timeframe"
 
-#: src/routes/new.tsx:490
+#: src/routes/new.tsx:501
 msgid "North Korean Won"
 msgstr "North Korean Won"
 
-#: src/routes/new.tsx:411
+#: src/routes/new.tsx:422
 msgid "Norwegian Krone"
 msgstr "Norwegian Krone"
 
@@ -1441,7 +1516,7 @@ msgstr "Offline-First"
 msgid "Older parties stay tucked away, not gone"
 msgstr "Older parties stay tucked away, not gone"
 
-#: src/routes/new.tsx:518
+#: src/routes/new.tsx:529
 msgid "Omani Rial"
 msgstr "Omani Rial"
 
@@ -1485,12 +1560,12 @@ msgstr "Optional description for this expense"
 msgid "or enter code"
 msgstr "or enter code"
 
-#: src/routes/party.$partyId.tsx:787
+#: src/routes/party.$partyId.tsx:799
 msgid "Other operations"
 msgstr "Other operations"
 
 #: src/routes/party_.$partyId.pay.tsx:104
-#: src/routes/party.$partyId.tsx:889
+#: src/routes/party.$partyId.tsx:901
 msgid "owes"
 msgstr "owes"
 
@@ -1515,23 +1590,23 @@ msgstr "Paid debt to {0}"
 msgid "Paid debt to {toName}"
 msgstr "Paid debt to {toName}"
 
-#: src/routes/new.tsx:523
+#: src/routes/new.tsx:534
 msgid "Pakistani Rupee"
 msgstr "Pakistani Rupee"
 
-#: src/routes/new.tsx:568
+#: src/routes/new.tsx:579
 msgid "Palladium (troy ounce)"
 msgstr "Palladium (troy ounce)"
 
-#: src/routes/new.tsx:519
+#: src/routes/new.tsx:530
 msgid "Panamanian Balboa"
 msgstr "Panamanian Balboa"
 
-#: src/routes/new.tsx:521
+#: src/routes/new.tsx:532
 msgid "Papua New Guinean Kina"
 msgstr "Papua New Guinean Kina"
 
-#: src/routes/new.tsx:524
+#: src/routes/new.tsx:535
 msgid "Paraguayan Guarani"
 msgstr "Paraguayan Guarani"
 
@@ -1539,7 +1614,7 @@ msgstr "Paraguayan Guarani"
 msgid "participant"
 msgstr "participant"
 
-#: src/routes/new.tsx:296
+#: src/routes/new.tsx:307
 #: src/routes/party_.$partyId.settings.tsx:282
 #: src/routes/party_.$partyId.settings.tsx:409
 msgid "Participant name"
@@ -1550,7 +1625,7 @@ msgid "participants"
 msgstr "participants"
 
 #: src/components/PartyStatsView.tsx:327
-#: src/routes/new.tsx:256
+#: src/routes/new.tsx:267
 #: src/routes/party_.$partyId.settings.tsx:213
 msgid "Participants"
 msgstr "Participants"
@@ -1563,7 +1638,8 @@ msgstr "Party actions"
 msgid "Party archived"
 msgstr "Party archived"
 
-#: src/routes/new.tsx:82
+#: src/routes/new.tsx:93
+#: src/routes/party_.$partyId.log.tsx:137
 msgid "Party created"
 msgstr "Party created"
 
@@ -1599,6 +1675,10 @@ msgstr "Party Settings"
 msgid "Party settings saved!"
 msgstr "Party settings saved!"
 
+#: src/routes/party_.$partyId.log.tsx:139
+msgid "Party settings updated"
+msgstr "Party settings updated"
+
 #: src/routes/party_.$partyId.share.tsx:37
 msgid "Party shared!"
 msgstr "Party shared!"
@@ -1616,11 +1696,11 @@ msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc12
 msgstr "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 
 #: src/routes/party_.$partyId.pay.tsx:93
-#: src/routes/party.$partyId.tsx:919
+#: src/routes/party.$partyId.tsx:931
 msgid "Pay"
 msgstr "Pay"
 
-#: src/routes/party.$partyId.tsx:758
+#: src/routes/party.$partyId.tsx:770
 msgid "People that owe you money"
 msgstr "People that owe you money"
 
@@ -1628,13 +1708,17 @@ msgstr "People that owe you money"
 msgid "Personal mode"
 msgstr "Personal mode"
 
-#: src/routes/new.tsx:520
+#: src/routes/new.tsx:531
 msgid "Peruvian Sol"
 msgstr "Peruvian Sol"
 
-#: src/routes/new.tsx:522
+#: src/routes/new.tsx:533
 msgid "Philippine Peso"
 msgstr "Philippine Peso"
+
+#: src/routes/party_.$partyId.log.tsx:235
+msgid "Phone"
+msgstr "Phone"
 
 #: src/routes/settings.tsx:162
 msgid "Phone number"
@@ -1668,7 +1752,7 @@ msgstr "Pinned parties stay close. Recent activity keeps the rest in order."
 msgid "Pinned parties stay on top, then the rest follow your latest activity."
 msgstr "Pinned parties stay on top, then the rest follow your latest activity."
 
-#: src/routes/new.tsx:570
+#: src/routes/new.tsx:581
 msgid "Platinum (troy ounce)"
 msgstr "Platinum (troy ounce)"
 
@@ -1700,7 +1784,7 @@ msgstr "Please wait while we fetch the latest data"
 msgid "Point your camera at a trizum QR code"
 msgstr "Point your camera at a trizum QR code"
 
-#: src/routes/new.tsx:413
+#: src/routes/new.tsx:424
 msgid "Polish Zloty"
 msgstr "Polish Zloty"
 
@@ -1712,7 +1796,7 @@ msgstr "Previous"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: src/routes/new.tsx:525
+#: src/routes/new.tsx:536
 msgid "Qatari Rial"
 msgstr "Qatari Rial"
 
@@ -1740,7 +1824,7 @@ msgstr "Recommended match"
 msgid "Reload"
 msgstr "Reload"
 
-#: src/routes/new.tsx:308
+#: src/routes/new.tsx:319
 #: src/routes/party_.$partyId.settings.tsx:295
 msgid "Remove"
 msgstr "Remove"
@@ -1773,41 +1857,41 @@ msgstr "Restore to home"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/routes/new.tsx:416
+#: src/routes/new.tsx:427
 msgid "Romanian Leu"
 msgstr "Romanian Leu"
 
-#: src/routes/new.tsx:419
+#: src/routes/new.tsx:430
 msgid "Russian Ruble"
 msgstr "Russian Ruble"
 
-#: src/routes/new.tsx:527
+#: src/routes/new.tsx:538
 msgid "Rwandan Franc"
 msgstr "Rwandan Franc"
 
-#: src/routes/new.tsx:531
+#: src/routes/new.tsx:542
 msgid "Saint Helena Pound"
 msgstr "Saint Helena Pound"
 
-#: src/routes/new.tsx:537
+#: src/routes/new.tsx:548
 msgid "Salvadoran Colón"
 msgstr "Salvadoran Colón"
 
-#: src/routes/new.tsx:557
+#: src/routes/new.tsx:568
 msgid "Samoan Tala"
 msgstr "Samoan Tala"
 
-#: src/routes/new.tsx:536
+#: src/routes/new.tsx:547
 msgid "São Tomé and Príncipe Dobra"
 msgstr "São Tomé and Príncipe Dobra"
 
-#: src/routes/new.tsx:428
+#: src/routes/new.tsx:439
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
 #: src/components/ExpenseEditor.tsx:288
 #: src/routes/migrate_.tricount.tsx:160
-#: src/routes/new.tsx:148
+#: src/routes/new.tsx:159
 #: src/routes/party_.$partyId.settings.tsx:127
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/settings.tsx:99
@@ -1839,7 +1923,7 @@ msgstr "Select emoji"
 msgid "Send us an email and we'll get back to you as soon as possible."
 msgstr "Send us an email and we'll get back to you as soon as possible."
 
-#: src/routes/new.tsx:526
+#: src/routes/new.tsx:537
 msgid "Serbian Dinar"
 msgstr "Serbian Dinar"
 
@@ -1848,7 +1932,7 @@ msgid "Set up your username, avatar, and preferences"
 msgstr "Set up your username, avatar, and preferences"
 
 #: src/routes/index.tsx:123
-#: src/routes/party.$partyId.tsx:295
+#: src/routes/party.$partyId.tsx:307
 #: src/routes/settings.tsx:88
 msgid "Settings"
 msgstr "Settings"
@@ -1861,13 +1945,13 @@ msgstr "Settings saved"
 msgid "Settled in"
 msgstr "Settled in"
 
-#: src/routes/new.tsx:529
+#: src/routes/new.tsx:540
 msgid "Seychellois Rupee"
 msgstr "Seychellois Rupee"
 
 #: src/routes/party_.$partyId.share.tsx:55
 #: src/routes/party_.$partyId.share.tsx:90
-#: src/routes/party.$partyId.tsx:283
+#: src/routes/party.$partyId.tsx:295
 msgid "Share party"
 msgstr "Share party"
 
@@ -1895,11 +1979,11 @@ msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} 
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
-#: src/routes/new.tsx:532
+#: src/routes/new.tsx:543
 msgid "Sierra Leonean Leone"
 msgstr "Sierra Leonean Leone"
 
-#: src/routes/new.tsx:559
+#: src/routes/new.tsx:570
 msgid "Silver (troy ounce)"
 msgstr "Silver (troy ounce)"
 
@@ -1907,15 +1991,15 @@ msgstr "Silver (troy ounce)"
 msgid "Simple"
 msgstr "Simple"
 
-#: src/routes/new.tsx:422
+#: src/routes/new.tsx:433
 msgid "Singapore Dollar"
 msgstr "Singapore Dollar"
 
-#: src/routes/new.tsx:528
+#: src/routes/new.tsx:539
 msgid "Solomon Islands Dollar"
 msgstr "Solomon Islands Dollar"
 
-#: src/routes/new.tsx:533
+#: src/routes/new.tsx:544
 msgid "Somali Shilling"
 msgstr "Somali Shilling"
 
@@ -1927,19 +2011,19 @@ msgstr "Something went wrong"
 msgid "Sort balances"
 msgstr "Sort balances"
 
-#: src/routes/new.tsx:425
+#: src/routes/new.tsx:436
 msgid "South African Rand"
 msgstr "South African Rand"
 
-#: src/routes/new.tsx:409
+#: src/routes/new.tsx:420
 msgid "South Korean Won"
 msgstr "South Korean Won"
 
-#: src/routes/new.tsx:535
+#: src/routes/new.tsx:546
 msgid "South Sudanese Pound"
 msgstr "South Sudanese Pound"
 
-#: src/routes/new.tsx:566
+#: src/routes/new.tsx:577
 msgid "Special Drawing Rights"
 msgstr "Special Drawing Rights"
 
@@ -1955,7 +2039,7 @@ msgstr "Split bills with friends and family. Track, calculate, and settle expens
 msgid "Split expenses fairly among multiple participants"
 msgstr "Split expenses fairly among multiple participants"
 
-#: src/routes/new.tsx:496
+#: src/routes/new.tsx:507
 msgid "Sri Lankan Rupee"
 msgstr "Sri Lankan Rupee"
 
@@ -1978,7 +2062,7 @@ msgstr "Submit a Request"
 
 #: src/components/ExpenseEditor.tsx:288
 #: src/routes/migrate_.tricount.tsx:160
-#: src/routes/new.tsx:148
+#: src/routes/new.tsx:159
 #: src/routes/party_.$partyId.settings.tsx:127
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/settings.tsx:99
@@ -1989,11 +2073,11 @@ msgstr "Submitting..."
 msgid "Subtract"
 msgstr "Subtract"
 
-#: src/routes/new.tsx:571
+#: src/routes/new.tsx:582
 msgid "Sucre"
 msgstr "Sucre"
 
-#: src/routes/new.tsx:530
+#: src/routes/new.tsx:541
 msgid "Sudanese Pound"
 msgstr "Sudanese Pound"
 
@@ -2002,15 +2086,15 @@ msgstr "Sudanese Pound"
 msgid "Support"
 msgstr "Support"
 
-#: src/routes/new.tsx:534
+#: src/routes/new.tsx:545
 msgid "Surinamese Dollar"
 msgstr "Surinamese Dollar"
 
-#: src/routes/new.tsx:539
+#: src/routes/new.tsx:550
 msgid "Swazi Lilangeni"
 msgstr "Swazi Lilangeni"
 
-#: src/routes/new.tsx:410
+#: src/routes/new.tsx:421
 msgid "Swedish Krona"
 msgstr "Swedish Krona"
 
@@ -2018,7 +2102,7 @@ msgstr "Swedish Krona"
 msgid "Swipe between expenses and balances tabs."
 msgstr "Swipe between expenses and balances tabs."
 
-#: src/routes/new.tsx:402
+#: src/routes/new.tsx:413
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
@@ -2030,7 +2114,8 @@ msgstr "Switch to a set amount"
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
-#: src/routes/new.tsx:199
+#: src/routes/new.tsx:210
+#: src/routes/party_.$partyId.log.tsx:224
 #: src/routes/party_.$partyId.settings.tsx:178
 msgid "Symbol"
 msgstr "Symbol"
@@ -2047,7 +2132,7 @@ msgstr "Symbol must contain only emojis"
 msgid "Syncing party information..."
 msgstr "Syncing party information..."
 
-#: src/routes/new.tsx:538
+#: src/routes/new.tsx:549
 msgid "Syrian Pound"
 msgstr "Syrian Pound"
 
@@ -2055,7 +2140,7 @@ msgstr "Syrian Pound"
 msgid "System (fallbacks to {DEFAULT_LOCALE})"
 msgstr "System (fallbacks to {DEFAULT_LOCALE})"
 
-#: src/routes/new.tsx:540
+#: src/routes/new.tsx:551
 msgid "Tajikistani Somoni"
 msgstr "Tajikistani Somoni"
 
@@ -2066,7 +2151,7 @@ msgstr "Tajikistani Somoni"
 msgid "Take photo"
 msgstr "Take photo"
 
-#: src/routes/new.tsx:546
+#: src/routes/new.tsx:557
 msgid "Tanzanian Shilling"
 msgstr "Tanzanian Shilling"
 
@@ -2074,7 +2159,7 @@ msgstr "Tanzanian Shilling"
 msgid "Tap to change"
 msgstr "Tap to change"
 
-#: src/routes/new.tsx:424
+#: src/routes/new.tsx:435
 msgid "Thai Baht"
 msgstr "Thai Baht"
 
@@ -2157,7 +2242,7 @@ msgstr "To join the <0>{0}</0>, please select who you are so that we can show yo
 msgid "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 
-#: src/routes/new.tsx:543
+#: src/routes/new.tsx:554
 msgid "Tongan Paʻanga"
 msgstr "Tongan Paʻanga"
 
@@ -2183,7 +2268,7 @@ msgstr "Total split:"
 msgid "Transfer debt"
 msgstr "Transfer debt"
 
-#: src/routes/party.$partyId.tsx:946
+#: src/routes/party.$partyId.tsx:958
 msgid "Transfer to another party"
 msgstr "Transfer to another party"
 
@@ -2203,7 +2288,7 @@ msgstr "Tricount key or URL is required"
 msgid "Tricount URL or key"
 msgstr "Tricount URL or key"
 
-#: src/routes/new.tsx:544
+#: src/routes/new.tsx:555
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
@@ -2224,31 +2309,31 @@ msgstr "Try another timeframe to compare a different period of your party."
 msgid "Try scanning another code"
 msgstr "Try scanning another code"
 
-#: src/routes/new.tsx:542
+#: src/routes/new.tsx:553
 msgid "Tunisian Dinar"
 msgstr "Tunisian Dinar"
 
-#: src/routes/new.tsx:420
+#: src/routes/new.tsx:431
 msgid "Turkish Lira"
 msgstr "Turkish Lira"
 
-#: src/routes/new.tsx:541
+#: src/routes/new.tsx:552
 msgid "Turkmenistani Manat"
 msgstr "Turkmenistani Manat"
 
-#: src/routes/new.tsx:427
+#: src/routes/new.tsx:438
 msgid "UAE Dirham"
 msgstr "UAE Dirham"
 
-#: src/routes/new.tsx:548
+#: src/routes/new.tsx:559
 msgid "Ugandan Shilling"
 msgstr "Ugandan Shilling"
 
-#: src/routes/new.tsx:547
+#: src/routes/new.tsx:558
 msgid "Ukrainian Hryvnia"
 msgstr "Ukrainian Hryvnia"
 
-#: src/routes/new.tsx:552
+#: src/routes/new.tsx:563
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
@@ -2313,19 +2398,19 @@ msgstr "Uploading..."
 msgid "URL or Party ID"
 msgstr "URL or Party ID"
 
-#: src/routes/new.tsx:550
+#: src/routes/new.tsx:561
 msgid "Uruguay Peso en Unidades Indexadas"
 msgstr "Uruguay Peso en Unidades Indexadas"
 
-#: src/routes/new.tsx:551
+#: src/routes/new.tsx:562
 msgid "Uruguayan Peso"
 msgstr "Uruguayan Peso"
 
-#: src/routes/new.tsx:399
+#: src/routes/new.tsx:410
 msgid "US Dollar"
 msgstr "US Dollar"
 
-#: src/routes/new.tsx:549
+#: src/routes/new.tsx:560
 msgid "US Dollar (Next day)"
 msgstr "US Dollar (Next day)"
 
@@ -2341,15 +2426,15 @@ msgstr "Use your camera to scan a trizum invite"
 msgid "Username"
 msgstr "Username"
 
-#: src/routes/new.tsx:553
+#: src/routes/new.tsx:564
 msgid "Uzbekistan Som"
 msgstr "Uzbekistan Som"
 
-#: src/routes/new.tsx:556
+#: src/routes/new.tsx:567
 msgid "Vanuatu Vatu"
 msgstr "Vanuatu Vatu"
 
-#: src/routes/new.tsx:554
+#: src/routes/new.tsx:565
 msgid "Venezuelan Bolívar Soberano"
 msgstr "Venezuelan Bolívar Soberano"
 
@@ -2357,7 +2442,7 @@ msgstr "Venezuelan Bolívar Soberano"
 msgid "Version"
 msgstr "Version"
 
-#: src/routes/new.tsx:555
+#: src/routes/new.tsx:566
 msgid "Vietnamese Dong"
 msgstr "Vietnamese Dong"
 
@@ -2402,7 +2487,7 @@ msgstr "Welcome to the party, {participantName}!"
 msgid "Welcome to trizum"
 msgstr "Welcome to trizum"
 
-#: src/routes/new.tsx:219
+#: src/routes/new.tsx:230
 #: src/routes/party_.$partyId.settings.tsx:198
 msgid "What is this party about?"
 msgstr "What is this party about?"
@@ -2415,7 +2500,7 @@ msgstr "What's your preferred way to be addressed?"
 msgid "Who are you?"
 msgstr "Who are you?"
 
-#: src/routes/new.tsx:260
+#: src/routes/new.tsx:271
 msgid "Who is invited to this party? You can add more participants later."
 msgstr "Who is invited to this party? You can add more participants later."
 
@@ -2423,11 +2508,11 @@ msgstr "Who is invited to this party? You can add more participants later."
 msgid "Why is this taking so long?"
 msgstr "Why is this taking so long?"
 
-#: src/routes/new.tsx:453
+#: src/routes/new.tsx:464
 msgid "WIR Euro"
 msgstr "WIR Euro"
 
-#: src/routes/new.tsx:454
+#: src/routes/new.tsx:465
 msgid "WIR Franc"
 msgstr "WIR Franc"
 
@@ -2435,7 +2520,7 @@ msgstr "WIR Franc"
 msgid "Works seamlessly offline with automatic sync when online"
 msgstr "Works seamlessly offline with automatic sync when online"
 
-#: src/routes/new.tsx:575
+#: src/routes/new.tsx:586
 msgid "Yemeni Rial"
 msgstr "Yemeni Rial"
 
@@ -2459,11 +2544,11 @@ msgstr "You left the party!"
 msgid "You need another active party with the same currency to transfer this debt."
 msgstr "You need another active party with the same currency to transfer this debt."
 
-#: src/routes/party.$partyId.tsx:728
+#: src/routes/party.$partyId.tsx:740
 msgid "You owe money to people"
 msgstr "You owe money to people"
 
-#: src/routes/party.$partyId.tsx:747
+#: src/routes/party.$partyId.tsx:759
 msgid "You're debt free!"
 msgstr "You're debt free!"
 
@@ -2491,10 +2576,10 @@ msgstr "Your parties"
 msgid "Your total"
 msgstr "Your total"
 
-#: src/routes/new.tsx:576
+#: src/routes/new.tsx:587
 msgid "Zambian Kwacha"
 msgstr "Zambian Kwacha"
 
-#: src/routes/new.tsx:577
+#: src/routes/new.tsx:588
 msgid "Zimbabwean Dollar"
 msgstr "Zimbabwean Dollar"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -15,12 +15,12 @@ msgstr ""
 
 #: src/routes/party_.$partyId.pay.tsx:101
 #: src/routes/party_.$partyId.pay.tsx:107
-#: src/routes/party.$partyId.tsx:886
-#: src/routes/party.$partyId.tsx:892
+#: src/routes/party.$partyId.tsx:898
+#: src/routes/party.$partyId.tsx:904
 msgid "(me)"
 msgstr "(yo)"
 
-#: src/routes/party.$partyId.tsx:399
+#: src/routes/party.$partyId.tsx:411
 msgid "[DEV] Create expenses"
 msgstr "[DEV] Crear gastos"
 
@@ -30,6 +30,30 @@ msgstr "[DEV] Crear gastos"
 msgid "{0, plural, one {and # other} other {and # others}}"
 msgstr "{0, plural, one {y # más} other {y # más}}"
 
+#: src/routes/party.$partyId.tsx:450
+msgid "{0} started tracking shared expenses."
+msgstr ""
+
+#: src/routes/party.$partyId.tsx:419
+msgid "{0} was added"
+msgstr ""
+
+#: src/routes/party.$partyId.tsx:423
+msgid "{0} was archived"
+msgstr ""
+
+#: src/routes/party.$partyId.tsx:427
+msgid "{0} was removed"
+msgstr ""
+
+#: src/routes/party.$partyId.tsx:425
+msgid "{0} was restored"
+msgstr ""
+
+#: src/routes/party.$partyId.tsx:421
+msgid "{0} was updated"
+msgstr ""
+
 #: src/routes/migrate_.tricount.tsx:377
 msgid "{message}"
 msgstr "{message}"
@@ -37,6 +61,30 @@ msgstr "{message}"
 #: src/routes/migrate_.tricount.tsx:321
 msgid "{name}"
 msgstr "{name}"
+
+#: src/routes/party_.$partyId.log.tsx:141
+msgid "{participantName} was added"
+msgstr ""
+
+#: src/routes/party_.$partyId.log.tsx:145
+msgid "{participantName} was archived"
+msgstr ""
+
+#: src/routes/party_.$partyId.log.tsx:149
+msgid "{participantName} was removed"
+msgstr ""
+
+#: src/routes/party_.$partyId.log.tsx:147
+msgid "{participantName} was restored"
+msgstr ""
+
+#: src/routes/party_.$partyId.log.tsx:143
+msgid "{participantName} was updated"
+msgstr ""
+
+#: src/routes/party_.$partyId.log.tsx:174
+msgid "{partyName} started tracking shared expenses."
+msgstr ""
 
 #: src/routes/about.tsx:158
 msgid "© {0} trizum"
@@ -79,7 +127,7 @@ msgstr "En el período seleccionado"
 msgid "Active"
 msgstr "Activos"
 
-#: src/routes/new.tsx:573
+#: src/routes/new.tsx:584
 msgid "ADB Unit of Account"
 msgstr "Unidad de Cuenta del BAsD"
 
@@ -87,8 +135,8 @@ msgstr "Unidad de Cuenta del BAsD"
 msgid "Add"
 msgstr "Sumar"
 
-#: src/routes/party.$partyId.tsx:411
-#: src/routes/party.$partyId.tsx:419
+#: src/routes/party.$partyId.tsx:423
+#: src/routes/party.$partyId.tsx:431
 msgid "Add an expense"
 msgstr "Añadir un gasto"
 
@@ -97,11 +145,11 @@ msgid "Add expenses to this party to unlock totals, rankings, and individual spe
 msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto individual."
 
 #: src/routes/index.tsx:204
-#: src/routes/party.$partyId.tsx:382
+#: src/routes/party.$partyId.tsx:394
 msgid "Add or create"
 msgstr "Añadir o crear"
 
-#: src/routes/new.tsx:374
+#: src/routes/new.tsx:385
 #: src/routes/party_.$partyId.settings.tsx:382
 msgid "Add participant"
 msgstr "Añadir participante"
@@ -114,15 +162,15 @@ msgstr "Añade tu nombre para que otros sepan quién eres y cómo pagarte"
 msgid "Adding expense..."
 msgstr "Añadiendo gasto..."
 
-#: src/routes/new.tsx:430
+#: src/routes/new.tsx:441
 msgid "Afghan Afghani"
 msgstr "Afgani Afgano"
 
-#: src/routes/new.tsx:431
+#: src/routes/new.tsx:442
 msgid "Albanian Lek"
 msgstr "Lek Albanés"
 
-#: src/routes/new.tsx:465
+#: src/routes/new.tsx:476
 msgid "Algerian Dinar"
 msgstr "Dinar Argelino"
 
@@ -150,7 +198,7 @@ msgstr "Cantidad para {participantName}"
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
-#: src/routes/new.tsx:434
+#: src/routes/new.tsx:445
 msgid "Angolan Kwanza"
 msgstr "Kwanza Angoleño"
 
@@ -190,19 +238,19 @@ msgstr "Grupos archivados"
 msgid "Archived parties live here until you restore them to the home screen."
 msgstr "Los grupos archivados se quedan aquí hasta que los restaures al inicio."
 
-#: src/routes/new.tsx:435
+#: src/routes/new.tsx:446
 msgid "Argentine Peso"
 msgstr "Peso Argentino"
 
-#: src/routes/new.tsx:432
+#: src/routes/new.tsx:443
 msgid "Armenian Dram"
 msgstr "Dram Armenio"
 
-#: src/routes/new.tsx:436
+#: src/routes/new.tsx:447
 msgid "Aruban Florin"
 msgstr "Florín Arubeño"
 
-#: src/routes/new.tsx:269
+#: src/routes/new.tsx:280
 #: src/routes/party_.$partyId.settings.tsx:234
 msgid "At least one participant is required"
 msgstr "Se requiere al menos un participante"
@@ -211,7 +259,7 @@ msgstr "Se requiere al menos un participante"
 msgid "Attachments"
 msgstr "Adjuntos"
 
-#: src/routes/new.tsx:404
+#: src/routes/new.tsx:415
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
@@ -228,6 +276,10 @@ msgstr "Abrir automáticamente la calculadora al enfocar campos de importe"
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Abrir automáticamente el último grupo visitado cuando abras la app"
 
+#: src/routes/party_.$partyId.log.tsx:237
+msgid "Avatar"
+msgstr ""
+
 #: src/components/AvatarPicker.tsx:97
 msgid "Avatar removed"
 msgstr "Avatar eliminado"
@@ -236,7 +288,7 @@ msgstr "Avatar eliminado"
 msgid "Avatar updated successfully"
 msgstr "Avatar actualizado correctamente"
 
-#: src/routes/new.tsx:437
+#: src/routes/new.tsx:448
 msgid "Azerbaijani Manat"
 msgstr "Manat Azerbaiyano"
 
@@ -248,11 +300,11 @@ msgstr "Volver al inicio"
 msgid "Backspace"
 msgstr "Retroceso"
 
-#: src/routes/new.tsx:447
+#: src/routes/new.tsx:458
 msgid "Bahamian Dollar"
 msgstr "Dólar Bahameño"
 
-#: src/routes/new.tsx:441
+#: src/routes/new.tsx:452
 msgid "Bahraini Dinar"
 msgstr "Dinar Bareiní"
 
@@ -264,31 +316,31 @@ msgstr "Balance, Mayor Primero"
 msgid "Balance, Lowest First"
 msgstr "Balance, Menor Primero"
 
-#: src/routes/party.$partyId.tsx:324
+#: src/routes/party.$partyId.tsx:336
 msgid "Balances"
 msgstr "Balance"
 
-#: src/routes/new.tsx:440
+#: src/routes/new.tsx:451
 msgid "Bangladeshi Taka"
 msgstr "Taka Bangladesí"
 
-#: src/routes/new.tsx:439
+#: src/routes/new.tsx:450
 msgid "Barbadian Dollar"
 msgstr "Dólar de Barbados"
 
-#: src/routes/new.tsx:450
+#: src/routes/new.tsx:461
 msgid "Belarusian Ruble"
 msgstr "Rublo Bielorruso"
 
-#: src/routes/new.tsx:451
+#: src/routes/new.tsx:462
 msgid "Belize Dollar"
 msgstr "Dólar Beliceño"
 
-#: src/routes/new.tsx:443
+#: src/routes/new.tsx:454
 msgid "Bermudan Dollar"
 msgstr "Dólar Bermudeño"
 
-#: src/routes/new.tsx:448
+#: src/routes/new.tsx:459
 msgid "Bhutanese Ngultrum"
 msgstr "Ngultrum Butanés"
 
@@ -296,31 +348,31 @@ msgstr "Ngultrum Butanés"
 msgid "Biggest spenders"
 msgstr "Quiénes más han pagado"
 
-#: src/routes/new.tsx:445
+#: src/routes/new.tsx:456
 msgid "Bolivian Boliviano"
 msgstr "Boliviano"
 
-#: src/routes/new.tsx:446
+#: src/routes/new.tsx:457
 msgid "Bolivian Mvdol"
 msgstr "Mvdol Boliviano"
 
-#: src/routes/new.tsx:438
+#: src/routes/new.tsx:449
 msgid "Bosnia-Herzegovina Convertible Mark"
 msgstr "Marco Convertible de Bosnia-Herzegovina"
 
-#: src/routes/new.tsx:449
+#: src/routes/new.tsx:460
 msgid "Botswanan Pula"
 msgstr "Pula Botsuano"
 
-#: src/routes/new.tsx:408
+#: src/routes/new.tsx:419
 msgid "Brazilian Real"
 msgstr "Real Brasileño"
 
-#: src/routes/new.tsx:400
+#: src/routes/new.tsx:411
 msgid "British Pound"
 msgstr "Libra Esterlina"
 
-#: src/routes/new.tsx:444
+#: src/routes/new.tsx:455
 msgid "Brunei Dollar"
 msgstr "Dólar de Brunéi"
 
@@ -328,11 +380,11 @@ msgstr "Dólar de Brunéi"
 msgid "Bug Reports"
 msgstr "Reportar errores"
 
-#: src/routes/new.tsx:417
+#: src/routes/new.tsx:428
 msgid "Bulgarian Lev"
 msgstr "Lev Búlgaro"
 
-#: src/routes/new.tsx:442
+#: src/routes/new.tsx:453
 msgid "Burundian Franc"
 msgstr "Franco Burundés"
 
@@ -348,7 +400,7 @@ msgstr "Calculadora"
 msgid "Calculator expression"
 msgstr "Expresión de calculadora"
 
-#: src/routes/new.tsx:488
+#: src/routes/new.tsx:499
 msgid "Cambodian Riel"
 msgstr "Riel Camboyano"
 
@@ -364,11 +416,11 @@ msgstr "Vista previa de la cámara"
 msgid "Can I use trizum without an account?"
 msgstr "¿Puedo usar trizum sin una cuenta?"
 
-#: src/routes/new.tsx:403
+#: src/routes/new.tsx:414
 msgid "Canadian Dollar"
 msgstr "Dólar Canadiense"
 
-#: src/routes/new.tsx:462
+#: src/routes/new.tsx:473
 msgid "Cape Verdean Escudo"
 msgstr "Escudo Caboverdiano"
 
@@ -376,21 +428,25 @@ msgstr "Escudo Caboverdiano"
 msgid "Cash or other ways"
 msgstr "Efectivo u otras formas"
 
-#: src/routes/new.tsx:492
+#: src/routes/new.tsx:503
 msgid "Cayman Islands Dollar"
 msgstr "Dólar de las Islas Caimán"
 
-#: src/routes/new.tsx:567
+#: src/routes/new.tsx:578
 msgid "CFA Franc BCEAO"
 msgstr "Franco CFA BCEAO"
 
-#: src/routes/new.tsx:558
+#: src/routes/new.tsx:569
 msgid "CFA Franc BEAC"
 msgstr "Franco CFA BEAC"
 
-#: src/routes/new.tsx:569
+#: src/routes/new.tsx:580
 msgid "CFP Franc"
 msgstr "Franco CFP"
+
+#: src/routes/party_.$partyId.log.tsx:77
+msgid "Changes made from now on will show up here."
+msgstr ""
 
 #: src/routes/about.tsx:68
 msgid "Changes sync automatically across all your devices"
@@ -400,15 +456,15 @@ msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
-#: src/routes/new.tsx:456
+#: src/routes/new.tsx:467
 msgid "Chilean Peso"
 msgstr "Peso Chileno"
 
-#: src/routes/new.tsx:455
+#: src/routes/new.tsx:466
 msgid "Chilean Unit of Account (UF)"
 msgstr "Unidad de Fomento Chilena (UF)"
 
-#: src/routes/new.tsx:405
+#: src/routes/new.tsx:416
 msgid "Chinese Yuan"
 msgstr "Yuan Chino"
 
@@ -416,7 +472,7 @@ msgstr "Yuan Chino"
 msgid "Choose a destination party"
 msgstr "Elige un grupo de destino"
 
-#: src/routes/new.tsx:236
+#: src/routes/new.tsx:247
 msgid "Choose the currency for expenses in this party"
 msgstr "Elige la moneda para los gastos de este grupo"
 
@@ -449,15 +505,15 @@ msgstr "Cerrar calculadora"
 msgid "Close parenthesis"
 msgstr "Cerrar paréntesis"
 
-#: src/routes/new.tsx:572
+#: src/routes/new.tsx:583
 msgid "Code for testing"
 msgstr "Código para pruebas"
 
-#: src/routes/new.tsx:457
+#: src/routes/new.tsx:468
 msgid "Colombian Peso"
 msgstr "Peso Colombiano"
 
-#: src/routes/new.tsx:458
+#: src/routes/new.tsx:469
 msgid "Colombian Real Value Unit"
 msgstr "Unidad de Valor Real Colombiana"
 
@@ -465,7 +521,7 @@ msgstr "Unidad de Valor Real Colombiana"
 msgid "Color"
 msgstr "Color"
 
-#: src/routes/new.tsx:489
+#: src/routes/new.tsx:500
 msgid "Comorian Franc"
 msgstr "Franco Comorense"
 
@@ -491,7 +547,7 @@ msgstr "Confirmar transferencia"
 msgid "Confirming..."
 msgstr "Confirmando..."
 
-#: src/routes/new.tsx:452
+#: src/routes/new.tsx:463
 msgid "Congolese Franc"
 msgstr "Franco Congoleño"
 
@@ -511,7 +567,7 @@ msgstr "Copiar enlace del grupo"
 msgid "Copy the phone number and pay through Bizum using your bank app."
 msgstr "Copia el número de teléfono y paga mediante Bizum usando la aplicación de tu banco."
 
-#: src/routes/new.tsx:459
+#: src/routes/new.tsx:470
 msgid "Costa Rican Colón"
 msgstr "Colón Costarricense"
 
@@ -528,19 +584,19 @@ msgstr "Acreedor"
 msgid "Credits"
 msgstr "Créditos"
 
-#: src/routes/new.tsx:418
+#: src/routes/new.tsx:429
 msgid "Croatian Kuna"
 msgstr "Kuna Croata"
 
-#: src/routes/new.tsx:460
+#: src/routes/new.tsx:471
 msgid "Cuban Convertible Peso"
 msgstr "Peso Cubano Convertible"
 
-#: src/routes/new.tsx:461
+#: src/routes/new.tsx:472
 msgid "Cuban Peso"
 msgstr "Peso Cubano"
 
-#: src/routes/new.tsx:235
+#: src/routes/new.tsx:246
 msgid "Currency"
 msgstr "Moneda"
 
@@ -559,11 +615,11 @@ msgstr "Año actual"
 msgid "Custom range"
 msgstr "Rango personalizado"
 
-#: src/routes/new.tsx:414
+#: src/routes/new.tsx:425
 msgid "Czech Koruna"
 msgstr "Corona Checa"
 
-#: src/routes/new.tsx:412
+#: src/routes/new.tsx:423
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
@@ -591,6 +647,7 @@ msgstr "Transferencia de deuda desde otro grupo"
 msgid "Debt transfer to another party"
 msgstr "Transferencia de deuda a otro grupo"
 
+#: src/routes/party_.$partyId.log.tsx:157
 #: src/routes/party_.$partyId.transfer-debt.tsx:325
 #: src/routes/party_.$partyId.transfer-debt.tsx:906
 msgid "Debt transferred"
@@ -604,7 +661,8 @@ msgstr "Punto decimal"
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/routes/new.tsx:218
+#: src/routes/new.tsx:229
+#: src/routes/party_.$partyId.log.tsx:226
 #: src/routes/party_.$partyId.settings.tsx:197
 msgid "Description"
 msgstr "Descripción"
@@ -625,15 +683,15 @@ msgstr "¿Sabías que?"
 msgid "Divide"
 msgstr "Dividir"
 
-#: src/routes/new.tsx:463
+#: src/routes/new.tsx:474
 msgid "Djiboutian Franc"
 msgstr "Franco Yibutiano"
 
-#: src/routes/new.tsx:464
+#: src/routes/new.tsx:475
 msgid "Dominican Peso"
 msgstr "Peso Dominicano"
 
-#: src/routes/new.tsx:565
+#: src/routes/new.tsx:576
 msgid "East Caribbean Dollar"
 msgstr "Dólar del Caribe Oriental"
 
@@ -649,7 +707,7 @@ msgstr "Editando {0}"
 msgid "Editing {expenseName}"
 msgstr "Editando {expenseName}"
 
-#: src/routes/new.tsx:466
+#: src/routes/new.tsx:477
 msgid "Egyptian Pound"
 msgstr "Libra Egipcia"
 
@@ -679,7 +737,7 @@ msgstr "Introduce un enlace o código de grupo para unirte"
 msgid "Enter the link or code of the trizum party you want to join"
 msgstr "Introduce el enlace o código del grupo de trizum al que quieres unirte"
 
-#: src/routes/new.tsx:467
+#: src/routes/new.tsx:478
 msgid "Eritrean Nakfa"
 msgstr "Nakfa Eritreo"
 
@@ -687,27 +745,27 @@ msgstr "Nakfa Eritreo"
 msgid "Español"
 msgstr "Español"
 
-#: src/routes/new.tsx:468
+#: src/routes/new.tsx:479
 msgid "Ethiopian Birr"
 msgstr "Birr Etíope"
 
-#: src/routes/new.tsx:398
+#: src/routes/new.tsx:409
 msgid "Euro"
 msgstr "Euro"
 
-#: src/routes/new.tsx:561
+#: src/routes/new.tsx:572
 msgid "European Composite Unit"
 msgstr "Unidad Compuesta Europea"
 
-#: src/routes/new.tsx:562
+#: src/routes/new.tsx:573
 msgid "European Monetary Unit"
 msgstr "Unidad Monetaria Europea"
 
-#: src/routes/new.tsx:564
+#: src/routes/new.tsx:575
 msgid "European Unit of Account 17"
 msgstr "Unidad de Cuenta Europea 17"
 
-#: src/routes/new.tsx:563
+#: src/routes/new.tsx:574
 msgid "European Unit of Account 9"
 msgstr "Unidad de Cuenta Europea 9"
 
@@ -716,6 +774,7 @@ msgid "Everything is archived for now. You can reopen any party from the archive
 msgstr "Por ahora todo está archivado. Puedes reabrir cualquier grupo desde la pantalla de archivados cuando lo necesites."
 
 #: src/routes/party_.$partyId.add.tsx:86
+#: src/routes/party_.$partyId.log.tsx:151
 msgid "Expense added"
 msgstr "Gasto añadido"
 
@@ -723,11 +782,16 @@ msgstr "Gasto añadido"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
+#: src/routes/party_.$partyId.log.tsx:155
+msgid "Expense deleted"
+msgstr ""
+
 #: src/routes/party_.$partyId.expense.$expenseId_.edit.tsx:150
+#: src/routes/party_.$partyId.log.tsx:153
 msgid "Expense updated"
 msgstr "Gasto actualizado"
 
-#: src/routes/party.$partyId.tsx:318
+#: src/routes/party.$partyId.tsx:330
 msgid "Expenses"
 msgstr "Gastos"
 
@@ -781,7 +845,7 @@ msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
-#: src/routes/new.tsx:470
+#: src/routes/new.tsx:481
 msgid "Falkland Islands Pound"
 msgstr "Libra Malvinense"
 
@@ -793,7 +857,7 @@ msgstr "Sugerencias"
 msgid "Features"
 msgstr "Características"
 
-#: src/routes/new.tsx:469
+#: src/routes/new.tsx:480
 msgid "Fijian Dollar"
 msgstr "Dólar Fiyiano"
 
@@ -813,11 +877,11 @@ msgstr "¿Encontraste un error? Avísanos en GitHub y lo solucionaremos."
 msgid "Frequently Asked Questions"
 msgstr "Preguntas frecuentes"
 
-#: src/routes/new.tsx:474
+#: src/routes/new.tsx:485
 msgid "Gambian Dalasi"
 msgstr "Dalasi Gambiano"
 
-#: src/routes/new.tsx:471
+#: src/routes/new.tsx:482
 msgid "Georgian Lari"
 msgstr "Lari Georgiano"
 
@@ -825,11 +889,11 @@ msgstr "Lari Georgiano"
 msgid "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 msgstr "Ponte en contacto con la persona para hacer el pago en efectivo o de otra forma diferente a las descritas anteriormente."
 
-#: src/routes/new.tsx:472
+#: src/routes/new.tsx:483
 msgid "Ghanaian Cedi"
 msgstr "Cedi Ghanés"
 
-#: src/routes/new.tsx:473
+#: src/routes/new.tsx:484
 msgid "Gibraltar Pound"
 msgstr "Libra de Gibraltar"
 
@@ -850,23 +914,23 @@ msgstr "Vuelve atrás e inténtalo de nuevo desde la lista de saldos."
 msgid "Go back to home"
 msgstr "Volver al inicio"
 
-#: src/routes/new.tsx:560
+#: src/routes/new.tsx:571
 msgid "Gold (troy ounce)"
 msgstr "Oro (onza troy)"
 
-#: src/routes/new.tsx:476
+#: src/routes/new.tsx:487
 msgid "Guatemalan Quetzal"
 msgstr "Quetzal Guatemalteco"
 
-#: src/routes/new.tsx:475
+#: src/routes/new.tsx:486
 msgid "Guinean Franc"
 msgstr "Franco Guineano"
 
-#: src/routes/new.tsx:477
+#: src/routes/new.tsx:488
 msgid "Guyanaese Dollar"
 msgstr "Dólar Guyanés"
 
-#: src/routes/new.tsx:479
+#: src/routes/new.tsx:490
 msgid "Haitian Gourde"
 msgstr "Gourde Haitiano"
 
@@ -878,7 +942,7 @@ msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 msgid "Heads up!"
 msgstr "¡Atención!"
 
-#: src/routes/party.$partyId.tsx:713
+#: src/routes/party.$partyId.tsx:725
 msgid "Here is a list of operations you and other party members can do to balance your position."
 msgstr "Aquí tienes una lista de operaciones que tú y otros miembros del grupo podéis hacer para equilibrar vuestra posición."
 
@@ -890,15 +954,15 @@ msgstr "Aquí tienes una lista de formas en las que puedes pagar, una vez hecho,
 msgid "Home"
 msgstr "Inicio"
 
-#: src/routes/new.tsx:478
+#: src/routes/new.tsx:489
 msgid "Honduran Lempira"
 msgstr "Lempira Hondureño"
 
-#: src/routes/new.tsx:423
+#: src/routes/new.tsx:434
 msgid "Hong Kong Dollar"
 msgstr "Dólar de Hong Kong"
 
-#: src/routes/new.tsx:177
+#: src/routes/new.tsx:188
 #: src/routes/party_.$partyId.settings.tsx:156
 msgid "How do you want to call this party?"
 msgstr "¿Cómo quieres llamar a este grupo?"
@@ -907,7 +971,7 @@ msgstr "¿Cómo quieres llamar a este grupo?"
 msgid "How does offline sync work?"
 msgstr "¿Cómo funciona la sincronización sin conexión?"
 
-#: src/routes/party.$partyId.tsx:709
+#: src/routes/party.$partyId.tsx:721
 msgid "How should I balance?"
 msgstr "¿Cómo debería equilibrar?"
 
@@ -915,11 +979,11 @@ msgstr "¿Cómo debería equilibrar?"
 msgid "How to pay?"
 msgstr "¿Cómo pagar?"
 
-#: src/routes/new.tsx:415
+#: src/routes/new.tsx:426
 msgid "Hungarian Forint"
 msgstr "Forinto Húngaro"
 
-#: src/routes/new.tsx:483
+#: src/routes/new.tsx:494
 msgid "Icelandic Króna"
 msgstr "Corona Islandesa"
 
@@ -935,7 +999,7 @@ msgstr "La imagen debe ser menor de 10MB"
 msgid "Impact on my balance: <0/>"
 msgstr "Impacto en mi balance: <0/>"
 
-#: src/routes/party.$partyId.tsx:602
+#: src/routes/party.$partyId.tsx:614
 msgid "Impact on my balance: <0/>"
 msgstr "Impacto en mi balance: <0/>"
 
@@ -963,7 +1027,7 @@ msgstr "Importando datos de Tricount..."
 msgid "Include all"
 msgstr "Incluir todos"
 
-#: src/routes/new.tsx:406
+#: src/routes/new.tsx:417
 msgid "Indian Rupee"
 msgstr "Rupia India"
 
@@ -971,7 +1035,7 @@ msgstr "Rupia India"
 msgid "Individual totals"
 msgstr "Totales individuales"
 
-#: src/routes/new.tsx:480
+#: src/routes/new.tsx:491
 msgid "Indonesian Rupiah"
 msgstr "Rupia Indonesia"
 
@@ -993,11 +1057,11 @@ msgstr "Código de grupo de trizum no válido"
 msgid "Invalid trizum party link"
 msgstr "Enlace de grupo de trizum no válido"
 
-#: src/routes/new.tsx:482
+#: src/routes/new.tsx:493
 msgid "Iranian Rial"
 msgstr "Rial Iraní"
 
-#: src/routes/new.tsx:481
+#: src/routes/new.tsx:492
 msgid "Iraqi Dinar"
 msgstr "Dinar Iraquí"
 
@@ -1005,15 +1069,15 @@ msgstr "Dinar Iraquí"
 msgid "Is my data secure?"
 msgstr "¿Mis datos están seguros?"
 
-#: src/routes/new.tsx:426
+#: src/routes/new.tsx:437
 msgid "Israeli Shekel"
 msgstr "Shekel Israelí"
 
-#: src/routes/new.tsx:484
+#: src/routes/new.tsx:495
 msgid "Jamaican Dollar"
 msgstr "Dólar Jamaicano"
 
-#: src/routes/new.tsx:401
+#: src/routes/new.tsx:412
 msgid "Japanese Yen"
 msgstr "Yen Japonés"
 
@@ -1038,7 +1102,7 @@ msgstr "Unirse a un Grupo"
 msgid "Join a trizum"
 msgstr "Unirse a un trizum"
 
-#: src/routes/new.tsx:485
+#: src/routes/new.tsx:496
 msgid "Jordanian Dinar"
 msgstr "Dinar Jordano"
 
@@ -1046,19 +1110,19 @@ msgstr "Dinar Jordano"
 msgid "Jump back into the groups you use most"
 msgstr "Vuelve a los grupos que más usas"
 
-#: src/routes/new.tsx:493
+#: src/routes/new.tsx:504
 msgid "Kazakhstani Tenge"
 msgstr "Tenge Kazajo"
 
-#: src/routes/new.tsx:486
+#: src/routes/new.tsx:497
 msgid "Kenyan Shilling"
 msgstr "Chelín Keniata"
 
-#: src/routes/new.tsx:491
+#: src/routes/new.tsx:502
 msgid "Kuwaiti Dinar"
 msgstr "Dinar Kuwaití"
 
-#: src/routes/new.tsx:487
+#: src/routes/new.tsx:498
 msgid "Kyrgystani Som"
 msgstr "Som Kirguís"
 
@@ -1066,7 +1130,7 @@ msgstr "Som Kirguís"
 msgid "Language"
 msgstr "Idioma"
 
-#: src/routes/new.tsx:494
+#: src/routes/new.tsx:505
 msgid "Laotian Kip"
 msgstr "Kip Laosiano"
 
@@ -1078,23 +1142,23 @@ msgstr "Último uso"
 msgid "Last year"
 msgstr "Año pasado"
 
-#: src/routes/party.$partyId.tsx:302
+#: src/routes/party.$partyId.tsx:314
 msgid "Leave party"
 msgstr "Dejar el grupo"
 
-#: src/routes/new.tsx:495
+#: src/routes/new.tsx:506
 msgid "Lebanese Pound"
 msgstr "Libra Libanesa"
 
-#: src/routes/new.tsx:498
+#: src/routes/new.tsx:509
 msgid "Lesotho Loti"
 msgstr "Loti de Lesoto"
 
-#: src/routes/new.tsx:497
+#: src/routes/new.tsx:508
 msgid "Liberian Dollar"
 msgstr "Dólar Liberiano"
 
-#: src/routes/new.tsx:499
+#: src/routes/new.tsx:510
 msgid "Libyan Dinar"
 msgstr "Dinar Libio"
 
@@ -1114,31 +1178,36 @@ msgstr "Enlaces"
 msgid "Loading licenses..."
 msgstr "Cargando licencias..."
 
+#: src/routes/party_.$partyId.log.tsx:50
+#: src/routes/party.$partyId.tsx:283
+msgid "Log"
+msgstr ""
+
 #: src/components/PartyListCard.tsx:89
 msgid "Long press for party actions"
 msgstr "Mantén pulsado para abrir las acciones del grupo"
 
-#: src/routes/new.tsx:506
+#: src/routes/new.tsx:517
 msgid "Macanese Pataca"
 msgstr "Pataca de Macao"
 
-#: src/routes/new.tsx:503
+#: src/routes/new.tsx:514
 msgid "Macedonian Denar"
 msgstr "Denar Macedonio"
 
-#: src/routes/new.tsx:502
+#: src/routes/new.tsx:513
 msgid "Malagasy Ariary"
 msgstr "Ariary Malgache"
 
-#: src/routes/new.tsx:510
+#: src/routes/new.tsx:521
 msgid "Malawian Kwacha"
 msgstr "Kwacha Malauí"
 
-#: src/routes/new.tsx:512
+#: src/routes/new.tsx:523
 msgid "Malaysian Ringgit"
 msgstr "Ringgit Malasio"
 
-#: src/routes/new.tsx:509
+#: src/routes/new.tsx:520
 msgid "Maldivian Rufiyaa"
 msgstr "Rufiyaa Maldiva"
 
@@ -1152,7 +1221,7 @@ msgstr "Gestiona la lista de participantes. Los miembros existentes solo pueden 
 
 #: src/routes/party_.$partyId.pay.tsx:93
 #: src/routes/party_.$partyId.pay.tsx:118
-#: src/routes/party.$partyId.tsx:919
+#: src/routes/party.$partyId.tsx:931
 msgid "Mark as paid"
 msgstr "Marcar como pagado"
 
@@ -1160,11 +1229,11 @@ msgstr "Marcar como pagado"
 msgid "Marking expense as paid..."
 msgstr "Marcando gasto como pagado..."
 
-#: src/routes/new.tsx:507
+#: src/routes/new.tsx:518
 msgid "Mauritanian Ouguiya"
 msgstr "Ouguiya Mauritano"
 
-#: src/routes/new.tsx:508
+#: src/routes/new.tsx:519
 msgid "Mauritian Rupee"
 msgstr "Rupia de Mauricio"
 
@@ -1182,11 +1251,11 @@ msgstr "Yo"
 msgid "Menu"
 msgstr "Menú"
 
-#: src/routes/new.tsx:511
+#: src/routes/new.tsx:522
 msgid "Mexican Investment Unit"
 msgstr "Unidad de Inversión Mexicana"
 
-#: src/routes/new.tsx:407
+#: src/routes/new.tsx:418
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
@@ -1209,15 +1278,15 @@ msgstr "Migración exitosa"
 msgid "Missing search params"
 msgstr "Faltan parámetros de búsqueda"
 
-#: src/routes/new.tsx:501
+#: src/routes/new.tsx:512
 msgid "Moldovan Leu"
 msgstr "Leu Moldavo"
 
-#: src/routes/new.tsx:505
+#: src/routes/new.tsx:516
 msgid "Mongolian Tugrik"
 msgstr "Tugrik Mongol"
 
-#: src/routes/new.tsx:500
+#: src/routes/new.tsx:511
 msgid "Moroccan Dirham"
 msgstr "Dírham Marroquí"
 
@@ -1233,7 +1302,7 @@ msgstr "Mover cursor a la derecha"
 msgid "Moved to"
 msgstr "Movida a"
 
-#: src/routes/new.tsx:513
+#: src/routes/new.tsx:524
 msgid "Mozambican Metical"
 msgstr "Metical Mozambiqueño"
 
@@ -1245,11 +1314,13 @@ msgstr "División Multi-Grupo"
 msgid "Multiply"
 msgstr "Multiplicar"
 
-#: src/routes/new.tsx:504
+#: src/routes/new.tsx:515
 msgid "Myanma Kyat"
 msgstr "Kyat Birmano"
 
-#: src/routes/new.tsx:176
+#: src/routes/new.tsx:187
+#: src/routes/party_.$partyId.log.tsx:222
+#: src/routes/party_.$partyId.log.tsx:233
 #: src/routes/party_.$partyId.settings.tsx:155
 #: src/routes/party.$partyId.tsx:160
 msgid "Name"
@@ -1259,7 +1330,7 @@ msgstr "Nombre"
 msgid "Name must be less than 50 characters"
 msgstr "El nombre debe tener menos de 50 caracteres"
 
-#: src/routes/new.tsx:514
+#: src/routes/new.tsx:525
 msgid "Namibian Dollar"
 msgstr "Dólar Namibio"
 
@@ -1267,11 +1338,11 @@ msgstr "Dólar Namibio"
 msgid "Need help with trizum? We're here to assist you."
 msgstr "¿Necesitas ayuda con trizum? Estamos aquí para ayudarte."
 
-#: src/routes/new.tsx:517
+#: src/routes/new.tsx:528
 msgid "Nepalese Rupee"
 msgstr "Rupia Nepalí"
 
-#: src/routes/new.tsx:433
+#: src/routes/new.tsx:444
 msgid "Netherlands Antillean Guilder"
 msgstr "Florín de las Antillas Neerlandesas"
 
@@ -1279,20 +1350,20 @@ msgstr "Florín de las Antillas Neerlandesas"
 msgid "New expense"
 msgstr "Nuevo gasto"
 
-#: src/routes/new.tsx:328
+#: src/routes/new.tsx:339
 #: src/routes/party_.$partyId.settings.tsx:336
 msgid "New participant name"
 msgstr "Nombre del nuevo participante"
 
-#: src/routes/new.tsx:545
+#: src/routes/new.tsx:556
 msgid "New Taiwan Dollar"
 msgstr "Nuevo Dólar Taiwanés"
 
-#: src/routes/new.tsx:137
+#: src/routes/new.tsx:148
 msgid "New trizum"
 msgstr "Nuevo trizum"
 
-#: src/routes/new.tsx:421
+#: src/routes/new.tsx:432
 msgid "New Zealand Dollar"
 msgstr "Dólar Neozelandés"
 
@@ -1300,11 +1371,11 @@ msgstr "Dólar Neozelandés"
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/routes/new.tsx:516
+#: src/routes/new.tsx:527
 msgid "Nicaraguan Córdoba"
 msgstr "Córdoba Nicaragüense"
 
-#: src/routes/new.tsx:515
+#: src/routes/new.tsx:526
 msgid "Nigerian Naira"
 msgstr "Naira Nigeriano"
 
@@ -1320,7 +1391,7 @@ msgstr "No hay grupos archivados"
 msgid "No camera found on this device"
 msgstr "No se encontró cámara en este dispositivo"
 
-#: src/routes/new.tsx:574
+#: src/routes/new.tsx:585
 msgid "No currency"
 msgstr "Sin moneda"
 
@@ -1331,6 +1402,10 @@ msgstr "No hay ningún grupo de destino disponible"
 #: src/components/EmojiPicker.tsx:319
 msgid "No emoji found"
 msgstr "No se encontraron emojis"
+
+#: src/routes/party_.$partyId.log.tsx:74
+msgid "No log entries yet"
+msgstr ""
 
 #: src/components/PartyStatsView.tsx:299
 #: src/components/PartyStatsView.tsx:513
@@ -1349,7 +1424,7 @@ msgstr "Aún no hay estadísticas de gastos"
 msgid "Nobody else is available in this party"
 msgstr "No hay nadie más disponible en este grupo"
 
-#: src/routes/party.$partyId.tsx:776
+#: src/routes/party.$partyId.tsx:788
 msgid "Nobody owes you money!"
 msgstr "¡Nadie te debe dinero!"
 
@@ -1361,11 +1436,11 @@ msgstr "Todavía nadie"
 msgid "Non-transfer expenses in this timeframe"
 msgstr "Gastos no asociados a transferencias en este período"
 
-#: src/routes/new.tsx:490
+#: src/routes/new.tsx:501
 msgid "North Korean Won"
 msgstr "Won Norcoreano"
 
-#: src/routes/new.tsx:411
+#: src/routes/new.tsx:422
 msgid "Norwegian Krone"
 msgstr "Corona Noruega"
 
@@ -1385,7 +1460,7 @@ msgstr "Sin Conexión Primero"
 msgid "Older parties stay tucked away, not gone"
 msgstr "Los grupos antiguos quedan apartados, no desaparecen"
 
-#: src/routes/new.tsx:518
+#: src/routes/new.tsx:529
 msgid "Omani Rial"
 msgstr "Rial Omaní"
 
@@ -1425,12 +1500,12 @@ msgstr "Abrir paréntesis"
 msgid "or enter code"
 msgstr "o introduce código"
 
-#: src/routes/party.$partyId.tsx:787
+#: src/routes/party.$partyId.tsx:799
 msgid "Other operations"
 msgstr "Otras operaciones"
 
 #: src/routes/party_.$partyId.pay.tsx:104
-#: src/routes/party.$partyId.tsx:889
+#: src/routes/party.$partyId.tsx:901
 msgid "owes"
 msgstr "le debe"
 
@@ -1455,23 +1530,23 @@ msgstr "Deuda pagada a {0}"
 msgid "Paid debt to {toName}"
 msgstr "Deuda pagada a {toName}"
 
-#: src/routes/new.tsx:523
+#: src/routes/new.tsx:534
 msgid "Pakistani Rupee"
 msgstr "Rupia Paquistaní"
 
-#: src/routes/new.tsx:568
+#: src/routes/new.tsx:579
 msgid "Palladium (troy ounce)"
 msgstr "Paladio (onza troy)"
 
-#: src/routes/new.tsx:519
+#: src/routes/new.tsx:530
 msgid "Panamanian Balboa"
 msgstr "Balboa Panameño"
 
-#: src/routes/new.tsx:521
+#: src/routes/new.tsx:532
 msgid "Papua New Guinean Kina"
 msgstr "Kina de Papúa Nueva Guinea"
 
-#: src/routes/new.tsx:524
+#: src/routes/new.tsx:535
 msgid "Paraguayan Guarani"
 msgstr "Guaraní Paraguayo"
 
@@ -1479,7 +1554,7 @@ msgstr "Guaraní Paraguayo"
 msgid "participant"
 msgstr "participante"
 
-#: src/routes/new.tsx:296
+#: src/routes/new.tsx:307
 #: src/routes/party_.$partyId.settings.tsx:282
 #: src/routes/party_.$partyId.settings.tsx:409
 msgid "Participant name"
@@ -1490,7 +1565,7 @@ msgid "participants"
 msgstr "participantes"
 
 #: src/components/PartyStatsView.tsx:327
-#: src/routes/new.tsx:256
+#: src/routes/new.tsx:267
 #: src/routes/party_.$partyId.settings.tsx:213
 msgid "Participants"
 msgstr "Participantes"
@@ -1503,7 +1578,8 @@ msgstr "Acciones del grupo"
 msgid "Party archived"
 msgstr "Grupo archivado"
 
-#: src/routes/new.tsx:82
+#: src/routes/new.tsx:93
+#: src/routes/party_.$partyId.log.tsx:137
 msgid "Party created"
 msgstr "Grupo creado"
 
@@ -1531,6 +1607,10 @@ msgstr "Configuración del Grupo"
 msgid "Party settings saved!"
 msgstr "¡Configuración del grupo guardada!"
 
+#: src/routes/party_.$partyId.log.tsx:139
+msgid "Party settings updated"
+msgstr ""
+
 #: src/routes/party_.$partyId.share.tsx:37
 msgid "Party shared!"
 msgstr "¡Grupo compartido!"
@@ -1548,11 +1628,11 @@ msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc12
 msgstr "Pega el mensaje de compartir de Tricount, la URL (p. ej., https://tricount.com/abc123), o la clave directa"
 
 #: src/routes/party_.$partyId.pay.tsx:93
-#: src/routes/party.$partyId.tsx:919
+#: src/routes/party.$partyId.tsx:931
 msgid "Pay"
 msgstr "Pagar"
 
-#: src/routes/party.$partyId.tsx:758
+#: src/routes/party.$partyId.tsx:770
 msgid "People that owe you money"
 msgstr "Personas que te deben dinero"
 
@@ -1560,13 +1640,17 @@ msgstr "Personas que te deben dinero"
 msgid "Personal mode"
 msgstr "Modo personal"
 
-#: src/routes/new.tsx:520
+#: src/routes/new.tsx:531
 msgid "Peruvian Sol"
 msgstr "Sol Peruano"
 
-#: src/routes/new.tsx:522
+#: src/routes/new.tsx:533
 msgid "Philippine Peso"
 msgstr "Peso Filipino"
+
+#: src/routes/party_.$partyId.log.tsx:235
+msgid "Phone"
+msgstr ""
 
 #: src/routes/settings.tsx:162
 msgid "Phone number"
@@ -1600,7 +1684,7 @@ msgstr "Los grupos fijados se mantienen a mano. La actividad reciente mantiene e
 msgid "Pinned parties stay on top, then the rest follow your latest activity."
 msgstr "Los grupos fijados se quedan arriba y el resto sigue tu actividad más reciente."
 
-#: src/routes/new.tsx:570
+#: src/routes/new.tsx:581
 msgid "Platinum (troy ounce)"
 msgstr "Platino (onza troy)"
 
@@ -1632,7 +1716,7 @@ msgstr "Por favor espera mientras obtenemos los datos más recientes"
 msgid "Point your camera at a trizum QR code"
 msgstr "Apunta tu cámara a un código QR de trizum"
 
-#: src/routes/new.tsx:413
+#: src/routes/new.tsx:424
 msgid "Polish Zloty"
 msgstr "Zloty Polaco"
 
@@ -1644,7 +1728,7 @@ msgstr "Anterior"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: src/routes/new.tsx:525
+#: src/routes/new.tsx:536
 msgid "Qatari Rial"
 msgstr "Rial Catarí"
 
@@ -1668,7 +1752,7 @@ msgstr "Coincidencia recomendada"
 msgid "Reload"
 msgstr "Recargar"
 
-#: src/routes/new.tsx:308
+#: src/routes/new.tsx:319
 #: src/routes/party_.$partyId.settings.tsx:295
 msgid "Remove"
 msgstr "Eliminar"
@@ -1701,41 +1785,41 @@ msgstr "Restaurar al inicio"
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/routes/new.tsx:416
+#: src/routes/new.tsx:427
 msgid "Romanian Leu"
 msgstr "Leu Rumano"
 
-#: src/routes/new.tsx:419
+#: src/routes/new.tsx:430
 msgid "Russian Ruble"
 msgstr "Rublo Ruso"
 
-#: src/routes/new.tsx:527
+#: src/routes/new.tsx:538
 msgid "Rwandan Franc"
 msgstr "Franco Ruandés"
 
-#: src/routes/new.tsx:531
+#: src/routes/new.tsx:542
 msgid "Saint Helena Pound"
 msgstr "Libra de Santa Elena"
 
-#: src/routes/new.tsx:537
+#: src/routes/new.tsx:548
 msgid "Salvadoran Colón"
 msgstr "Colón Salvadoreño"
 
-#: src/routes/new.tsx:557
+#: src/routes/new.tsx:568
 msgid "Samoan Tala"
 msgstr "Tala Samoano"
 
-#: src/routes/new.tsx:536
+#: src/routes/new.tsx:547
 msgid "São Tomé and Príncipe Dobra"
 msgstr "Dobra de Santo Tomé y Príncipe"
 
-#: src/routes/new.tsx:428
+#: src/routes/new.tsx:439
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
 #: src/components/ExpenseEditor.tsx:288
 #: src/routes/migrate_.tricount.tsx:160
-#: src/routes/new.tsx:148
+#: src/routes/new.tsx:159
 #: src/routes/party_.$partyId.settings.tsx:127
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/settings.tsx:99
@@ -1767,7 +1851,7 @@ msgstr "Seleccionar emoji"
 msgid "Send us an email and we'll get back to you as soon as possible."
 msgstr "Envíanos un email y te responderemos lo antes posible."
 
-#: src/routes/new.tsx:526
+#: src/routes/new.tsx:537
 msgid "Serbian Dinar"
 msgstr "Dinar Serbio"
 
@@ -1776,7 +1860,7 @@ msgid "Set up your username, avatar, and preferences"
 msgstr "Configura tu nombre de usuario, avatar y preferencias"
 
 #: src/routes/index.tsx:123
-#: src/routes/party.$partyId.tsx:295
+#: src/routes/party.$partyId.tsx:307
 #: src/routes/settings.tsx:88
 msgid "Settings"
 msgstr "Configuración"
@@ -1789,13 +1873,13 @@ msgstr "Configuración guardada"
 msgid "Settled in"
 msgstr "Saldada en"
 
-#: src/routes/new.tsx:529
+#: src/routes/new.tsx:540
 msgid "Seychellois Rupee"
 msgstr "Rupia de Seychelles"
 
 #: src/routes/party_.$partyId.share.tsx:55
 #: src/routes/party_.$partyId.share.tsx:90
-#: src/routes/party.$partyId.tsx:283
+#: src/routes/party.$partyId.tsx:295
 msgid "Share party"
 msgstr "Compartir grupo"
 
@@ -1823,23 +1907,23 @@ msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
-#: src/routes/new.tsx:532
+#: src/routes/new.tsx:543
 msgid "Sierra Leonean Leone"
 msgstr "Leone de Sierra Leona"
 
-#: src/routes/new.tsx:559
+#: src/routes/new.tsx:570
 msgid "Silver (troy ounce)"
 msgstr "Plata (onza troy)"
 
-#: src/routes/new.tsx:422
+#: src/routes/new.tsx:433
 msgid "Singapore Dollar"
 msgstr "Dólar de Singapur"
 
-#: src/routes/new.tsx:528
+#: src/routes/new.tsx:539
 msgid "Solomon Islands Dollar"
 msgstr "Dólar de las Islas Salomón"
 
-#: src/routes/new.tsx:533
+#: src/routes/new.tsx:544
 msgid "Somali Shilling"
 msgstr "Chelín Somalí"
 
@@ -1851,19 +1935,19 @@ msgstr "Algo salió mal"
 msgid "Sort balances"
 msgstr "Ordenar balances"
 
-#: src/routes/new.tsx:425
+#: src/routes/new.tsx:436
 msgid "South African Rand"
 msgstr "Rand Sudafricano"
 
-#: src/routes/new.tsx:409
+#: src/routes/new.tsx:420
 msgid "South Korean Won"
 msgstr "Won Surcoreano"
 
-#: src/routes/new.tsx:535
+#: src/routes/new.tsx:546
 msgid "South Sudanese Pound"
 msgstr "Libra Sursudanesa"
 
-#: src/routes/new.tsx:566
+#: src/routes/new.tsx:577
 msgid "Special Drawing Rights"
 msgstr "Derechos Especiales de Giro"
 
@@ -1879,7 +1963,7 @@ msgstr "Divide facturas con amigos y familia. Registra, calcula y salda gastos j
 msgid "Split expenses fairly among multiple participants"
 msgstr "Divide los gastos de forma justa entre múltiples participantes"
 
-#: src/routes/new.tsx:496
+#: src/routes/new.tsx:507
 msgid "Sri Lankan Rupee"
 msgstr "Rupia de Sri Lanka"
 
@@ -1902,7 +1986,7 @@ msgstr "Enviar sugerencia"
 
 #: src/components/ExpenseEditor.tsx:288
 #: src/routes/migrate_.tricount.tsx:160
-#: src/routes/new.tsx:148
+#: src/routes/new.tsx:159
 #: src/routes/party_.$partyId.settings.tsx:127
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/settings.tsx:99
@@ -1913,11 +1997,11 @@ msgstr "Enviando..."
 msgid "Subtract"
 msgstr "Restar"
 
-#: src/routes/new.tsx:571
+#: src/routes/new.tsx:582
 msgid "Sucre"
 msgstr "Sucre"
 
-#: src/routes/new.tsx:530
+#: src/routes/new.tsx:541
 msgid "Sudanese Pound"
 msgstr "Libra Sudanesa"
 
@@ -1926,15 +2010,15 @@ msgstr "Libra Sudanesa"
 msgid "Support"
 msgstr "Soporte"
 
-#: src/routes/new.tsx:534
+#: src/routes/new.tsx:545
 msgid "Surinamese Dollar"
 msgstr "Dólar Surinamés"
 
-#: src/routes/new.tsx:539
+#: src/routes/new.tsx:550
 msgid "Swazi Lilangeni"
 msgstr "Lilangeni Suazi"
 
-#: src/routes/new.tsx:410
+#: src/routes/new.tsx:421
 msgid "Swedish Krona"
 msgstr "Corona Sueca"
 
@@ -1942,7 +2026,7 @@ msgstr "Corona Sueca"
 msgid "Swipe between expenses and balances tabs."
 msgstr "Desliza entre las pestañas de gastos y balance."
 
-#: src/routes/new.tsx:402
+#: src/routes/new.tsx:413
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
@@ -1954,7 +2038,8 @@ msgstr "Cambiar a una cantidad fija"
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
-#: src/routes/new.tsx:199
+#: src/routes/new.tsx:210
+#: src/routes/party_.$partyId.log.tsx:224
 #: src/routes/party_.$partyId.settings.tsx:178
 msgid "Symbol"
 msgstr "Símbolo"
@@ -1971,7 +2056,7 @@ msgstr "El símbolo solo debe contener emojis"
 msgid "Syncing party information..."
 msgstr "Sincronizando información del grupo..."
 
-#: src/routes/new.tsx:538
+#: src/routes/new.tsx:549
 msgid "Syrian Pound"
 msgstr "Libra Siria"
 
@@ -1979,7 +2064,7 @@ msgstr "Libra Siria"
 msgid "System (fallbacks to {DEFAULT_LOCALE})"
 msgstr "Sistema (por defecto {DEFAULT_LOCALE})"
 
-#: src/routes/new.tsx:540
+#: src/routes/new.tsx:551
 msgid "Tajikistani Somoni"
 msgstr "Somoni Tayiko"
 
@@ -1990,7 +2075,7 @@ msgstr "Somoni Tayiko"
 msgid "Take photo"
 msgstr "Hacer foto"
 
-#: src/routes/new.tsx:546
+#: src/routes/new.tsx:557
 msgid "Tanzanian Shilling"
 msgstr "Chelín Tanzano"
 
@@ -1998,7 +2083,7 @@ msgstr "Chelín Tanzano"
 msgid "Tap to change"
 msgstr "Toca para cambiar"
 
-#: src/routes/new.tsx:424
+#: src/routes/new.tsx:435
 msgid "Thai Baht"
 msgstr "Baht Tailandés"
 
@@ -2081,7 +2166,7 @@ msgstr "Para unirte al <0>{0}</0>, por favor selecciona quién eres para que pod
 msgid "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "Para unirte al <0>{partyName}</0>, por favor selecciona quién eres para que podamos mostrarte los gastos y estadísticas que te importan."
 
-#: src/routes/new.tsx:543
+#: src/routes/new.tsx:554
 msgid "Tongan Paʻanga"
 msgstr "Paʻanga Tongano"
 
@@ -2103,7 +2188,7 @@ msgstr "Total gastado"
 msgid "Transfer debt"
 msgstr "Transferir deuda"
 
-#: src/routes/party.$partyId.tsx:946
+#: src/routes/party.$partyId.tsx:958
 msgid "Transfer to another party"
 msgstr "Transferir a otro grupo"
 
@@ -2115,7 +2200,7 @@ msgstr "Se requiere la clave o URL de Tricount"
 msgid "Tricount URL or key"
 msgstr "URL o clave de Tricount"
 
-#: src/routes/new.tsx:544
+#: src/routes/new.tsx:555
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
@@ -2136,31 +2221,31 @@ msgstr "Prueba otro período para comparar otra etapa de tu grupo."
 msgid "Try scanning another code"
 msgstr "Prueba escaneando otro código"
 
-#: src/routes/new.tsx:542
+#: src/routes/new.tsx:553
 msgid "Tunisian Dinar"
 msgstr "Dinar Tunecino"
 
-#: src/routes/new.tsx:420
+#: src/routes/new.tsx:431
 msgid "Turkish Lira"
 msgstr "Lira Turca"
 
-#: src/routes/new.tsx:541
+#: src/routes/new.tsx:552
 msgid "Turkmenistani Manat"
 msgstr "Manat Turkmeno"
 
-#: src/routes/new.tsx:427
+#: src/routes/new.tsx:438
 msgid "UAE Dirham"
 msgstr "Dírham de los EAU"
 
-#: src/routes/new.tsx:548
+#: src/routes/new.tsx:559
 msgid "Ugandan Shilling"
 msgstr "Chelín Ugandés"
 
-#: src/routes/new.tsx:547
+#: src/routes/new.tsx:558
 msgid "Ukrainian Hryvnia"
 msgstr "Grivna Ucraniana"
 
-#: src/routes/new.tsx:552
+#: src/routes/new.tsx:563
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
@@ -2216,19 +2301,19 @@ msgstr "Subiendo avatar..."
 msgid "Uploading..."
 msgstr "Subiendo..."
 
-#: src/routes/new.tsx:550
+#: src/routes/new.tsx:561
 msgid "Uruguay Peso en Unidades Indexadas"
 msgstr "Peso Uruguayo en Unidades Indexadas"
 
-#: src/routes/new.tsx:551
+#: src/routes/new.tsx:562
 msgid "Uruguayan Peso"
 msgstr "Peso Uruguayo"
 
-#: src/routes/new.tsx:399
+#: src/routes/new.tsx:410
 msgid "US Dollar"
 msgstr "Dólar Estadounidense"
 
-#: src/routes/new.tsx:549
+#: src/routes/new.tsx:560
 msgid "US Dollar (Next day)"
 msgstr "Dólar Estadounidense (Día siguiente)"
 
@@ -2244,15 +2329,15 @@ msgstr "Usa tu cámara para escanear una invitación de trizum"
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: src/routes/new.tsx:553
+#: src/routes/new.tsx:564
 msgid "Uzbekistan Som"
 msgstr "Som Uzbeko"
 
-#: src/routes/new.tsx:556
+#: src/routes/new.tsx:567
 msgid "Vanuatu Vatu"
 msgstr "Vatu de Vanuatu"
 
-#: src/routes/new.tsx:554
+#: src/routes/new.tsx:565
 msgid "Venezuelan Bolívar Soberano"
 msgstr "Bolívar Soberano Venezolano"
 
@@ -2260,7 +2345,7 @@ msgstr "Bolívar Soberano Venezolano"
 msgid "Version"
 msgstr "Versión"
 
-#: src/routes/new.tsx:555
+#: src/routes/new.tsx:566
 msgid "Vietnamese Dong"
 msgstr "Dong Vietnamita"
 
@@ -2301,7 +2386,7 @@ msgstr "¡Bienvenido al grupo, {participantName}!"
 msgid "Welcome to trizum"
 msgstr "Bienvenid@ a trizum"
 
-#: src/routes/new.tsx:219
+#: src/routes/new.tsx:230
 #: src/routes/party_.$partyId.settings.tsx:198
 msgid "What is this party about?"
 msgstr "¿De qué trata este grupo?"
@@ -2314,7 +2399,7 @@ msgstr "¿Cuál es tu forma preferida de que te llamen?"
 msgid "Who are you?"
 msgstr "¿Quién eres?"
 
-#: src/routes/new.tsx:260
+#: src/routes/new.tsx:271
 msgid "Who is invited to this party? You can add more participants later."
 msgstr "¿Quién está invitado a este grupo? Puedes añadir más participantes más tarde."
 
@@ -2322,11 +2407,11 @@ msgstr "¿Quién está invitado a este grupo? Puedes añadir más participantes 
 msgid "Why is this taking so long?"
 msgstr "¿Por qué está tardando tanto?"
 
-#: src/routes/new.tsx:453
+#: src/routes/new.tsx:464
 msgid "WIR Euro"
 msgstr "Euro WIR"
 
-#: src/routes/new.tsx:454
+#: src/routes/new.tsx:465
 msgid "WIR Franc"
 msgstr "Franco WIR"
 
@@ -2334,7 +2419,7 @@ msgstr "Franco WIR"
 msgid "Works seamlessly offline with automatic sync when online"
 msgstr "Funciona sin problemas sin conexión con sincronización automática cuando estás en línea"
 
-#: src/routes/new.tsx:575
+#: src/routes/new.tsx:586
 msgid "Yemeni Rial"
 msgstr "Rial Yemení"
 
@@ -2358,11 +2443,11 @@ msgstr "¡Has dejado el grupo!"
 msgid "You need another active party with the same currency to transfer this debt."
 msgstr "Necesitas otro grupo activo con la misma moneda para transferir esta deuda."
 
-#: src/routes/party.$partyId.tsx:728
+#: src/routes/party.$partyId.tsx:740
 msgid "You owe money to people"
 msgstr "Debes dinero a personas"
 
-#: src/routes/party.$partyId.tsx:747
+#: src/routes/party.$partyId.tsx:759
 msgid "You're debt free!"
 msgstr "¡Estás libre de deudas!"
 
@@ -2390,10 +2475,10 @@ msgstr "Tus grupos"
 msgid "Your total"
 msgstr "Tu total"
 
-#: src/routes/new.tsx:576
+#: src/routes/new.tsx:587
 msgid "Zambian Kwacha"
 msgstr "Kwacha Zambiano"
 
-#: src/routes/new.tsx:577
+#: src/routes/new.tsx:588
 msgid "Zimbabwean Dollar"
 msgstr "Dólar Zimbabuense"

--- a/packages/pwa/src/hooks/useBalancesSortBy.ts
+++ b/packages/pwa/src/hooks/useBalancesSortBy.ts
@@ -17,7 +17,7 @@ export function useBalancesSortedBy(): [BalancesSortedBy, (sorted: BalancesSorte
       : defaultBalancesSortedBy;
 
   function setter(sortedBy: BalancesSortedBy) {
-    setParticipantDetails(participant.id, {
+    void setParticipantDetails(participant.id, {
       balancesSortedBy: sortedBy,
     });
   }

--- a/packages/pwa/src/hooks/useParty.ts
+++ b/packages/pwa/src/hooks/useParty.ts
@@ -10,6 +10,7 @@ import {
 } from "#src/models/expense.js";
 import type {
   Party,
+  PartyActivityLogEntryInput,
   PartyExpenseChunk,
   PartyExpenseChunkBalances,
   PartyExpenseChunkRef,
@@ -23,6 +24,13 @@ import { clone } from "@opentf/std";
 import { useParams } from "@tanstack/react-router";
 import { getLogger } from "#src/lib/log.ts";
 import { createDebtTransferExpenses } from "#src/lib/debtTransfer.ts";
+import {
+  appendPartyActivityLogEntry,
+  appendPartyActivityLogEntries,
+  createExpenseActivityLogEntry,
+  getPartySettingsActivityEntries,
+  getParticipantActivityChanges,
+} from "#src/models/partyActivity.ts";
 
 const logger = getLogger("hooks", "useParty");
 
@@ -97,27 +105,59 @@ export function useCurrentParty() {
 }
 
 export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
-  function updateSettings(values: Pick<Party, "name" | "symbol" | "description" | "participants">) {
+  async function updateSettings(
+    values: Pick<Party, "name" | "symbol" | "description" | "participants">,
+  ) {
+    let activityEntries: PartyActivityLogEntryInput[] = [];
+
     handle.change((doc) => {
+      activityEntries = getPartySettingsActivityEntries(doc, values);
+
       doc.name = values.name;
       doc.symbol = values.symbol;
       doc.description = values.description;
       doc.participants = values.participants;
     });
+
+    await appendPartyActivityLogEntries(repo, handle, activityEntries);
   }
 
-  function setParticipantDetails(
+  async function setParticipantDetails(
     participantId: PartyParticipant["id"],
     details: Partial<
       Pick<PartyParticipant, "phone" | "personalMode" | "avatarId" | "balancesSortedBy">
     >,
   ) {
+    let activityEntry:
+      | {
+          type: "participant-updated";
+          participantId: PartyParticipant["id"];
+          participantName: PartyParticipant["name"];
+          changes: ReturnType<typeof getParticipantActivityChanges>;
+        }
+      | undefined;
+
     handle.change((doc) => {
       const participant = doc.participants[participantId];
 
       if (!participant) {
         return;
       }
+
+      const nextParticipant = { ...participant };
+
+      for (const key in details) {
+        const value = details[key as keyof typeof details];
+
+        if (value === undefined) {
+          delete nextParticipant[key as keyof typeof participant];
+        } else {
+          // @ts-expect-error -- idk tbh
+          nextParticipant[key] = value;
+        }
+      }
+
+      const activityChanges = getParticipantActivityChanges(participant, nextParticipant);
 
       for (const key in details) {
         const value = details[key as keyof typeof details];
@@ -129,7 +169,20 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
           participant[key] = value;
         }
       }
+
+      if (activityChanges.length > 0) {
+        activityEntry = {
+          type: "participant-updated",
+          participantId: participant.id,
+          participantName: participant.name,
+          changes: activityChanges,
+        };
+      }
     });
+
+    if (activityEntry) {
+      await appendPartyActivityLogEntry(repo, handle, activityEntry);
+    }
   }
 
   function createChunk() {
@@ -247,6 +300,12 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
       patchMutate(doc.balances, diff(clone(doc.balances), clone(balancesByParticipant)));
     });
 
+    await appendPartyActivityLogEntry(
+      repo,
+      handle,
+      createExpenseActivityLogEntry("expense-added", expenseWithHash),
+    );
+
     return expenseWithHash;
   }
 
@@ -306,6 +365,12 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
     lastChunkBalancesHandle.change((doc) => {
       patchMutate(doc.balances, diff(clone(doc.balances), clone(balancesByParticipant)));
     });
+
+    await appendPartyActivityLogEntry(
+      repo,
+      handle,
+      createExpenseActivityLogEntry("expense-updated", expense),
+    );
   }
 
   async function removeExpense(expenseId: Expense["id"]) {
@@ -330,6 +395,8 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
       throw new Error("Chunk not found, this should not happen");
     }
 
+    let removedExpense: Expense | undefined;
+
     chunkHandle.change((doc) => {
       const expenseIndex = doc.expenses.findIndex((e) => e.id === expenseId);
 
@@ -337,6 +404,7 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
         throw new Error("Expense not found, this should not happen");
       }
 
+      removedExpense = clone(doc.expenses[expenseIndex]);
       deleteAt(doc.expenses, expenseIndex);
     });
 
@@ -362,6 +430,16 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
       patchMutate(doc.balances, diff(clone(doc.balances), clone(balancesByParticipant)));
     });
     lastChunkBalancesHandle.doc();
+
+    const expenseForLog = removedExpense;
+
+    if (expenseForLog) {
+      await appendPartyActivityLogEntry(
+        repo,
+        handle,
+        createExpenseActivityLogEntry("expense-removed", expenseForLog),
+      );
+    }
 
     return true;
   }
@@ -442,6 +520,15 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
     try {
       const createdOriginExpense = await addExpenseToParty(originExpense);
 
+      await appendPartyActivityLogEntry(repo, handle, {
+        type: "debt-transferred",
+        originExpenseId: createdOriginExpense.id,
+        originExpenseName: createdOriginExpense.name,
+        destinationExpenseId: createdDestinationExpense.id,
+        destinationExpenseName: createdDestinationExpense.name,
+        amount,
+      });
+
       return {
         originExpense: createdOriginExpense,
         destinationExpense: createdDestinationExpense,
@@ -453,7 +540,6 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
         logger.error("Failed to rollback destination debt transfer expense", {
           rollbackError,
           destinationExpenseId: createdDestinationExpense.id,
-          destinationPartyId,
         });
       }
 

--- a/packages/pwa/src/models/migration.test.ts
+++ b/packages/pwa/src/models/migration.test.ts
@@ -1,6 +1,6 @@
 import type { Repo } from "@automerge/automerge-repo/slim";
 import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
-import type { Party } from "./party";
+import type { Party, PartyActivityLog } from "./party";
 import type { Expense } from "./expense";
 
 const addExpenseToPartyMock =
@@ -50,13 +50,21 @@ function assertNoUndefinedValues(value: unknown, path: string) {
 
 function createMockRepo() {
   let nextId = 0;
-  let lastCreatedHandle:
-    | {
-        doc: Party;
-        documentId: string;
-        change: (changeFn: (nextDoc: Party) => void) => void;
-      }
-    | undefined;
+  const createdHandles: {
+    doc: Party | PartyActivityLog;
+    documentId: string;
+    change: (changeFn: (nextDoc: Party | PartyActivityLog) => void) => void;
+  }[] = [];
+
+  function getCreatedHandle(type: Party["type"] | PartyActivityLog["type"]) {
+    const handle = createdHandles.find((handle) => handle.doc.type === type);
+
+    if (!handle) {
+      throw new Error(`Expected a created ${type} handle`);
+    }
+
+    return handle;
+  }
 
   return {
     repo: {
@@ -71,18 +79,23 @@ function createMockRepo() {
           },
         };
 
-        lastCreatedHandle = handle as unknown as typeof lastCreatedHandle;
+        createdHandles.push(handle as unknown as (typeof createdHandles)[number]);
 
         return handle;
       },
     } as unknown as Repo,
-    getLastCreatedHandle: () => {
-      if (!lastCreatedHandle) {
-        throw new Error("Expected a created party handle");
-      }
-
-      return lastCreatedHandle;
-    },
+    getCreatedPartyHandle: () =>
+      getCreatedHandle("party") as {
+        doc: Party;
+        documentId: string;
+        change: (changeFn: (nextDoc: Party) => void) => void;
+      },
+    getCreatedActivityLogHandle: () =>
+      getCreatedHandle("partyActivityLog") as {
+        doc: PartyActivityLog;
+        documentId: string;
+        change: (changeFn: (nextDoc: PartyActivityLog) => void) => void;
+      },
   };
 }
 
@@ -116,7 +129,7 @@ describe("createPartyFromMigrationData", () => {
       }),
     ).resolves.toBe("mock-doc-1");
 
-    expect(mockRepo.getLastCreatedHandle().doc).not.toHaveProperty("symbol");
+    expect(mockRepo.getCreatedPartyHandle().doc).not.toHaveProperty("symbol");
   });
 
   test("preserves the party symbol when migration data includes one", async () => {
@@ -129,8 +142,32 @@ describe("createPartyFromMigrationData", () => {
       }),
     });
 
-    expect(mockRepo.getLastCreatedHandle().doc).toMatchObject({
+    expect(mockRepo.getCreatedPartyHandle().doc).toMatchObject({
       symbol: "🏕️",
+    });
+  });
+
+  test("creates a separate activity log document for the imported party", async () => {
+    const mockRepo = createMockRepo();
+
+    await createPartyFromMigrationData({
+      repo: mockRepo.repo,
+      data: createMigrationData(),
+    });
+
+    const partyHandle = mockRepo.getCreatedPartyHandle();
+    const activityLogHandle = mockRepo.getCreatedActivityLogHandle();
+
+    expect(partyHandle.doc.activityLogId).toBe(activityLogHandle.documentId);
+    expect(activityLogHandle.doc).toMatchObject({
+      type: "partyActivityLog",
+      partyId: partyHandle.documentId,
+      entries: [
+        {
+          type: "party-created",
+          partyName: "Andalusian Point",
+        },
+      ],
     });
   });
 });

--- a/packages/pwa/src/models/migration.ts
+++ b/packages/pwa/src/models/migration.ts
@@ -7,6 +7,7 @@ import type { MediaFile } from "./media";
 import { compressionPresets } from "#src/lib/imageCompression.ts";
 import { getLogger } from "#src/lib/log.ts";
 import { requestIdleCallback } from "#src/lib/requestIdleCallback.ts";
+import { createPartyActivityLog } from "./partyActivity";
 
 const logger = getLogger("models", "migration");
 
@@ -49,8 +50,17 @@ export async function createPartyFromMigrationData({
   }
 
   const handle = repo.create<Party>(party);
-  handle.change((doc) => (doc.id = handle.documentId));
   const partyId = handle.documentId;
+  const activityLogHandle = createPartyActivityLog(repo, partyId, [
+    {
+      type: "party-created",
+      partyName: data.party.name,
+    },
+  ]);
+  handle.change((doc) => {
+    doc.id = partyId;
+    doc.activityLogId = activityLogHandle.documentId;
+  });
 
   // Import photos
   const photoMap = new Map<string, MediaFile["id"]>();

--- a/packages/pwa/src/models/party.ts
+++ b/packages/pwa/src/models/party.ts
@@ -13,6 +13,9 @@ export interface Party {
   currency: Currency;
   participants: Record<ExpenseUser, PartyParticipant>;
   chunkRefs: PartyExpenseChunkRef[];
+  activityLogId?: PartyActivityLog["id"];
+  /** @deprecated Move entries to the separate PartyActivityLog document. */
+  activityLog?: PartyActivityLogEntry[];
 }
 
 export const DEFAULT_PARTY_SYMBOL = "🏝️";
@@ -27,6 +30,84 @@ export interface PartyParticipant {
   isArchived?: boolean;
   personalMode?: boolean;
   balancesSortedBy?: BalancesSortedBy;
+}
+
+export type PartyActivityLogEntry =
+  | {
+      id: string;
+      createdAt: Date;
+      type: "party-created";
+      partyName: string;
+    }
+  | {
+      id: string;
+      createdAt: Date;
+      type: "party-settings-updated";
+      changes: PartyActivitySettingsChange[];
+    }
+  | {
+      id: string;
+      createdAt: Date;
+      type: "participant-added";
+      participantId: PartyParticipant["id"];
+      participantName: string;
+    }
+  | {
+      id: string;
+      createdAt: Date;
+      type: "participant-updated";
+      participantId: PartyParticipant["id"];
+      participantName: string;
+      changes: PartyActivityParticipantChange[];
+    }
+  | {
+      id: string;
+      createdAt: Date;
+      type: "participant-archived" | "participant-restored";
+      participantId: PartyParticipant["id"];
+      participantName: string;
+    }
+  | {
+      id: string;
+      createdAt: Date;
+      type: "participant-removed";
+      participantId: PartyParticipant["id"];
+      participantName: string;
+    }
+  | {
+      id: string;
+      createdAt: Date;
+      type: "expense-added" | "expense-updated" | "expense-removed";
+      expenseId: Expense["id"];
+      expenseName: Expense["name"];
+      amount: number;
+    }
+  | {
+      id: string;
+      createdAt: Date;
+      type: "debt-transferred";
+      originExpenseId: Expense["id"];
+      originExpenseName: Expense["name"];
+      destinationExpenseId: Expense["id"];
+      destinationExpenseName: Expense["name"];
+      amount: number;
+    };
+
+export type PartyActivitySettingsChange = "name" | "symbol" | "description";
+
+export type PartyActivityParticipantChange = "name" | "phone" | "avatar";
+
+export type PartyActivityLogEntryInput = PartyActivityLogEntry extends infer Entry
+  ? Entry extends PartyActivityLogEntry
+    ? Omit<Entry, "id" | "createdAt">
+    : never
+  : never;
+
+export interface PartyActivityLog {
+  id: DocumentId;
+  type: "partyActivityLog";
+  partyId: Party["id"];
+  entries: PartyActivityLogEntry[];
 }
 
 export interface PartyExpenseChunkRef {

--- a/packages/pwa/src/models/partyActivity.test.ts
+++ b/packages/pwa/src/models/partyActivity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vite-plus/test";
+import type { Party } from "./party";
+import { getPartySettingsActivityEntries, getParticipantActivityChanges } from "./partyActivity";
+
+describe("party activity", () => {
+  test("describes party setting and participant changes", () => {
+    const previous = {
+      name: "Trip",
+      symbol: "T",
+      description: "Summer",
+      participants: {
+        alice: { id: "alice", name: "Alice" },
+        bob: { id: "bob", name: "Bob" },
+        clara: { id: "clara", name: "Clara", isArchived: true },
+      },
+    } satisfies Pick<Party, "name" | "symbol" | "description" | "participants">;
+    const next = {
+      name: "Beach trip",
+      symbol: "B",
+      description: "Summer",
+      participants: {
+        alice: { id: "alice", name: "Alicia" },
+        bob: { id: "bob", name: "Bob", isArchived: true },
+        clara: { id: "clara", name: "Clara" },
+        diego: { id: "diego", name: "Diego" },
+      },
+    } satisfies Pick<Party, "name" | "symbol" | "description" | "participants">;
+
+    expect(getPartySettingsActivityEntries(previous, next)).toEqual([
+      {
+        type: "party-settings-updated",
+        changes: ["name", "symbol"],
+      },
+      {
+        type: "participant-updated",
+        participantId: "alice",
+        participantName: "Alicia",
+        changes: ["name"],
+      },
+      {
+        type: "participant-archived",
+        participantId: "bob",
+        participantName: "Bob",
+      },
+      {
+        type: "participant-restored",
+        participantId: "clara",
+        participantName: "Clara",
+      },
+      {
+        type: "participant-added",
+        participantId: "diego",
+        participantName: "Diego",
+      },
+    ]);
+  });
+
+  test("ignores participant view preferences", () => {
+    expect(
+      getParticipantActivityChanges(
+        {
+          id: "alice",
+          name: "Alice",
+          personalMode: false,
+          balancesSortedBy: "name",
+        },
+        {
+          id: "alice",
+          name: "Alice",
+          personalMode: true,
+          balancesSortedBy: "balance-descending",
+        },
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/pwa/src/models/partyActivity.ts
+++ b/packages/pwa/src/models/partyActivity.ts
@@ -1,0 +1,222 @@
+import {
+  insertAt,
+  type DocHandle,
+  type DocumentId,
+  type Repo,
+} from "@automerge/automerge-repo/slim";
+import { ulid } from "ulidx";
+import { getExpenseTotalAmount, type Expense } from "./expense";
+import type {
+  Party,
+  PartyActivityLog,
+  PartyActivityLogEntry,
+  PartyActivityLogEntryInput,
+  PartyActivityParticipantChange,
+  PartyActivitySettingsChange,
+  PartyParticipant,
+} from "./party";
+
+export function createPartyActivityLogEntry(
+  input: PartyActivityLogEntryInput,
+): PartyActivityLogEntry {
+  return {
+    ...input,
+    id: ulid(),
+    createdAt: new Date(),
+  } as PartyActivityLogEntry;
+}
+
+export function createPartyActivityLog(
+  repo: Repo,
+  partyId: Party["id"],
+  entries: PartyActivityLogEntryInput[] = [],
+) {
+  return createPartyActivityLogWithEntries(
+    repo,
+    partyId,
+    entries.map((entry) => createPartyActivityLogEntry(entry)),
+  );
+}
+
+function createPartyActivityLogWithEntries(
+  repo: Repo,
+  partyId: Party["id"],
+  entries: PartyActivityLogEntry[],
+) {
+  const handle = repo.create<PartyActivityLog>({
+    id: "" as DocumentId,
+    type: "partyActivityLog",
+    partyId,
+    entries,
+  });
+
+  handle.change((doc) => (doc.id = handle.documentId));
+
+  return handle;
+}
+
+export async function ensurePartyActivityLog(repo: Repo, partyHandle: DocHandle<Party>) {
+  const party = partyHandle.doc();
+
+  if (!party) {
+    throw new Error("Party not found, this should not happen");
+  }
+
+  if (party.activityLogId) {
+    const existingHandle = await repo.find<PartyActivityLog>(party.activityLogId);
+
+    if (existingHandle.doc()) {
+      return existingHandle;
+    }
+  }
+
+  const legacyEntries = party.activityLog ? [...party.activityLog] : [];
+  const logHandle = createPartyActivityLogWithEntries(repo, party.id, legacyEntries);
+
+  partyHandle.change((doc) => {
+    doc.activityLogId = logHandle.documentId;
+    delete doc.activityLog;
+  });
+
+  return logHandle;
+}
+
+export async function appendPartyActivityLogEntry(
+  repo: Repo,
+  partyHandle: DocHandle<Party>,
+  input: PartyActivityLogEntryInput,
+) {
+  await appendPartyActivityLogEntries(repo, partyHandle, [input]);
+}
+
+export async function appendPartyActivityLogEntries(
+  repo: Repo,
+  partyHandle: DocHandle<Party>,
+  inputs: PartyActivityLogEntryInput[],
+) {
+  if (inputs.length === 0) {
+    return;
+  }
+
+  const logHandle = await ensurePartyActivityLog(repo, partyHandle);
+
+  logHandle.change((doc) => {
+    for (const input of [...inputs].reverse()) {
+      insertAt(doc.entries, 0, createPartyActivityLogEntry(input));
+    }
+  });
+}
+
+export function createExpenseActivityLogEntry(
+  type: "expense-added" | "expense-updated" | "expense-removed",
+  expense: Expense,
+): PartyActivityLogEntryInput {
+  return {
+    type,
+    expenseId: expense.id,
+    expenseName: expense.name,
+    amount: getExpenseTotalAmount(expense),
+  };
+}
+
+export function getPartySettingsActivityEntries(
+  previous: Pick<Party, "name" | "symbol" | "description" | "participants">,
+  next: Pick<Party, "name" | "symbol" | "description" | "participants">,
+): PartyActivityLogEntryInput[] {
+  const entries: PartyActivityLogEntryInput[] = [];
+  const settingsChanges: PartyActivitySettingsChange[] = [];
+
+  if (previous.name !== next.name) {
+    settingsChanges.push("name");
+  }
+
+  if ((previous.symbol ?? "") !== (next.symbol ?? "")) {
+    settingsChanges.push("symbol");
+  }
+
+  if (previous.description !== next.description) {
+    settingsChanges.push("description");
+  }
+
+  if (settingsChanges.length > 0) {
+    entries.push({
+      type: "party-settings-updated",
+      changes: settingsChanges,
+    });
+  }
+
+  for (const participant of Object.values(next.participants)) {
+    const previousParticipant = previous.participants[participant.id];
+
+    if (!previousParticipant) {
+      entries.push({
+        type: "participant-added",
+        participantId: participant.id,
+        participantName: participant.name,
+      });
+      continue;
+    }
+
+    const participantChanges = getParticipantActivityChanges(previousParticipant, participant);
+
+    if (participantChanges.length > 0) {
+      entries.push({
+        type: "participant-updated",
+        participantId: participant.id,
+        participantName: participant.name,
+        changes: participantChanges,
+      });
+    }
+
+    if (!previousParticipant.isArchived && participant.isArchived) {
+      entries.push({
+        type: "participant-archived",
+        participantId: participant.id,
+        participantName: participant.name,
+      });
+    }
+
+    if (previousParticipant.isArchived && !participant.isArchived) {
+      entries.push({
+        type: "participant-restored",
+        participantId: participant.id,
+        participantName: participant.name,
+      });
+    }
+  }
+
+  for (const participant of Object.values(previous.participants)) {
+    if (next.participants[participant.id]) {
+      continue;
+    }
+
+    entries.push({
+      type: "participant-removed",
+      participantId: participant.id,
+      participantName: participant.name,
+    });
+  }
+
+  return entries;
+}
+
+export function getParticipantActivityChanges(
+  previous: PartyParticipant,
+  next: PartyParticipant,
+): PartyActivityParticipantChange[] {
+  const changes: PartyActivityParticipantChange[] = [];
+
+  if (previous.name !== next.name) {
+    changes.push("name");
+  }
+
+  if ((previous.phone ?? "") !== (next.phone ?? "")) {
+    changes.push("phone");
+  }
+
+  if ((previous.avatarId ?? null) !== (next.avatarId ?? null)) {
+    changes.push("avatar");
+  }
+
+  return changes;
+}

--- a/packages/pwa/src/routeTree.gen.ts
+++ b/packages/pwa/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as PartyPartyIdStatsRouteImport } from './routes/party_.$partyId.
 import { Route as PartyPartyIdShareRouteImport } from './routes/party_.$partyId.share'
 import { Route as PartyPartyIdSettingsRouteImport } from './routes/party_.$partyId.settings'
 import { Route as PartyPartyIdPayRouteImport } from './routes/party_.$partyId.pay'
+import { Route as PartyPartyIdLogRouteImport } from './routes/party_.$partyId.log'
 import { Route as PartyPartyIdAddRouteImport } from './routes/party_.$partyId.add'
 import { Route as PartyPartyIdExpenseExpenseIdRouteImport } from './routes/party_.$partyId.expense.$expenseId'
 import { Route as PartyPartyIdExpenseExpenseIdEditRouteImport } from './routes/party_.$partyId.expense.$expenseId_.edit'
@@ -116,6 +117,11 @@ const PartyPartyIdPayRoute = PartyPartyIdPayRouteImport.update({
   path: '/party/$partyId/pay',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PartyPartyIdLogRoute = PartyPartyIdLogRouteImport.update({
+  id: '/party_/$partyId/log',
+  path: '/party/$partyId/log',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PartyPartyIdAddRoute = PartyPartyIdAddRouteImport.update({
   id: '/party_/$partyId/add',
   path: '/party/$partyId/add',
@@ -147,6 +153,7 @@ export interface FileRoutesByFullPath {
   '/migrate/tricount': typeof MigrateTricountRoute
   '/party/$partyId': typeof PartyPartyIdRoute
   '/party/$partyId/add': typeof PartyPartyIdAddRoute
+  '/party/$partyId/log': typeof PartyPartyIdLogRoute
   '/party/$partyId/pay': typeof PartyPartyIdPayRoute
   '/party/$partyId/settings': typeof PartyPartyIdSettingsRoute
   '/party/$partyId/share': typeof PartyPartyIdShareRoute
@@ -169,6 +176,7 @@ export interface FileRoutesByTo {
   '/migrate/tricount': typeof MigrateTricountRoute
   '/party/$partyId': typeof PartyPartyIdRoute
   '/party/$partyId/add': typeof PartyPartyIdAddRoute
+  '/party/$partyId/log': typeof PartyPartyIdLogRoute
   '/party/$partyId/pay': typeof PartyPartyIdPayRoute
   '/party/$partyId/settings': typeof PartyPartyIdSettingsRoute
   '/party/$partyId/share': typeof PartyPartyIdShareRoute
@@ -192,6 +200,7 @@ export interface FileRoutesById {
   '/migrate_/tricount': typeof MigrateTricountRoute
   '/party/$partyId': typeof PartyPartyIdRoute
   '/party_/$partyId/add': typeof PartyPartyIdAddRoute
+  '/party_/$partyId/log': typeof PartyPartyIdLogRoute
   '/party_/$partyId/pay': typeof PartyPartyIdPayRoute
   '/party_/$partyId/settings': typeof PartyPartyIdSettingsRoute
   '/party_/$partyId/share': typeof PartyPartyIdShareRoute
@@ -216,6 +225,7 @@ export interface FileRouteTypes {
     | '/migrate/tricount'
     | '/party/$partyId'
     | '/party/$partyId/add'
+    | '/party/$partyId/log'
     | '/party/$partyId/pay'
     | '/party/$partyId/settings'
     | '/party/$partyId/share'
@@ -238,6 +248,7 @@ export interface FileRouteTypes {
     | '/migrate/tricount'
     | '/party/$partyId'
     | '/party/$partyId/add'
+    | '/party/$partyId/log'
     | '/party/$partyId/pay'
     | '/party/$partyId/settings'
     | '/party/$partyId/share'
@@ -260,6 +271,7 @@ export interface FileRouteTypes {
     | '/migrate_/tricount'
     | '/party/$partyId'
     | '/party_/$partyId/add'
+    | '/party_/$partyId/log'
     | '/party_/$partyId/pay'
     | '/party_/$partyId/settings'
     | '/party_/$partyId/share'
@@ -283,6 +295,7 @@ export interface RootRouteChildren {
   MigrateTricountRoute: typeof MigrateTricountRoute
   PartyPartyIdRoute: typeof PartyPartyIdRoute
   PartyPartyIdAddRoute: typeof PartyPartyIdAddRoute
+  PartyPartyIdLogRoute: typeof PartyPartyIdLogRoute
   PartyPartyIdPayRoute: typeof PartyPartyIdPayRoute
   PartyPartyIdSettingsRoute: typeof PartyPartyIdSettingsRoute
   PartyPartyIdShareRoute: typeof PartyPartyIdShareRoute
@@ -414,6 +427,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PartyPartyIdPayRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/party_/$partyId/log': {
+      id: '/party_/$partyId/log'
+      path: '/party/$partyId/log'
+      fullPath: '/party/$partyId/log'
+      preLoaderRoute: typeof PartyPartyIdLogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/party_/$partyId/add': {
       id: '/party_/$partyId/add'
       path: '/party/$partyId/add'
@@ -451,6 +471,7 @@ const rootRouteChildren: RootRouteChildren = {
   MigrateTricountRoute: MigrateTricountRoute,
   PartyPartyIdRoute: PartyPartyIdRoute,
   PartyPartyIdAddRoute: PartyPartyIdAddRoute,
+  PartyPartyIdLogRoute: PartyPartyIdLogRoute,
   PartyPartyIdPayRoute: PartyPartyIdPayRoute,
   PartyPartyIdSettingsRoute: PartyPartyIdSettingsRoute,
   PartyPartyIdShareRoute: PartyPartyIdShareRoute,

--- a/packages/pwa/src/routes/new.tsx
+++ b/packages/pwa/src/routes/new.tsx
@@ -21,6 +21,7 @@ import { BackButton } from "#src/components/BackButton.js";
 import { toast } from "sonner";
 import type { Currency } from "dinero.js";
 import { AppEmojiField } from "#src/components/AppEmojiField.tsx";
+import { createPartyActivityLog } from "#src/models/partyActivity.ts";
 
 export const Route = createFileRoute("/new")({
   component: New,
@@ -69,7 +70,17 @@ function New() {
       }, {}),
       chunkRefs: [],
     });
-    handle.change((doc) => (doc.id = handle.documentId));
+    const activityLogHandle = createPartyActivityLog(repo, handle.documentId, [
+      {
+        type: "party-created",
+        partyName: values.name,
+      },
+    ]);
+
+    handle.change((doc) => {
+      doc.id = handle.documentId;
+      doc.activityLogId = activityLogHandle.documentId;
+    });
     void navigate({
       to: "/party/$partyId",
       params: { partyId: handle.documentId },

--- a/packages/pwa/src/routes/party.$partyId.tsx
+++ b/packages/pwa/src/routes/party.$partyId.tsx
@@ -77,7 +77,7 @@ function PartyById() {
     void navigate({
       to: "/party/$partyId",
       params: { partyId },
-      search: { tab: tab as "expenses" | "balances" },
+      search: { tab: tab as PartyByIdSearchParams["tab"] },
       replace: true,
     });
   }
@@ -132,7 +132,7 @@ function PartyById() {
   const participantName = participant.name;
 
   function onTogglePersonalMode() {
-    setParticipantDetails(participant.id, {
+    void setParticipantDetails(participant.id, {
       personalMode: !participant.personalMode,
     });
   }
@@ -270,6 +270,18 @@ function PartyById() {
                     <Trans>See spending totals and rankings</Trans>
                   </span>
                 </div>
+              </MenuItem>
+
+              <MenuItem
+                href={{
+                  to: "/party/$partyId/log",
+                  params: { partyId },
+                }}
+              >
+                <Icon icon="lucide.history" width={20} height={20} className="mr-3" />
+                <span className="h-3.5 leading-none">
+                  <Trans>Log</Trans>
+                </span>
               </MenuItem>
 
               <MenuItem

--- a/packages/pwa/src/routes/party_.$partyId.log.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.log.tsx
@@ -1,0 +1,266 @@
+import { Trans } from "@lingui/react/macro";
+import { t } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { createFileRoute } from "@tanstack/react-router";
+import type { Currency } from "dinero.js";
+import { BackButton } from "#src/components/BackButton.tsx";
+import { CurrencyText } from "#src/components/CurrencyText.tsx";
+import { useCurrentParty, useParty } from "#src/hooks/useParty.ts";
+import { documentCache, useSuspenseDocument } from "#src/lib/automerge/suspense-hooks.ts";
+import { guardParticipatingInParty } from "#src/lib/guards.ts";
+import { ensurePartyActivityLog } from "#src/models/partyActivity.ts";
+import type {
+  Party,
+  PartyActivityLog,
+  PartyActivityLogEntry,
+  PartyActivityParticipantChange,
+  PartyActivitySettingsChange,
+} from "#src/models/party.ts";
+import { Icon } from "#src/ui/Icon.tsx";
+import { PartyPendingComponent } from "#src/components/PartyPendingComponent.tsx";
+
+export const Route = createFileRoute("/party_/$partyId/log")({
+  component: PartyLogRoute,
+  pendingComponent: PartyPendingComponent,
+  loader: async ({ context, params: { partyId }, location }) => {
+    const { party } = await guardParticipatingInParty(partyId, context, location);
+    const partyHandle = await context.repo.find<Party>(party.id);
+    const activityLogHandle = await ensurePartyActivityLog(context.repo, partyHandle);
+
+    await documentCache.readAsync(context.repo, activityLogHandle.documentId);
+  },
+});
+
+function PartyLogRoute() {
+  const { partyId } = Route.useParams();
+  const { party } = useParty(partyId);
+  const activityLogId = party.activityLogId;
+
+  return (
+    <div className="flex h-[100dvh] max-h-[100dvh] min-h-0 flex-col">
+      <div className="container flex h-16 flex-shrink-0 items-center px-2 mt-safe">
+        <BackButton
+          fallbackOptions={{
+            to: "/party/$partyId",
+            params: { partyId },
+          }}
+        />
+
+        <h1 className="max-h-12 truncate px-4 text-xl font-medium">
+          <Trans>Log</Trans>
+        </h1>
+      </div>
+
+      {activityLogId ? <PartyActivityLogDocument activityLogId={activityLogId} /> : null}
+    </div>
+  );
+}
+
+function PartyActivityLogDocument({ activityLogId }: { activityLogId: PartyActivityLog["id"] }) {
+  const { party } = useCurrentParty();
+  const { i18n } = useLingui();
+  const [activityLog] = useSuspenseDocument<PartyActivityLog>(activityLogId, {
+    required: true,
+  });
+  const entries = activityLog.entries;
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="container flex flex-col gap-3 px-2 py-4">
+        {entries.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-accent-300 p-6 text-center dark:border-accent-700">
+            <Icon icon="lucide.history" className="mx-auto mb-3 text-accent-500" />
+            <p className="font-medium">
+              <Trans>No log entries yet</Trans>
+            </p>
+            <p className="mt-2 text-sm text-accent-700 dark:text-accent-300">
+              <Trans>Changes made from now on will show up here.</Trans>
+            </p>
+          </div>
+        ) : (
+          entries.map((entry) => (
+            <ActivityLogItem
+              key={entry.id}
+              currency={party.currency}
+              entry={entry}
+              locale={i18n.locale}
+            />
+          ))
+        )}
+      </div>
+
+      <div className="h-8 flex-shrink-0" />
+    </div>
+  );
+}
+
+function ActivityLogItem({
+  currency,
+  entry,
+  locale,
+}: {
+  currency: Currency;
+  entry: PartyActivityLogEntry;
+  locale: string;
+}) {
+  const icon = getActivityLogIcon(entry);
+  const createdAt = new Date(entry.createdAt);
+
+  return (
+    <article className="rounded-lg bg-white p-4 text-start dark:bg-accent-900">
+      <div className="flex gap-3">
+        <div className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-800 dark:text-accent-200">
+          <Icon icon={icon} width={18} height={18} aria-hidden="true" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <h3 className="font-medium text-accent-950 dark:text-accent-50">
+            <ActivityLogTitle entry={entry} />
+          </h3>
+
+          <p className="mt-1 text-sm text-accent-700 dark:text-accent-300">
+            {createdAt.toLocaleString(locale)}
+          </p>
+
+          <ActivityLogDetails entry={entry} currency={currency} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ActivityLogTitle({ entry }: { entry: PartyActivityLogEntry }) {
+  const participantName = "participantName" in entry ? entry.participantName : "";
+
+  switch (entry.type) {
+    case "party-created":
+      return <Trans>Party created</Trans>;
+    case "party-settings-updated":
+      return <Trans>Party settings updated</Trans>;
+    case "participant-added":
+      return <Trans>{participantName} was added</Trans>;
+    case "participant-updated":
+      return <Trans>{participantName} was updated</Trans>;
+    case "participant-archived":
+      return <Trans>{participantName} was archived</Trans>;
+    case "participant-restored":
+      return <Trans>{participantName} was restored</Trans>;
+    case "participant-removed":
+      return <Trans>{participantName} was removed</Trans>;
+    case "expense-added":
+      return <Trans>Expense added</Trans>;
+    case "expense-updated":
+      return <Trans>Expense updated</Trans>;
+    case "expense-removed":
+      return <Trans>Expense deleted</Trans>;
+    case "debt-transferred":
+      return <Trans>Debt transferred</Trans>;
+  }
+}
+
+function ActivityLogDetails({
+  currency,
+  entry,
+}: {
+  currency: Currency;
+  entry: PartyActivityLogEntry;
+}) {
+  const partyName = "partyName" in entry ? entry.partyName : "";
+
+  switch (entry.type) {
+    case "party-created":
+      return (
+        <p className="mt-2 text-sm">
+          <Trans>{partyName} started tracking shared expenses.</Trans>
+        </p>
+      );
+    case "party-settings-updated":
+      return <ActivityLogChangeList changes={entry.changes.map(getSettingsChangeLabel)} />;
+    case "participant-updated":
+      return <ActivityLogChangeList changes={entry.changes.map(getParticipantChangeLabel)} />;
+    case "expense-added":
+    case "expense-updated":
+    case "expense-removed":
+      return (
+        <p className="mt-2 text-sm">
+          <span className="font-medium">{entry.expenseName}</span>
+          {" - "}
+          <CurrencyText amount={entry.amount} currency={currency} />
+        </p>
+      );
+    case "debt-transferred":
+      return (
+        <p className="mt-2 text-sm">
+          <span className="font-medium">{entry.originExpenseName}</span>
+          {" - "}
+          <CurrencyText amount={entry.amount} currency={currency} />
+        </p>
+      );
+    case "participant-added":
+    case "participant-archived":
+    case "participant-restored":
+    case "participant-removed":
+      return null;
+  }
+}
+
+function ActivityLogChangeList({ changes }: { changes: string[] }) {
+  return (
+    <ul className="mt-2 flex flex-wrap gap-2 text-sm">
+      {changes.map((change) => (
+        <li key={change} className="rounded-md bg-accent-100 px-2 py-1 dark:bg-accent-800">
+          {change}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function getSettingsChangeLabel(change: PartyActivitySettingsChange) {
+  switch (change) {
+    case "name":
+      return t`Name`;
+    case "symbol":
+      return t`Symbol`;
+    case "description":
+      return t`Description`;
+  }
+}
+
+function getParticipantChangeLabel(change: PartyActivityParticipantChange) {
+  switch (change) {
+    case "name":
+      return t`Name`;
+    case "phone":
+      return t`Phone`;
+    case "avatar":
+      return t`Avatar`;
+  }
+}
+
+function getActivityLogIcon(entry: PartyActivityLogEntry) {
+  switch (entry.type) {
+    case "party-created":
+      return "lucide.sparkles";
+    case "party-settings-updated":
+      return "lucide.settings";
+    case "participant-added":
+      return "lucide.user-plus";
+    case "participant-updated":
+      return "lucide.user-round-pen";
+    case "participant-archived":
+      return "lucide.archive";
+    case "participant-restored":
+      return "lucide.archive-restore";
+    case "participant-removed":
+      return "lucide.user-minus";
+    case "expense-added":
+      return "lucide.list-plus";
+    case "expense-updated":
+      return "lucide.pencil";
+    case "expense-removed":
+      return "lucide.trash";
+    case "debt-transferred":
+      return "lucide.corner-down-right";
+  }
+}

--- a/packages/pwa/src/routes/party_.$partyId.settings.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.settings.tsx
@@ -39,7 +39,7 @@ function PartySettings() {
   const params = Route.useParams();
   const { party, updateSettings } = useParty(params.partyId);
 
-  function onSaveSettings(values: PartySettingsFormValues) {
+  async function onSaveSettings(values: PartySettingsFormValues) {
     const participants = values.participants
       .map((participant): PartyParticipant => {
         if ("__isNew" in participant) {
@@ -56,7 +56,7 @@ function PartySettings() {
         return result;
       }, {});
 
-    updateSettings({
+    await updateSettings({
       name: values.name,
       symbol: values.symbol,
       description: values.description,
@@ -73,8 +73,8 @@ function PartySettings() {
       description: party.description,
       participants: Object.values(party.participants),
     } as PartySettingsFormValues,
-    onSubmit: ({ value }) => {
-      onSaveSettings(value);
+    onSubmit: async ({ value }) => {
+      await onSaveSettings(value);
     },
   });
 

--- a/packages/pwa/src/routes/party_.$partyId.who.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.who.tsx
@@ -58,7 +58,7 @@ function Who() {
     addPartyToList(party.id, participant.id);
 
     if (needsToJoin) {
-      setParticipantDetails(participant.id, {
+      void setParticipantDetails(participant.id, {
         phone: partyList.phone,
         avatarId: partyList.avatarId,
       });


### PR DESCRIPTION
## Description

Adds a party Log screen that records and displays a readable history of party operations over time.

The log is stored in a separate Automerge `partyActivityLog` document referenced by the party document, so accumulated history does not grow the main party document. The party three-dot menu now links to the dedicated Log screen.

The log currently records:

- party creation
- party settings updates
- participant additions, profile updates, archiving, restoration, and removal
- expense additions, updates, and deletions
- debt transfers between parties

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [ ] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [ ] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not attached in this draft. Browser smoke testing verified the three-dot menu opens the dedicated Log screen, and that `Party created` plus `Expense added` entries render after creating a sample party and expense.

## Additional Notes

`vp run build` passes from `packages/pwa`. The full workspace `vp run build` previously reached the mobile iOS sync step and failed locally because Bundler 2.7.2 is not installed for `packages/mobile/ios/App/Gemfile.lock`.
