### PR TITLE
fix(release): fetch full history for Sentry builds

### DIFF
--- a/.github/workflows/android-internal-testing.yml
+++ b/.github/workflows/android-internal-testing.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: voidzero-dev/setup-vp@v1

--- a/.github/workflows/android-playstore-deploy.yml
+++ b/.github/workflows/android-playstore-deploy.yml
@@ -57,6 +57,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           - test
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/ios-appstore-deploy.yml
+++ b/.github/workflows/ios-appstore-deploy.yml
@@ -50,6 +50,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: voidzero-dev/setup-vp@v1

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -69,6 +69,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: ".node-version"
@@ -156,6 +158,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/pwa-production-deploy.yml
+++ b/.github/workflows/pwa-production-deploy.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           ref: ${{ inputs.ref }}
 
       - uses: voidzero-dev/setup-vp@v1


### PR DESCRIPTION
## Description

Fixes Sentry release commit association failures like:

`Could not find the SHA of the previous release in the git history. If you limit the clone depth, try to increase it.`

Workflows that run `@trizum/pwa` builds with `SENTRY_AUTH_TOKEN` now checkout full git history using `fetch-depth: 0`, so Sentry can resolve the previous release SHA while keeping `setCommits.auto` enabled.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable) - Not applicable; workflow-only fix.
- [x] I've run `vp run lingui:extract` (if I added new strings) - No strings were added; the commit hook also ran extraction.
- [x] I've added a changeset (if this is a user-facing change) - Not applicable; CI/release workflow fix.

## Screenshots

Not applicable.

## Additional Notes

Also validated the changed workflow files with `actionlint` 1.7.12.
