### PR TITLE
fix(server): include prepare files in Docker build

### DIFF
--- a/.changeset/tall-buses-fix.md
+++ b/.changeset/tall-buses-fix.md
@@ -1,0 +1,5 @@
+---
+"@trizum/server": patch
+---
+
+Fix the server Docker image build so releases can install workspace dependencies before packaging the runtime.

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -22,6 +22,8 @@ WORKDIR /app
 
 # Copy workspace configuration files from monorepo root
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY AGENTS.md ./
+COPY scripts/apply-vite-plus-agent-overrides.mjs ./scripts/apply-vite-plus-agent-overrides.mjs
 
 # Copy workspace manifests before sources so dependency install stays cached.
 COPY packages/icon-sprite/package.json ./packages/icon-sprite/package.json


### PR DESCRIPTION
## Description

Fixes the server Fly.io Docker image build by copying the root files required by the workspace `prepare` lifecycle before `vp install` runs in the image build stage.

The failed release job showed `vp install --frozen-lockfile` running `node scripts/apply-vite-plus-agent-overrides.mjs` from `/app`, but the Dockerfile had only copied root package metadata and workspace package manifests at that point. The helper script was missing, so the build failed before server sources were copied.

This PR copies `AGENTS.md` and `scripts/apply-vite-plus-agent-overrides.mjs` into the build stage before dependency installation. Those are the only root files the prepare helper needs.

## Related Issues

Related to failing release job: https://github.com/HorusGoul/trizum/actions/runs/27483397984/job/81234983832

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this is a Docker build fix.

## Additional Notes

Validation performed:

- Reproduced the failing Docker install layer locally in `/tmp` with the same partial file layout from the Dockerfile; it failed with the same missing `scripts/apply-vite-plus-agent-overrides.mjs` error.
- Re-ran that install-layer reproduction after the fix; `vp install --frozen-lockfile` passed.
- Ran `vp run --filter @trizum/logging build`.
- Ran `vp pack` in `packages/server`.
- Ran `vp run check`.
- Ran `vp run test`.
- Ran `vp run build`.
- Ran `vp exec changeset status`.

A full `docker build` was not available locally because the Docker daemon is not running in this environment.
