### PR TITLE
chore(server): add fly production release workflow

### DIFF
--- a/.changeset/shaky-bags-march.md
+++ b/.changeset/shaky-bags-march.md
@@ -1,0 +1,5 @@
+---
+"@trizum/server": patch
+---
+
+Server releases through CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
       cancel-in-progress: false
     environment:
       name: server-production
-      url: https://trizum-server.fly.dev
+      url: https://server.trizum.app
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,32 @@ jobs:
           packageManager: npm
           workingDirectory: packages/pwa
 
+  deploy-server-production:
+    name: Deploy Server Production
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, '@trizum/server@') && !github.event.release.prerelease
+    permissions:
+      contents: read
+      deployments: write
+    concurrency:
+      group: server-production
+      cancel-in-progress: false
+    environment:
+      name: server-production
+      url: https://trizum-server.fly.dev
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: Deploy Server to Fly.io
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: ./packages/server/deploy.sh
+
   build-mobile-android-release-apk:
     name: Build Mobile Android Release APK
     if: github.event_name == 'release' && startsWith(github.event.release.tag_name, '@trizum/mobile@') && !github.event.release.prerelease

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -29,3 +29,29 @@ and [`package.json`](./package.json):
 
 - `vp run check`
 - `vp run dev` or `vp run start` when validating runtime behavior
+
+## Deployment
+
+Production deploys are managed by the repo `Release` GitHub Actions workflow.
+When Changesets publishes a non-prerelease `@trizum/server@...` GitHub release,
+the workflow deploys the tagged server revision to Fly.io. Backend preview
+environments are intentionally unsupported.
+
+The workflow requires one GitHub repository or `server-production` environment
+secret:
+
+- `FLY_API_TOKEN`: a Fly app-scoped deploy token for the `trizum-server` app.
+  Create it with `fly tokens create deploy --app trizum-server --name "GitHub Actions server production" --expiry <duration>`.
+
+The Fly app also needs runtime secrets configured with `fly secrets set --app
+trizum-server`:
+
+- `BUCKET_NAME`
+- `AWS_ENDPOINT_URL_S3`
+- `AWS_REGION`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `SENTRY_DSN` when Sentry should be enabled in production
+
+`DB_FILE_NAME`, `PORT`, and the persistent volume mount are configured in
+[`fly.toml`](./fly.toml).

--- a/packages/server/deploy.sh
+++ b/packages/server/deploy.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
 # Deploy to Fly.io from monorepo root
 # This ensures the build context includes all workspace files
 cd "$(dirname "$0")/../.." || exit 1
 
-COMMIT_HASH=$(git rev-parse --short HEAD)
+COMMIT_HASH="$(git rev-parse --short HEAD)"
 
-fly deploy --config packages/server/fly.toml --env COMMIT_HASH="$COMMIT_HASH"
+flyctl deploy --config packages/server/fly.toml --env COMMIT_HASH="$COMMIT_HASH" --remote-only


### PR DESCRIPTION
## Description

- Adds a production-only server deploy job to the Release workflow for non-prerelease `@trizum/server@...` releases.
- Uses Fly.io via `superfly/flyctl-actions/setup-flyctl@v1` and the existing server deploy script.
- Updates the server deploy script to use `flyctl deploy --remote-only` and documents required GitHub/Fly secrets.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [x] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [ ] I've added tests for new functionality (if applicable)
- [ ] I've run `vp run lingui:extract` (if I added new strings)
- [ ] I've added a changeset (if this is a user-facing change)

## Screenshots

N/A.

## Additional Notes

Other change type: CI/release automation.

No changeset was added because this is internal release infrastructure and documentation, not a user-facing product change.

Required GitHub secret: `FLY_API_TOKEN`. Fly runtime secrets are documented in `packages/server/README.md`.

Validation also included `git diff --check`, `sh -n packages/server/deploy.sh`, and a YAML parse of `.github/workflows/release.yml`.
