### PR TITLE
fix(mobile): disable iOS phased release

### DIFF
--- a/.changeset/immediate-ios-releases.md
+++ b/.changeset/immediate-ios-releases.md
@@ -1,0 +1,5 @@
+---
+"@trizum/mobile": patch
+---
+
+Configure iOS App Store releases to roll out immediately instead of using phased release.

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -330,8 +330,8 @@ Published, non-prerelease GitHub releases tagged as `@trizum/mobile@*` also
 trigger the shared release workflow. That path reuses the mobile build and
 store deployment workflows to generate store screenshots, publish Android to the
 Play Store production track with `release_status` `completed`, submit iOS to
-App Store review with `automatic_release` enabled, and attach the signed Android
-APK and AAB to the GitHub release.
+App Store review with immediate rollout and `automatic_release` enabled, and
+attach the signed Android APK and AAB to the GitHub release.
 
 ### Required Secrets
 

--- a/packages/mobile/ios/App/fastlane/Deliverfile
+++ b/packages/mobile/ios/App/fastlane/Deliverfile
@@ -11,8 +11,8 @@ screenshots_path "./fastlane/screenshots"
 # App Rating configuration
 app_rating_config_path "./fastlane/rating_config.json"
 
-# Phased release (gradual rollout over 7 days)
-phased_release true
+# Immediate release (no phased rollout)
+phased_release false
 
 # Precheck settings (validates before upload)
 precheck_include_in_app_purchases false

--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -289,7 +289,7 @@ platform :ios do
       force: true,
       submit_for_review: false,
       automatic_release: false,
-      phased_release: true,
+      phased_release: false,
       run_precheck_before_submit: !submit_for_review,
       precheck_include_in_app_purchases: false,
       overwrite_screenshots: true,
@@ -352,7 +352,7 @@ platform :ios do
       app_version: app_version,
       submit_for_review: true,
       automatic_release: options[:automatic_release] || false,
-      phased_release: true,
+      phased_release: false,
       run_precheck_before_submit: true,
       precheck_include_in_app_purchases: false,
       submission_information: app_store_submission_information
@@ -409,7 +409,7 @@ platform :ios do
       app_version: build.app_version,
       submit_for_review: true,
       automatic_release: options[:automatic_release] || false,
-      phased_release: true,
+      phased_release: false,
       run_precheck_before_submit: true,
       precheck_include_in_app_purchases: false,
       submission_information: app_store_submission_information


### PR DESCRIPTION
## Description

Configures iOS App Store releases to roll out immediately instead of using App Store phased release. The change updates the Fastlane Deliverfile default and every App Store submission path in the iOS Fastfile so metadata upload, direct review submission, and processed-build submission all pass `phased_release: false`.

The mobile release docs now describe the immediate rollout behavior, and a patch changeset records the release behavior fix.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this PR does not change UI.

## Additional Notes

`vp run build` was rerun as `mise exec -- vp run build` after installing Bundler 2.7.2 in the repo-managed Ruby, matching the mobile package setup instructions. The commit hook also ran `vp check --fix` and `vp run lingui:extract`.