### PR TITLE
fix(release): attach raw Android mobile assets

### DIFF
--- a/.changeset/android-release-assets.md
+++ b/.changeset/android-release-assets.md
@@ -1,0 +1,5 @@
+---
+"@trizum/mobile": patch
+---
+
+Attach Android GitHub release assets as raw APK and AAB files.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,19 +134,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download signed APK artifact
         uses: actions/download-artifact@v8
         with:
           name: android-release-apk
           path: release-assets/apk
-          skip-decompress: false
 
       - name: Download signed AAB artifact
         uses: actions/download-artifact@v8
         with:
           name: android-playstore-aab
           path: release-assets/aab
-          skip-decompress: false
 
       - name: Attach Android release assets
         env:
@@ -168,5 +168,4 @@ jobs:
           gh release upload "$RELEASE_TAG" \
             "trizum-mobile-${version}-signed.apk" \
             "trizum-mobile-${version}-signed.aab" \
-            --repo "$GITHUB_REPOSITORY" \
             --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,12 +139,14 @@ jobs:
         with:
           name: android-release-apk
           path: release-assets/apk
+          skip-decompress: false
 
       - name: Download signed AAB artifact
         uses: actions/download-artifact@v8
         with:
           name: android-playstore-aab
           path: release-assets/aab
+          skip-decompress: false
 
       - name: Attach Android release assets
         env:
@@ -166,4 +168,5 @@ jobs:
           gh release upload "$RELEASE_TAG" \
             "trizum-mobile-${version}-signed.apk" \
             "trizum-mobile-${version}-signed.aab" \
+            --repo "$GITHUB_REPOSITORY" \
             --clobber


### PR DESCRIPTION
## Description

Fix the mobile release attach job that failed while publishing Android release assets. The attach job now checks out the repository before downloading the signed APK and AAB artifacts, so `gh release upload` has normal git repository context. The downloaded artifacts are extracted by `actions/download-artifact` and copied to stable `.apk` and `.aab` release asset names before upload.

This also adds a patch changeset for `@trizum/mobile`.

## Related Issues

None. Related failed release job: https://github.com/HorusGoul/trizum/actions/runs/27237290634/job/80433812254

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [ ] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

N/A.

## Additional Notes

`vp run build` was attempted and failed locally during iOS dependency sync because system Ruby could not find Bundler `2.7.2`, which is required by `packages/mobile/ios/App/Gemfile.lock`. The PWA build and Android sync completed before that iOS `pod install` failure.

`vp exec changeset status` reports a patch bump for both `@trizum/mobile` and `@trizum/pwa` because the Changesets config keeps those packages in a fixed version group.
