### PR TITLE
fix(pwa): ignore missing Sentry release commits

### DIFF
--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -238,6 +238,7 @@ export default defineConfig(({ mode }) => {
                 name: fullVersion,
                 setCommits: {
                   auto: true,
+                  ignoreMissing: true,
                 },
                 inject: true,
               },


### PR DESCRIPTION
## Description

Fixes the remaining Sentry release commit association error seen in run `27947951163`:

`Could not find the SHA of the previous release in the git history.`

That run already used `fetch-depth: 0`, so the remaining issue is that Sentry's previous release commit is not recoverable from the repository history. This keeps `setCommits.auto` enabled but adds `ignoreMissing: true`, matching the Sentry CLI's recommended `--ignore-missing` behavior for this case.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable) - Not applicable; Sentry build configuration change.
- [x] I've run `vp run lingui:extract` (if I added new strings) - No strings were added; the commit hook also ran extraction.
- [x] I've added a changeset (if this is a user-facing change) - Not applicable; release observability configuration only.

## Screenshots

Not applicable.

## Additional Notes

Local validation confirms the option is accepted by the installed Sentry Vite plugin types. The authenticated Sentry `set-commits` request still needs to be verified by a GitHub Actions run with `SENTRY_AUTH_TOKEN` available.
