### PR TITLE
chore(release): split PWA production deploy workflow

### DIFF
--- a/.github/workflows/pwa-production-deploy.yml
+++ b/.github/workflows/pwa-production-deploy.yml
@@ -1,0 +1,67 @@
+name: PWA Production Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref, tag, or SHA to deploy"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref, tag, or SHA to deploy"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: pwa-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy PWA Production
+    runs-on: ubuntu-latest
+    environment:
+      name: pwa-production
+      url: https://trizum.app
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+
+      - name: Build PWA
+        run: vp run --filter @trizum/pwa build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Apply PWA D1 migrations
+        working-directory: packages/pwa
+        run: vp exec wrangler d1 migrations apply DB --remote
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Deploy PWA to Cloudflare
+        id: deploy
+        uses: cloudflare/wrangler-action@v4
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          packageManager: npm
+          workingDirectory: packages/pwa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,53 +51,14 @@ jobs:
 
   deploy-pwa-production:
     name: Deploy PWA Production
-    runs-on: ubuntu-latest
     if: github.event_name == 'release' && startsWith(github.event.release.tag_name, '@trizum/pwa@') && !github.event.release.prerelease
     permissions:
       contents: read
       deployments: write
-    concurrency:
-      group: pwa-production
-      cancel-in-progress: false
-    environment:
-      name: pwa-production
-      url: https://trizum.app
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version-file: ".node-version"
-          cache: true
-
-      - name: Build PWA
-        run: vp run --filter @trizum/pwa build
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-      - name: Apply PWA D1 migrations
-        working-directory: packages/pwa
-        run: vp exec wrangler d1 migrations apply DB --remote
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-
-      - name: Deploy PWA to Cloudflare
-        id: deploy
-        uses: cloudflare/wrangler-action@v4
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          packageManager: npm
-          workingDirectory: packages/pwa
+    uses: ./.github/workflows/pwa-production-deploy.yml
+    with:
+      ref: ${{ github.event.release.tag_name }}
+    secrets: inherit
 
   deploy-server-production:
     name: Deploy Server Production


### PR DESCRIPTION
## Description

Extracts the PWA production deployment into `.github/workflows/pwa-production-deploy.yml`.

The release workflow now calls that reusable workflow for published `@trizum/pwa@` release tags, and the standalone workflow can also be run manually with a required git ref, tag, or SHA input.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (describe below)

Release workflow maintenance.

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable) - Not applicable; workflow-only change.
- [x] I've run `vp run lingui:extract` (if I added new strings) - No user-facing strings were added; the commit hook also ran extraction.
- [x] I've added a changeset (if this is a user-facing change) - Not applicable; release automation only.

## Screenshots

Not applicable.

## Additional Notes

Also validated the two workflow files with `actionlint` 1.7.12 from the upstream release binary.
