### PR TITLE
fix(pwa): show auth linking callback errors

### DIFF
--- a/.changeset/cloud-link-errors.md
+++ b/.changeset/cloud-link-errors.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Show trizum cloud account-linking errors in a dialog, including OAuth email mismatch errors.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -79,7 +79,7 @@ msgstr "Accent color"
 msgid "Account created"
 msgstr "Account created"
 
-#: src/routes/settings_.cloud-sync.tsx:605
+#: src/routes/settings_.cloud-sync.tsx:615
 msgid "Account deleted"
 msgstr "Account deleted"
 
@@ -108,7 +108,7 @@ msgstr "Add"
 msgid "Add an expense"
 msgstr "Add an expense"
 
-#: src/routes/settings_.cloud-sync.tsx:855
+#: src/routes/settings_.cloud-sync.tsx:865
 msgid "Add Apple as a sign-in method"
 msgstr "Add Apple as a sign-in method"
 
@@ -116,7 +116,7 @@ msgstr "Add Apple as a sign-in method"
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Add expenses to this party to unlock totals, rankings, and individual spend."
 
-#: src/routes/settings_.cloud-sync.tsx:874
+#: src/routes/settings_.cloud-sync.tsx:884
 msgid "Add Google as a sign-in method"
 msgstr "Add Google as a sign-in method"
 
@@ -186,7 +186,7 @@ msgstr "Amount must be greater than 0"
 msgid "Angolan Kwanza"
 msgstr "Angolan Kwanza"
 
-#: src/routes/settings_.cloud-sync.tsx:851
+#: src/routes/settings_.cloud-sync.tsx:861
 msgid "Apple"
 msgstr "Apple"
 
@@ -194,7 +194,7 @@ msgstr "Apple"
 msgid "Apple connected"
 msgstr "Apple connected"
 
-#: src/routes/settings_.cloud-sync.tsx:854
+#: src/routes/settings_.cloud-sync.tsx:864
 msgid "Apple is connected to this account"
 msgstr "Apple is connected to this account"
 
@@ -263,11 +263,14 @@ msgstr "Attachments"
 msgid "Australian Dollar"
 msgstr "Australian Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:401
-#: src/routes/settings_.cloud-sync.tsx:415
-#: src/routes/settings_.cloud-sync.tsx:432
-#: src/routes/settings_.cloud-sync.tsx:440
-#: src/routes/settings_.cloud-sync.tsx:1641
+#: src/routes/settings_.cloud-sync.tsx:1065
+msgid "Authentication error"
+msgstr "Authentication error"
+
+#: src/routes/settings_.cloud-sync.tsx:411
+#: src/routes/settings_.cloud-sync.tsx:425
+#: src/routes/settings_.cloud-sync.tsx:442
+#: src/routes/settings_.cloud-sync.tsx:450
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
@@ -301,11 +304,11 @@ msgid "Back to home"
 msgstr "Back to home"
 
 #: src/routes/reset-password.tsx:102
-#: src/routes/settings_.cloud-sync.tsx:1047
+#: src/routes/settings_.cloud-sync.tsx:1142
 msgid "Back to settings"
 msgstr "Back to settings"
 
-#: src/routes/settings_.cloud-sync.tsx:675
+#: src/routes/settings_.cloud-sync.tsx:685
 msgid "Back to sign in"
 msgstr "Back to sign in"
 
@@ -441,8 +444,8 @@ msgstr "Can't add an expense to a party that doesn't exist"
 msgid "Canadian Dollar"
 msgstr "Canadian Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:1429
-#: src/routes/settings_.cloud-sync.tsx:1597
+#: src/routes/settings_.cloud-sync.tsx:1524
+#: src/routes/settings_.cloud-sync.tsx:1692
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -478,11 +481,11 @@ msgstr "Changes sync automatically across all your devices"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/routes/settings_.cloud-sync.tsx:482
+#: src/routes/settings_.cloud-sync.tsx:492
 msgid "Check your email for the password link"
 msgstr "Check your email for the password link"
 
-#: src/routes/settings_.cloud-sync.tsx:371
+#: src/routes/settings_.cloud-sync.tsx:381
 msgid "Check your email for the sign-in link"
 msgstr "Check your email for the sign-in link"
 
@@ -583,7 +586,7 @@ msgstr "Complete your profile"
 msgid "Configure Profile"
 msgstr "Configure Profile"
 
-#: src/routes/settings_.cloud-sync.tsx:1380
+#: src/routes/settings_.cloud-sync.tsx:1475
 msgid "Confirm action"
 msgstr "Confirm action"
 
@@ -593,7 +596,7 @@ msgstr "Confirm action"
 msgid "Confirm transfer"
 msgstr "Confirm transfer"
 
-#: src/routes/settings_.cloud-sync.tsx:1572
+#: src/routes/settings_.cloud-sync.tsx:1667
 msgid "Confirmation"
 msgstr "Confirmation"
 
@@ -610,15 +613,15 @@ msgstr "Congolese Franc"
 msgid "Connect"
 msgstr "Connect"
 
-#: src/routes/settings_.cloud-sync.tsx:1458
+#: src/routes/settings_.cloud-sync.tsx:1553
 msgid "Connect Apple"
 msgstr "Connect Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:1465
+#: src/routes/settings_.cloud-sync.tsx:1560
 msgid "Connect Apple?"
 msgstr "Connect Apple?"
 
-#: src/routes/settings_.cloud-sync.tsx:1469
+#: src/routes/settings_.cloud-sync.tsx:1564
 msgid "Connect Google"
 msgstr "Connect Google"
 
@@ -626,12 +629,12 @@ msgstr "Connect Google"
 msgid "Connect Google, Apple, or a password to the same account."
 msgstr "Connect Google, Apple, or a password to the same account."
 
-#: src/routes/settings_.cloud-sync.tsx:1476
+#: src/routes/settings_.cloud-sync.tsx:1571
 msgid "Connect Google?"
 msgstr "Connect Google?"
 
-#: src/routes/settings_.cloud-sync.tsx:857
-#: src/routes/settings_.cloud-sync.tsx:876
+#: src/routes/settings_.cloud-sync.tsx:867
+#: src/routes/settings_.cloud-sync.tsx:886
 msgid "Connected"
 msgstr "Connected"
 
@@ -644,7 +647,7 @@ msgstr "Connected to this account"
 msgid "Connected: {linkedProviderLabels}"
 msgstr "Connected: {linkedProviderLabels}"
 
-#: src/routes/settings_.cloud-sync.tsx:848
+#: src/routes/settings_.cloud-sync.tsx:858
 msgid "Connections"
 msgstr "Connections"
 
@@ -652,11 +655,11 @@ msgstr "Connections"
 msgid "Contact Us"
 msgstr "Contact Us"
 
-#: src/routes/settings_.cloud-sync.tsx:699
+#: src/routes/settings_.cloud-sync.tsx:709
 msgid "Continue with Apple"
 msgstr "Continue with Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:714
+#: src/routes/settings_.cloud-sync.tsx:724
 msgid "Continue with Google"
 msgstr "Continue with Google"
 
@@ -680,11 +683,11 @@ msgstr "Costa Rican Colón"
 msgid "Could not apply cloud settings"
 msgstr "Could not apply cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:468
+#: src/routes/settings_.cloud-sync.tsx:478
 msgid "Could not connect sign-in method"
 msgstr "Could not connect sign-in method"
 
-#: src/routes/settings_.cloud-sync.tsx:611
+#: src/routes/settings_.cloud-sync.tsx:621
 msgid "Could not delete account"
 msgstr "Could not delete account"
 
@@ -696,7 +699,7 @@ msgstr "Could not load cloud settings"
 msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
-#: src/routes/settings_.cloud-sync.tsx:254
+#: src/routes/settings_.cloud-sync.tsx:256
 #: src/routes/settings.tsx:388
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
@@ -709,17 +712,21 @@ msgstr "Could not reset password"
 msgid "Could not save cloud settings"
 msgstr "Could not save cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:485
+#: src/routes/settings_.cloud-sync.tsx:495
 msgid "Could not send password email"
 msgstr "Could not send password email"
 
-#: src/routes/settings_.cloud-sync.tsx:374
+#: src/routes/settings_.cloud-sync.tsx:384
 msgid "Could not send sign-in link"
 msgstr "Could not send sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:533
+#: src/routes/settings_.cloud-sync.tsx:543
 msgid "Could not sign out"
 msgstr "Could not sign out"
+
+#: src/lib/authCallbackErrors.ts:22
+msgid "Couldn't connect sign-in method"
+msgstr "Couldn't connect sign-in method"
 
 #: src/routes/index.tsx:221
 #: src/routes/index.tsx:369
@@ -819,13 +826,13 @@ msgstr "Decimal point"
 msgid "Delete"
 msgstr "Delete"
 
-#: src/routes/settings_.cloud-sync.tsx:923
-#: src/routes/settings_.cloud-sync.tsx:1551
-#: src/routes/settings_.cloud-sync.tsx:1586
+#: src/routes/settings_.cloud-sync.tsx:933
+#: src/routes/settings_.cloud-sync.tsx:1646
+#: src/routes/settings_.cloud-sync.tsx:1681
 msgid "Delete account"
 msgstr "Delete account"
 
-#: src/routes/settings_.cloud-sync.tsx:1557
+#: src/routes/settings_.cloud-sync.tsx:1652
 msgid "Delete account?"
 msgstr "Delete account?"
 
@@ -842,7 +849,7 @@ msgstr "Description must be less than 500 characters"
 msgid "Destination party"
 msgstr "Destination party"
 
-#: src/routes/settings_.cloud-sync.tsx:920
+#: src/routes/settings_.cloud-sync.tsx:930
 msgid "Destructive actions"
 msgstr "Destructive actions"
 
@@ -882,14 +889,14 @@ msgstr "Editing {expenseName}"
 msgid "Egyptian Pound"
 msgstr "Egyptian Pound"
 
-#: src/routes/settings_.cloud-sync.tsx:647
-#: src/routes/settings_.cloud-sync.tsx:733
-#: src/routes/settings_.cloud-sync.tsx:799
-#: src/routes/settings_.cloud-sync.tsx:892
+#: src/routes/settings_.cloud-sync.tsx:657
+#: src/routes/settings_.cloud-sync.tsx:743
+#: src/routes/settings_.cloud-sync.tsx:809
+#: src/routes/settings_.cloud-sync.tsx:902
 msgid "Email"
 msgstr "Email"
 
-#: src/routes/settings_.cloud-sync.tsx:902
+#: src/routes/settings_.cloud-sync.tsx:912
 msgid "Email a password reset link"
 msgstr "Email a password reset link"
 
@@ -897,19 +904,23 @@ msgstr "Email a password reset link"
 msgid "Email a password setup link"
 msgstr "Email a password setup link"
 
+#: src/lib/authCallbackErrors.ts:12
+msgid "Email addresses don't match"
+msgstr "Email addresses don't match"
+
 #: src/routes/settings_.cloud-sync.tsx:901
 msgid "Email link"
 msgstr "Email link"
 
-#: src/routes/settings_.cloud-sync.tsx:810
+#: src/routes/settings_.cloud-sync.tsx:820
 msgid "Email me a sign-in link"
 msgstr "Email me a sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:1480
+#: src/routes/settings_.cloud-sync.tsx:1575
 msgid "Email password link"
 msgstr "Email password link"
 
-#: src/routes/settings_.cloud-sync.tsx:1493
+#: src/routes/settings_.cloud-sync.tsx:1588
 msgid "Email password link?"
 msgstr "Email password link?"
 
@@ -1085,8 +1096,8 @@ msgstr "Fijian Dollar"
 msgid "Filter totals and rankings"
 msgstr "Filter totals and rankings"
 
-#: src/routes/settings_.cloud-sync.tsx:1099
-#: src/routes/settings_.cloud-sync.tsx:1110
+#: src/routes/settings_.cloud-sync.tsx:1194
+#: src/routes/settings_.cloud-sync.tsx:1205
 msgid "Finishing sign in"
 msgstr "Finishing sign in"
 
@@ -1094,7 +1105,7 @@ msgstr "Finishing sign in"
 msgid "For payments through Bizum or similar services"
 msgstr "For payments through Bizum or similar services"
 
-#: src/routes/settings_.cloud-sync.tsx:788
+#: src/routes/settings_.cloud-sync.tsx:798
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
@@ -1147,7 +1158,7 @@ msgstr "Go back to home"
 msgid "Gold (troy ounce)"
 msgstr "Gold (troy ounce)"
 
-#: src/routes/settings_.cloud-sync.tsx:870
+#: src/routes/settings_.cloud-sync.tsx:880
 msgid "Google"
 msgstr "Google"
 
@@ -1155,9 +1166,13 @@ msgstr "Google"
 msgid "Google connected"
 msgstr "Google connected"
 
-#: src/routes/settings_.cloud-sync.tsx:873
+#: src/routes/settings_.cloud-sync.tsx:883
 msgid "Google is connected to this account"
 msgstr "Google is connected to this account"
+
+#: src/routes/settings_.cloud-sync.tsx:1090
+msgid "Got it"
+msgstr "Got it"
 
 #: src/routes/about.tsx:38
 msgid "Group expense sharing made simple. Track, split and settle shared costs effortlessly."
@@ -1783,7 +1798,7 @@ msgstr "Optional description for this expense"
 msgid "or enter code"
 msgstr "or enter code"
 
-#: src/routes/settings_.cloud-sync.tsx:721
+#: src/routes/settings_.cloud-sync.tsx:731
 msgid "or use email"
 msgstr "or use email"
 
@@ -1913,12 +1928,12 @@ msgstr "Party stats"
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
-#: src/routes/settings_.cloud-sync.tsx:743
-#: src/routes/settings_.cloud-sync.tsx:899
+#: src/routes/settings_.cloud-sync.tsx:753
+#: src/routes/settings_.cloud-sync.tsx:909
 msgid "Password"
 msgstr "Password"
 
-#: src/routes/settings_.cloud-sync.tsx:483
+#: src/routes/settings_.cloud-sync.tsx:493
 msgid "Password email sent"
 msgstr "Password email sent"
 
@@ -1963,7 +1978,7 @@ msgstr "Pay"
 msgid "People that owe you money"
 msgstr "People that owe you money"
 
-#: src/routes/settings_.cloud-sync.tsx:924
+#: src/routes/settings_.cloud-sync.tsx:934
 msgid "Permanently delete your trizum cloud account"
 msgstr "Permanently delete your trizum cloud account"
 
@@ -2183,7 +2198,7 @@ msgstr "Search emoji"
 msgid "Search emoji..."
 msgstr "Search emoji..."
 
-#: src/routes/settings_.cloud-sync.tsx:889
+#: src/routes/settings_.cloud-sync.tsx:899
 msgid "Security"
 msgstr "Security"
 
@@ -2195,7 +2210,7 @@ msgstr "See spending totals and rankings"
 msgid "Select emoji"
 msgstr "Select emoji"
 
-#: src/routes/settings_.cloud-sync.tsx:663
+#: src/routes/settings_.cloud-sync.tsx:673
 msgid "Send password link"
 msgstr "Send password link"
 
@@ -2211,11 +2226,11 @@ msgstr "Serbian Dinar"
 msgid "Set up"
 msgstr "Set up"
 
-#: src/routes/settings_.cloud-sync.tsx:902
+#: src/routes/settings_.cloud-sync.tsx:912
 msgid "Set up password sign-in"
 msgstr "Set up password sign-in"
 
-#: src/routes/settings_.cloud-sync.tsx:1493
+#: src/routes/settings_.cloud-sync.tsx:1588
 msgid "Set up password?"
 msgstr "Set up password?"
 
@@ -2275,50 +2290,54 @@ msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amoun
 msgid "Sierra Leonean Leone"
 msgstr "Sierra Leonean Leone"
 
-#: src/routes/settings_.cloud-sync.tsx:1043
+#: src/routes/settings_.cloud-sync.tsx:1138
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/routes/settings_.cloud-sync.tsx:1630
+#: src/routes/settings_.cloud-sync.tsx:1725
 msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
-#: src/routes/settings_.cloud-sync.tsx:1063
+#: src/routes/settings_.cloud-sync.tsx:1158
 msgid "Sign in to trizum cloud"
 msgstr "Sign in to trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:775
+#: src/routes/settings_.cloud-sync.tsx:785
 msgid "Sign in with magic link"
 msgstr "Sign in with magic link"
 
-#: src/routes/settings_.cloud-sync.tsx:760
-#: src/routes/settings_.cloud-sync.tsx:825
+#: src/routes/settings_.cloud-sync.tsx:770
+#: src/routes/settings_.cloud-sync.tsx:835
 msgid "Sign in with password"
 msgstr "Sign in with password"
 
-#: src/routes/settings_.cloud-sync.tsx:911
-#: src/routes/settings_.cloud-sync.tsx:996
-#: src/routes/settings_.cloud-sync.tsx:1497
+#: src/routes/settings_.cloud-sync.tsx:921
+#: src/routes/settings_.cloud-sync.tsx:1022
+#: src/routes/settings_.cloud-sync.tsx:1592
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/routes/settings_.cloud-sync.tsx:1504
+#: src/routes/settings_.cloud-sync.tsx:1599
 msgid "Sign out?"
 msgstr "Sign out?"
+
+#: src/lib/authCallbackErrors.ts:17
+msgid "Sign-in link expired"
+msgstr "Sign-in link expired"
 
 #: src/routes/settings_.cloud-sync.tsx:1639
 msgid "Sign-in link is invalid or expired"
 msgstr "Sign-in link is invalid or expired"
 
-#: src/routes/settings_.cloud-sync.tsx:372
+#: src/routes/settings_.cloud-sync.tsx:382
 msgid "Sign-in link sent"
 msgstr "Sign-in link sent"
 
-#: src/routes/settings_.cloud-sync.tsx:466
+#: src/routes/settings_.cloud-sync.tsx:476
 msgid "Sign-in method connected"
 msgstr "Sign-in method connected"
 
-#: src/routes/settings_.cloud-sync.tsx:412
+#: src/routes/settings_.cloud-sync.tsx:422
 msgid "Sign-in method is not configured"
 msgstr "Sign-in method is not configured"
 
@@ -2326,14 +2345,14 @@ msgstr "Sign-in method is not configured"
 msgid "Sign-in methods"
 msgstr "Sign-in methods"
 
-#: src/routes/settings_.cloud-sync.tsx:406
-#: src/routes/settings_.cloud-sync.tsx:436
-#: src/routes/settings_.cloud-sync.tsx:894
-#: src/routes/settings_.cloud-sync.tsx:1179
+#: src/routes/settings_.cloud-sync.tsx:416
+#: src/routes/settings_.cloud-sync.tsx:446
+#: src/routes/settings_.cloud-sync.tsx:904
+#: src/routes/settings_.cloud-sync.tsx:1274
 msgid "Signed in"
 msgstr "Signed in"
 
-#: src/routes/settings_.cloud-sync.tsx:530
+#: src/routes/settings_.cloud-sync.tsx:540
 msgid "Signed out"
 msgstr "Signed out"
 
@@ -2410,7 +2429,7 @@ msgstr "Start tracking expenses with your group"
 msgid "Stats"
 msgstr "Stats"
 
-#: src/routes/settings_.cloud-sync.tsx:912
+#: src/routes/settings_.cloud-sync.tsx:922
 msgid "Stop trizum cloud on this device"
 msgstr "Stop trizum cloud on this device"
 
@@ -2563,11 +2582,11 @@ msgstr "This application uses the following open source libraries and tools. Bel
 msgid "This debt is no longer available"
 msgstr "This debt is no longer available"
 
-#: src/routes/settings_.cloud-sync.tsx:978
+#: src/routes/settings_.cloud-sync.tsx:1004
 msgid "This device already has local trizum data. Using trizum cloud here will switch this device to your cloud data, and the local list on this device will stop being used."
 msgstr "This device already has local trizum data. Using trizum cloud here will switch this device to your cloud data, and the local list on this device will stop being used."
 
-#: src/routes/settings_.cloud-sync.tsx:551
+#: src/routes/settings_.cloud-sync.tsx:561
 msgid "This device is already using trizum cloud"
 msgstr "This device is already using trizum cloud"
 
@@ -2587,7 +2606,7 @@ msgstr "This isn't a valid ID"
 msgid "This party needs another active participant besides you to receive the transferred debt."
 msgstr "This party needs another active participant besides you to receive the transferred debt."
 
-#: src/routes/settings_.cloud-sync.tsx:1560
+#: src/routes/settings_.cloud-sync.tsx:1655
 msgid "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 msgstr "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 
@@ -2595,7 +2614,11 @@ msgstr "This permanently deletes your trizum cloud account, sign-in methods, and
 msgid "This project uses various open source libraries and tools."
 msgstr "This project uses various open source libraries and tools."
 
-#: src/routes/settings_.cloud-sync.tsx:1499
+#: src/lib/authCallbackErrors.ts:18
+msgid "This sign-in link is invalid or expired. Request a new link and try again."
+msgstr "This sign-in link is invalid or expired. Request a new link and try again."
+
+#: src/routes/settings_.cloud-sync.tsx:1594
 msgid "This stops trizum cloud on this device. Your local data stays on this device."
 msgstr "This stops trizum cloud on this device. Your local data stays on this device."
 
@@ -2615,6 +2638,10 @@ msgstr "Title is required"
 #: src/lib/validation.ts:27
 msgid "Title must be less than 50 characters"
 msgstr "Title must be less than 50 characters"
+
+#: src/lib/authCallbackErrors.ts:13
+msgid "To connect Google or Apple, choose an account with the same email address as your trizum cloud account."
+msgstr "To connect Google or Apple, choose an account with the same email address as your trizum cloud account."
 
 #: src/routes/party_.$partyId.who.tsx:134
 msgid "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
@@ -2674,38 +2701,42 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:843
+#: src/routes/settings_.cloud-sync.tsx:853
 #: src/routes/settings.tsx:216
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:221
-#: src/routes/settings_.cloud-sync.tsx:546
+#: src/routes/settings_.cloud-sync.tsx:223
+#: src/routes/settings_.cloud-sync.tsx:556
 msgid "trizum cloud data is invalid"
 msgstr "trizum cloud data is invalid"
 
-#: src/routes/settings_.cloud-sync.tsx:242
-#: src/routes/settings_.cloud-sync.tsx:565
+#: src/routes/settings_.cloud-sync.tsx:244
+#: src/routes/settings_.cloud-sync.tsx:575
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud enabled on this device"
 
-#: src/routes/settings_.cloud-sync.tsx:541
+#: src/routes/settings_.cloud-sync.tsx:551
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud is not set up yet"
 
-#: src/routes/settings_.cloud-sync.tsx:204
+#: src/routes/settings_.cloud-sync.tsx:206
 msgid "trizum cloud started"
 msgstr "trizum cloud started"
+
+#: src/lib/authCallbackErrors.ts:23
+msgid "trizum could not finish connecting that sign-in method. Please try again."
+msgstr "trizum could not finish connecting that sign-in method. Please try again."
 
 #: src/routes/support.tsx:93
 msgid "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 msgstr "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 
-#: src/routes/settings_.cloud-sync.tsx:1460
+#: src/routes/settings_.cloud-sync.tsx:1555
 msgid "trizum will open Apple so you can add it as a sign-in method for this account."
 msgstr "trizum will open Apple so you can add it as a sign-in method for this account."
 
-#: src/routes/settings_.cloud-sync.tsx:1471
+#: src/routes/settings_.cloud-sync.tsx:1566
 msgid "trizum will open Google so you can add it as a sign-in method for this account."
 msgstr "trizum will open Google so you can add it as a sign-in method for this account."
 
@@ -2714,7 +2745,7 @@ msgstr "trizum will open Google so you can add it as a sign-in method for this a
 msgid "Try again"
 msgstr "Try again"
 
-#: src/routes/settings_.cloud-sync.tsx:1149
+#: src/routes/settings_.cloud-sync.tsx:1244
 msgid "Try another email"
 msgstr "Try another email"
 
@@ -2738,7 +2769,7 @@ msgstr "Turkish Lira"
 msgid "Turkmenistani Manat"
 msgstr "Turkmenistani Manat"
 
-#: src/routes/settings_.cloud-sync.tsx:1570
+#: src/routes/settings_.cloud-sync.tsx:1665
 msgid "Type \"delete account\" to confirm."
 msgstr "Type \"delete account\" to confirm."
 
@@ -2839,7 +2870,7 @@ msgstr "US Dollar"
 msgid "US Dollar (Next day)"
 msgstr "US Dollar (Next day)"
 
-#: src/routes/settings_.cloud-sync.tsx:993
+#: src/routes/settings_.cloud-sync.tsx:1019
 msgid "Use cloud data"
 msgstr "Use cloud data"
 
@@ -2855,7 +2886,7 @@ msgstr "Use it on this device to continue with your cloud data."
 msgid "Use personal mode to filter only your expenses."
 msgstr "Use personal mode to filter only your expenses."
 
-#: src/routes/settings_.cloud-sync.tsx:975
+#: src/routes/settings_.cloud-sync.tsx:1001
 msgid "Use trizum cloud on this device?"
 msgstr "Use trizum cloud on this device?"
 
@@ -2920,15 +2951,15 @@ msgstr "Viewing as {participantName}"
 msgid "Warning: Split amounts don't match total expense"
 msgstr "Warning: Split amounts don't match total expense"
 
-#: src/routes/settings_.cloud-sync.tsx:1143
+#: src/routes/settings_.cloud-sync.tsx:1238
 msgid "We sent a sign-in link to {email}. Open it to finish signing in."
 msgstr "We sent a sign-in link to {email}. Open it to finish signing in."
 
-#: src/routes/settings_.cloud-sync.tsx:1482
+#: src/routes/settings_.cloud-sync.tsx:1577
 msgid "We will email a password link to {email}. Your current password keeps working until you change it."
 msgstr "We will email a password link to {email}. Your current password keeps working until you change it."
 
-#: src/routes/settings_.cloud-sync.tsx:1487
+#: src/routes/settings_.cloud-sync.tsx:1582
 msgid "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 msgstr "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -75,7 +75,7 @@ msgstr "Color de acento"
 msgid "Account created"
 msgstr "Cuenta creada"
 
-#: src/routes/settings_.cloud-sync.tsx:605
+#: src/routes/settings_.cloud-sync.tsx:615
 msgid "Account deleted"
 msgstr "Cuenta eliminada"
 
@@ -104,7 +104,7 @@ msgstr "Sumar"
 msgid "Add an expense"
 msgstr "Añadir un gasto"
 
-#: src/routes/settings_.cloud-sync.tsx:855
+#: src/routes/settings_.cloud-sync.tsx:865
 msgid "Add Apple as a sign-in method"
 msgstr "Añadir Apple como método de inicio de sesión"
 
@@ -112,7 +112,7 @@ msgstr "Añadir Apple como método de inicio de sesión"
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto individual."
 
-#: src/routes/settings_.cloud-sync.tsx:874
+#: src/routes/settings_.cloud-sync.tsx:884
 msgid "Add Google as a sign-in method"
 msgstr "Añadir Google como método de inicio de sesión"
 
@@ -178,7 +178,7 @@ msgstr "La cantidad debe ser mayor que 0"
 msgid "Angolan Kwanza"
 msgstr "Kwanza Angoleño"
 
-#: src/routes/settings_.cloud-sync.tsx:851
+#: src/routes/settings_.cloud-sync.tsx:861
 msgid "Apple"
 msgstr "Apple"
 
@@ -186,7 +186,7 @@ msgstr "Apple"
 msgid "Apple connected"
 msgstr "Apple conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:854
+#: src/routes/settings_.cloud-sync.tsx:864
 msgid "Apple is connected to this account"
 msgstr "Apple está conectado a esta cuenta"
 
@@ -251,11 +251,14 @@ msgstr "Adjuntos"
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
-#: src/routes/settings_.cloud-sync.tsx:401
-#: src/routes/settings_.cloud-sync.tsx:415
-#: src/routes/settings_.cloud-sync.tsx:432
-#: src/routes/settings_.cloud-sync.tsx:440
-#: src/routes/settings_.cloud-sync.tsx:1641
+#: src/routes/settings_.cloud-sync.tsx:1065
+msgid "Authentication error"
+msgstr "Error de autenticación"
+
+#: src/routes/settings_.cloud-sync.tsx:411
+#: src/routes/settings_.cloud-sync.tsx:425
+#: src/routes/settings_.cloud-sync.tsx:442
+#: src/routes/settings_.cloud-sync.tsx:450
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
@@ -289,11 +292,11 @@ msgid "Back to home"
 msgstr "Volver al inicio"
 
 #: src/routes/reset-password.tsx:102
-#: src/routes/settings_.cloud-sync.tsx:1047
+#: src/routes/settings_.cloud-sync.tsx:1142
 msgid "Back to settings"
 msgstr "Volver a configuración"
 
-#: src/routes/settings_.cloud-sync.tsx:675
+#: src/routes/settings_.cloud-sync.tsx:685
 msgid "Back to sign in"
 msgstr "Volver a iniciar sesión"
 
@@ -421,8 +424,8 @@ msgstr "¿Puedo usar trizum sin una cuenta?"
 msgid "Canadian Dollar"
 msgstr "Dólar Canadiense"
 
-#: src/routes/settings_.cloud-sync.tsx:1429
-#: src/routes/settings_.cloud-sync.tsx:1597
+#: src/routes/settings_.cloud-sync.tsx:1524
+#: src/routes/settings_.cloud-sync.tsx:1692
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -458,11 +461,11 @@ msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
-#: src/routes/settings_.cloud-sync.tsx:482
+#: src/routes/settings_.cloud-sync.tsx:492
 msgid "Check your email for the password link"
 msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:371
+#: src/routes/settings_.cloud-sync.tsx:381
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
@@ -559,7 +562,7 @@ msgstr "Completa tu perfil"
 msgid "Configure Profile"
 msgstr "Configurar perfil"
 
-#: src/routes/settings_.cloud-sync.tsx:1380
+#: src/routes/settings_.cloud-sync.tsx:1475
 msgid "Confirm action"
 msgstr "Confirmar acción"
 
@@ -569,7 +572,7 @@ msgstr "Confirmar acción"
 msgid "Confirm transfer"
 msgstr "Confirmar transferencia"
 
-#: src/routes/settings_.cloud-sync.tsx:1572
+#: src/routes/settings_.cloud-sync.tsx:1667
 msgid "Confirmation"
 msgstr "Confirmación"
 
@@ -586,15 +589,15 @@ msgstr "Franco Congoleño"
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/routes/settings_.cloud-sync.tsx:1458
+#: src/routes/settings_.cloud-sync.tsx:1553
 msgid "Connect Apple"
 msgstr "Conectar Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:1465
+#: src/routes/settings_.cloud-sync.tsx:1560
 msgid "Connect Apple?"
 msgstr "¿Conectar Apple?"
 
-#: src/routes/settings_.cloud-sync.tsx:1469
+#: src/routes/settings_.cloud-sync.tsx:1564
 msgid "Connect Google"
 msgstr "Conectar Google"
 
@@ -602,12 +605,12 @@ msgstr "Conectar Google"
 msgid "Connect Google, Apple, or a password to the same account."
 msgstr "Conecta Google, Apple o una contraseña a la misma cuenta."
 
-#: src/routes/settings_.cloud-sync.tsx:1476
+#: src/routes/settings_.cloud-sync.tsx:1571
 msgid "Connect Google?"
 msgstr "¿Conectar Google?"
 
-#: src/routes/settings_.cloud-sync.tsx:857
-#: src/routes/settings_.cloud-sync.tsx:876
+#: src/routes/settings_.cloud-sync.tsx:867
+#: src/routes/settings_.cloud-sync.tsx:886
 msgid "Connected"
 msgstr "Conectado"
 
@@ -620,7 +623,7 @@ msgstr "Conectado a esta cuenta"
 msgid "Connected: {linkedProviderLabels}"
 msgstr "Conectado: {linkedProviderLabels}"
 
-#: src/routes/settings_.cloud-sync.tsx:848
+#: src/routes/settings_.cloud-sync.tsx:858
 msgid "Connections"
 msgstr "Conexiones"
 
@@ -628,11 +631,11 @@ msgstr "Conexiones"
 msgid "Contact Us"
 msgstr "Contacto"
 
-#: src/routes/settings_.cloud-sync.tsx:699
+#: src/routes/settings_.cloud-sync.tsx:709
 msgid "Continue with Apple"
 msgstr "Continuar con Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:714
+#: src/routes/settings_.cloud-sync.tsx:724
 msgid "Continue with Google"
 msgstr "Continuar con Google"
 
@@ -656,11 +659,11 @@ msgstr "Colón Costarricense"
 msgid "Could not apply cloud settings"
 msgstr "No se pudo aplicar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:468
+#: src/routes/settings_.cloud-sync.tsx:478
 msgid "Could not connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:611
+#: src/routes/settings_.cloud-sync.tsx:621
 msgid "Could not delete account"
 msgstr "No se pudo eliminar la cuenta"
 
@@ -672,7 +675,7 @@ msgstr "No se pudo cargar la configuración en la nube"
 msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:254
+#: src/routes/settings_.cloud-sync.tsx:256
 #: src/routes/settings.tsx:388
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
@@ -685,17 +688,21 @@ msgstr "No se pudo restablecer la contraseña"
 msgid "Could not save cloud settings"
 msgstr "No se pudo guardar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:485
+#: src/routes/settings_.cloud-sync.tsx:495
 msgid "Could not send password email"
 msgstr "No se pudo enviar el correo de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:374
+#: src/routes/settings_.cloud-sync.tsx:384
 msgid "Could not send sign-in link"
 msgstr "No se pudo enviar el enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:533
+#: src/routes/settings_.cloud-sync.tsx:543
 msgid "Could not sign out"
 msgstr "No se pudo cerrar sesión"
+
+#: src/lib/authCallbackErrors.ts:22
+msgid "Couldn't connect sign-in method"
+msgstr "No se pudo conectar el método de inicio de sesión"
 
 #: src/routes/index.tsx:221
 #: src/routes/index.tsx:369
@@ -791,13 +798,13 @@ msgstr "Punto decimal"
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/routes/settings_.cloud-sync.tsx:923
-#: src/routes/settings_.cloud-sync.tsx:1551
-#: src/routes/settings_.cloud-sync.tsx:1586
+#: src/routes/settings_.cloud-sync.tsx:933
+#: src/routes/settings_.cloud-sync.tsx:1646
+#: src/routes/settings_.cloud-sync.tsx:1681
 msgid "Delete account"
 msgstr "Eliminar cuenta"
 
-#: src/routes/settings_.cloud-sync.tsx:1557
+#: src/routes/settings_.cloud-sync.tsx:1652
 msgid "Delete account?"
 msgstr "¿Eliminar cuenta?"
 
@@ -814,7 +821,7 @@ msgstr "La descripción debe tener menos de 500 caracteres"
 msgid "Destination party"
 msgstr "Grupo de destino"
 
-#: src/routes/settings_.cloud-sync.tsx:920
+#: src/routes/settings_.cloud-sync.tsx:930
 msgid "Destructive actions"
 msgstr "Acciones destructivas"
 
@@ -854,14 +861,14 @@ msgstr "Editando {expenseName}"
 msgid "Egyptian Pound"
 msgstr "Libra Egipcia"
 
-#: src/routes/settings_.cloud-sync.tsx:647
-#: src/routes/settings_.cloud-sync.tsx:733
-#: src/routes/settings_.cloud-sync.tsx:799
-#: src/routes/settings_.cloud-sync.tsx:892
+#: src/routes/settings_.cloud-sync.tsx:657
+#: src/routes/settings_.cloud-sync.tsx:743
+#: src/routes/settings_.cloud-sync.tsx:809
+#: src/routes/settings_.cloud-sync.tsx:902
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: src/routes/settings_.cloud-sync.tsx:902
+#: src/routes/settings_.cloud-sync.tsx:912
 msgid "Email a password reset link"
 msgstr "Enviar un enlace para restablecer la contraseña"
 
@@ -869,19 +876,23 @@ msgstr "Enviar un enlace para restablecer la contraseña"
 msgid "Email a password setup link"
 msgstr "Enviar un enlace para configurar la contraseña"
 
+#: src/lib/authCallbackErrors.ts:12
+msgid "Email addresses don't match"
+msgstr "Los correos no coinciden"
+
 #: src/routes/settings_.cloud-sync.tsx:901
 msgid "Email link"
 msgstr "Enviar enlace"
 
-#: src/routes/settings_.cloud-sync.tsx:810
+#: src/routes/settings_.cloud-sync.tsx:820
 msgid "Email me a sign-in link"
 msgstr "Enviarme un enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1480
+#: src/routes/settings_.cloud-sync.tsx:1575
 msgid "Email password link"
 msgstr "Enviar enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:1493
+#: src/routes/settings_.cloud-sync.tsx:1588
 msgid "Email password link?"
 msgstr "¿Enviar enlace de contraseña?"
 
@@ -1041,8 +1052,8 @@ msgstr "Dólar Fiyiano"
 msgid "Filter totals and rankings"
 msgstr "Filtra totales y rankings"
 
-#: src/routes/settings_.cloud-sync.tsx:1099
-#: src/routes/settings_.cloud-sync.tsx:1110
+#: src/routes/settings_.cloud-sync.tsx:1194
+#: src/routes/settings_.cloud-sync.tsx:1205
 msgid "Finishing sign in"
 msgstr "Terminando el inicio de sesión"
 
@@ -1050,7 +1061,7 @@ msgstr "Terminando el inicio de sesión"
 msgid "For payments through Bizum or similar services"
 msgstr "Para pagos mediante Bizum o servicios similares"
 
-#: src/routes/settings_.cloud-sync.tsx:788
+#: src/routes/settings_.cloud-sync.tsx:798
 msgid "Forgot password?"
 msgstr "¿Olvidaste tu contraseña?"
 
@@ -1103,7 +1114,7 @@ msgstr "Volver al inicio"
 msgid "Gold (troy ounce)"
 msgstr "Oro (onza troy)"
 
-#: src/routes/settings_.cloud-sync.tsx:870
+#: src/routes/settings_.cloud-sync.tsx:880
 msgid "Google"
 msgstr "Google"
 
@@ -1111,9 +1122,13 @@ msgstr "Google"
 msgid "Google connected"
 msgstr "Google conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:873
+#: src/routes/settings_.cloud-sync.tsx:883
 msgid "Google is connected to this account"
 msgstr "Google está conectado a esta cuenta"
+
+#: src/routes/settings_.cloud-sync.tsx:1090
+msgid "Got it"
+msgstr "Entendido"
 
 #: src/routes/new.tsx:476
 msgid "Guatemalan Quetzal"
@@ -1723,7 +1738,7 @@ msgstr "Abrir paréntesis"
 msgid "or enter code"
 msgstr "o introduce código"
 
-#: src/routes/settings_.cloud-sync.tsx:721
+#: src/routes/settings_.cloud-sync.tsx:731
 msgid "or use email"
 msgstr "o usa el correo"
 
@@ -1845,12 +1860,12 @@ msgstr "Estadísticas del grupo"
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
-#: src/routes/settings_.cloud-sync.tsx:743
-#: src/routes/settings_.cloud-sync.tsx:899
+#: src/routes/settings_.cloud-sync.tsx:753
+#: src/routes/settings_.cloud-sync.tsx:909
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:483
+#: src/routes/settings_.cloud-sync.tsx:493
 msgid "Password email sent"
 msgstr "Correo de contraseña enviado"
 
@@ -1895,7 +1910,7 @@ msgstr "Pagar"
 msgid "People that owe you money"
 msgstr "Personas que te deben dinero"
 
-#: src/routes/settings_.cloud-sync.tsx:924
+#: src/routes/settings_.cloud-sync.tsx:934
 msgid "Permanently delete your trizum cloud account"
 msgstr "Eliminar permanentemente tu cuenta de trizum cloud"
 
@@ -2111,7 +2126,7 @@ msgstr "Buscar emoji"
 msgid "Search emoji..."
 msgstr "Buscar emoji..."
 
-#: src/routes/settings_.cloud-sync.tsx:889
+#: src/routes/settings_.cloud-sync.tsx:899
 msgid "Security"
 msgstr "Seguridad"
 
@@ -2123,7 +2138,7 @@ msgstr "Ver totales y clasificación de gasto"
 msgid "Select emoji"
 msgstr "Seleccionar emoji"
 
-#: src/routes/settings_.cloud-sync.tsx:663
+#: src/routes/settings_.cloud-sync.tsx:673
 msgid "Send password link"
 msgstr "Enviar enlace de contraseña"
 
@@ -2139,11 +2154,11 @@ msgstr "Dinar Serbio"
 msgid "Set up"
 msgstr "Configurar"
 
-#: src/routes/settings_.cloud-sync.tsx:902
+#: src/routes/settings_.cloud-sync.tsx:912
 msgid "Set up password sign-in"
 msgstr "Configurar inicio de sesión con contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:1493
+#: src/routes/settings_.cloud-sync.tsx:1588
 msgid "Set up password?"
 msgstr "¿Configurar contraseña?"
 
@@ -2203,50 +2218,54 @@ msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantida
 msgid "Sierra Leonean Leone"
 msgstr "Leone de Sierra Leona"
 
-#: src/routes/settings_.cloud-sync.tsx:1043
+#: src/routes/settings_.cloud-sync.tsx:1138
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1630
+#: src/routes/settings_.cloud-sync.tsx:1725
 msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
-#: src/routes/settings_.cloud-sync.tsx:1063
+#: src/routes/settings_.cloud-sync.tsx:1158
 msgid "Sign in to trizum cloud"
 msgstr "Iniciar sesión en trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:775
+#: src/routes/settings_.cloud-sync.tsx:785
 msgid "Sign in with magic link"
 msgstr "Iniciar sesión con enlace mágico"
 
-#: src/routes/settings_.cloud-sync.tsx:760
-#: src/routes/settings_.cloud-sync.tsx:825
+#: src/routes/settings_.cloud-sync.tsx:770
+#: src/routes/settings_.cloud-sync.tsx:835
 msgid "Sign in with password"
 msgstr "Iniciar sesión con contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:911
-#: src/routes/settings_.cloud-sync.tsx:996
-#: src/routes/settings_.cloud-sync.tsx:1497
+#: src/routes/settings_.cloud-sync.tsx:921
+#: src/routes/settings_.cloud-sync.tsx:1022
+#: src/routes/settings_.cloud-sync.tsx:1592
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1504
+#: src/routes/settings_.cloud-sync.tsx:1599
 msgid "Sign out?"
 msgstr "¿Cerrar sesión?"
+
+#: src/lib/authCallbackErrors.ts:17
+msgid "Sign-in link expired"
+msgstr "El enlace de inicio de sesión ha caducado"
 
 #: src/routes/settings_.cloud-sync.tsx:1639
 msgid "Sign-in link is invalid or expired"
 msgstr "El enlace de inicio de sesión no es válido o ha caducado"
 
-#: src/routes/settings_.cloud-sync.tsx:372
+#: src/routes/settings_.cloud-sync.tsx:382
 msgid "Sign-in link sent"
 msgstr "Enlace de inicio de sesión enviado"
 
-#: src/routes/settings_.cloud-sync.tsx:466
+#: src/routes/settings_.cloud-sync.tsx:476
 msgid "Sign-in method connected"
 msgstr "Método de inicio de sesión conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:412
+#: src/routes/settings_.cloud-sync.tsx:422
 msgid "Sign-in method is not configured"
 msgstr "El método de inicio de sesión no está configurado"
 
@@ -2254,14 +2273,14 @@ msgstr "El método de inicio de sesión no está configurado"
 msgid "Sign-in methods"
 msgstr "Métodos de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:406
-#: src/routes/settings_.cloud-sync.tsx:436
-#: src/routes/settings_.cloud-sync.tsx:894
-#: src/routes/settings_.cloud-sync.tsx:1179
+#: src/routes/settings_.cloud-sync.tsx:416
+#: src/routes/settings_.cloud-sync.tsx:446
+#: src/routes/settings_.cloud-sync.tsx:904
+#: src/routes/settings_.cloud-sync.tsx:1274
 msgid "Signed in"
 msgstr "Sesión iniciada"
 
-#: src/routes/settings_.cloud-sync.tsx:530
+#: src/routes/settings_.cloud-sync.tsx:540
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
@@ -2334,7 +2353,7 @@ msgstr "Comienza a registrar gastos con tu grupo"
 msgid "Stats"
 msgstr "Estadísticas"
 
-#: src/routes/settings_.cloud-sync.tsx:912
+#: src/routes/settings_.cloud-sync.tsx:922
 msgid "Stop trizum cloud on this device"
 msgstr "Detener trizum cloud en este dispositivo"
 
@@ -2487,11 +2506,11 @@ msgstr "Esta aplicación utiliza las siguientes bibliotecas y herramientas de c�
 msgid "This debt is no longer available"
 msgstr "Esta deuda ya no está disponible"
 
-#: src/routes/settings_.cloud-sync.tsx:978
+#: src/routes/settings_.cloud-sync.tsx:1004
 msgid "This device already has local trizum data. Using trizum cloud here will switch this device to your cloud data, and the local list on this device will stop being used."
 msgstr "Este dispositivo ya tiene datos locales de trizum. Si usas trizum cloud aquí, este dispositivo cambiará a tus datos en la nube y dejará de usar la lista local de este dispositivo."
 
-#: src/routes/settings_.cloud-sync.tsx:551
+#: src/routes/settings_.cloud-sync.tsx:561
 msgid "This device is already using trizum cloud"
 msgstr "Este dispositivo ya usa trizum cloud"
 
@@ -2511,7 +2530,7 @@ msgstr "Este no es un ID válido"
 msgid "This party needs another active participant besides you to receive the transferred debt."
 msgstr "Este grupo necesita otro participante activo además de ti para recibir la deuda transferida."
 
-#: src/routes/settings_.cloud-sync.tsx:1560
+#: src/routes/settings_.cloud-sync.tsx:1655
 msgid "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 msgstr "Esto elimina permanentemente tu cuenta de trizum cloud, los métodos de inicio de sesión y la configuración en la nube. Tus datos locales en este dispositivo se conservarán."
 
@@ -2519,7 +2538,11 @@ msgstr "Esto elimina permanentemente tu cuenta de trizum cloud, los métodos de 
 msgid "This project uses various open source libraries and tools."
 msgstr "Este proyecto utiliza varias bibliotecas y herramientas de código abierto."
 
-#: src/routes/settings_.cloud-sync.tsx:1499
+#: src/lib/authCallbackErrors.ts:18
+msgid "This sign-in link is invalid or expired. Request a new link and try again."
+msgstr "Este enlace de inicio de sesión no es válido o ha caducado. Solicita un enlace nuevo e inténtalo de nuevo."
+
+#: src/routes/settings_.cloud-sync.tsx:1594
 msgid "This stops trizum cloud on this device. Your local data stays on this device."
 msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se quedan en este dispositivo."
 
@@ -2539,6 +2562,10 @@ msgstr "Se requiere un título"
 #: src/lib/validation.ts:27
 msgid "Title must be less than 50 characters"
 msgstr "El título debe tener menos de 50 caracteres"
+
+#: src/lib/authCallbackErrors.ts:13
+msgid "To connect Google or Apple, choose an account with the same email address as your trizum cloud account."
+msgstr "Para conectar Google o Apple, elige una cuenta con el mismo correo que tu cuenta de trizum cloud."
 
 #: src/routes/party_.$partyId.who.tsx:134
 msgid "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
@@ -2586,38 +2613,42 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/settings_.cloud-sync.tsx:843
+#: src/routes/settings_.cloud-sync.tsx:853
 #: src/routes/settings.tsx:216
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:221
-#: src/routes/settings_.cloud-sync.tsx:546
+#: src/routes/settings_.cloud-sync.tsx:223
+#: src/routes/settings_.cloud-sync.tsx:556
 msgid "trizum cloud data is invalid"
 msgstr "Los datos de trizum cloud no son válidos"
 
-#: src/routes/settings_.cloud-sync.tsx:242
-#: src/routes/settings_.cloud-sync.tsx:565
+#: src/routes/settings_.cloud-sync.tsx:244
+#: src/routes/settings_.cloud-sync.tsx:575
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud activado en este dispositivo"
 
-#: src/routes/settings_.cloud-sync.tsx:541
+#: src/routes/settings_.cloud-sync.tsx:551
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud todavía no está configurado"
 
-#: src/routes/settings_.cloud-sync.tsx:204
+#: src/routes/settings_.cloud-sync.tsx:206
 msgid "trizum cloud started"
 msgstr "trizum cloud iniciado"
+
+#: src/lib/authCallbackErrors.ts:23
+msgid "trizum could not finish connecting that sign-in method. Please try again."
+msgstr "trizum no pudo terminar de conectar ese método de inicio de sesión. Inténtalo de nuevo."
 
 #: src/routes/support.tsx:93
 msgid "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 msgstr "trizum almacena todos tus datos localmente en tu dispositivo. Cuando estás conectado y compartes un grupo con otros, los cambios se sincronizan automáticamente en todos los dispositivos en tiempo real."
 
-#: src/routes/settings_.cloud-sync.tsx:1460
+#: src/routes/settings_.cloud-sync.tsx:1555
 msgid "trizum will open Apple so you can add it as a sign-in method for this account."
 msgstr "trizum abrirá Apple para que puedas añadirlo como método de inicio de sesión para esta cuenta."
 
-#: src/routes/settings_.cloud-sync.tsx:1471
+#: src/routes/settings_.cloud-sync.tsx:1566
 msgid "trizum will open Google so you can add it as a sign-in method for this account."
 msgstr "trizum abrirá Google para que puedas añadirlo como método de inicio de sesión para esta cuenta."
 
@@ -2626,7 +2657,7 @@ msgstr "trizum abrirá Google para que puedas añadirlo como método de inicio d
 msgid "Try again"
 msgstr "Reintentar"
 
-#: src/routes/settings_.cloud-sync.tsx:1149
+#: src/routes/settings_.cloud-sync.tsx:1244
 msgid "Try another email"
 msgstr "Probar con otro email"
 
@@ -2650,7 +2681,7 @@ msgstr "Lira Turca"
 msgid "Turkmenistani Manat"
 msgstr "Manat Turkmeno"
 
-#: src/routes/settings_.cloud-sync.tsx:1570
+#: src/routes/settings_.cloud-sync.tsx:1665
 msgid "Type \"delete account\" to confirm."
 msgstr "Escribe \"delete account\" para confirmar."
 
@@ -2742,7 +2773,7 @@ msgstr "Dólar Estadounidense"
 msgid "US Dollar (Next day)"
 msgstr "Dólar Estadounidense (Día siguiente)"
 
-#: src/routes/settings_.cloud-sync.tsx:993
+#: src/routes/settings_.cloud-sync.tsx:1019
 msgid "Use cloud data"
 msgstr "Usar datos en la nube"
 
@@ -2758,7 +2789,7 @@ msgstr "Úsala en este dispositivo para continuar con tus datos en la nube."
 msgid "Use personal mode to filter only your expenses."
 msgstr "Usa el modo personal para filtrar solo tus gastos."
 
-#: src/routes/settings_.cloud-sync.tsx:975
+#: src/routes/settings_.cloud-sync.tsx:1001
 msgid "Use trizum cloud on this device?"
 msgstr "¿Usar trizum cloud en este dispositivo?"
 
@@ -2819,15 +2850,15 @@ msgstr "Viendo como {0}"
 msgid "Viewing as {participantName}"
 msgstr "Viendo como {participantName}"
 
-#: src/routes/settings_.cloud-sync.tsx:1143
+#: src/routes/settings_.cloud-sync.tsx:1238
 msgid "We sent a sign-in link to {email}. Open it to finish signing in."
 msgstr "Hemos enviado un enlace de inicio de sesión a {email}. Ábrelo para terminar de iniciar sesión."
 
-#: src/routes/settings_.cloud-sync.tsx:1482
+#: src/routes/settings_.cloud-sync.tsx:1577
 msgid "We will email a password link to {email}. Your current password keeps working until you change it."
 msgstr "Enviaremos un enlace de contraseña a {email}. Tu contraseña actual seguirá funcionando hasta que la cambies."
 
-#: src/routes/settings_.cloud-sync.tsx:1487
+#: src/routes/settings_.cloud-sync.tsx:1582
 msgid "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 msgstr "Enviaremos un enlace para configurar la contraseña a {email}. El inicio de sesión con contraseña empezará a funcionar cuando añadas una."
 

--- a/packages/pwa/src/lib/authCallbackErrors.test.ts
+++ b/packages/pwa/src/lib/authCallbackErrors.test.ts
@@ -1,0 +1,36 @@
+import { i18n } from "@lingui/core";
+import { beforeEach, describe, expect, test } from "vite-plus/test";
+import { getAuthCallbackErrorContent } from "./authCallbackErrors.ts";
+
+describe("getAuthCallbackErrorContent", () => {
+  beforeEach(() => {
+    i18n.load("en", {});
+    i18n.activate("en");
+  });
+
+  test("maps email mismatch callback errors", () => {
+    expect(getAuthCallbackErrorContent("email_doesn't_match")).toEqual({
+      title: "Email addresses don't match",
+      description:
+        "To connect Google or Apple, choose an account with the same email address as your trizum cloud account.",
+    });
+
+    expect(getAuthCallbackErrorContent("email_doesn%27t_match").title).toBe(
+      "Email addresses don't match",
+    );
+  });
+
+  test("maps invalid token callback errors", () => {
+    expect(getAuthCallbackErrorContent("INVALID_TOKEN")).toEqual({
+      title: "Sign-in link expired",
+      description: "This sign-in link is invalid or expired. Request a new link and try again.",
+    });
+  });
+
+  test("maps unknown callback errors to a generic message", () => {
+    expect(getAuthCallbackErrorContent("provider_error")).toEqual({
+      title: "Couldn't connect sign-in method",
+      description: "trizum could not finish connecting that sign-in method. Please try again.",
+    });
+  });
+});

--- a/packages/pwa/src/lib/authCallbackErrors.ts
+++ b/packages/pwa/src/lib/authCallbackErrors.ts
@@ -1,0 +1,42 @@
+import { t } from "@lingui/core/macro";
+
+export interface AuthCallbackErrorContent {
+  description: string;
+  title: string;
+}
+
+export function getAuthCallbackErrorContent(error: string): AuthCallbackErrorContent {
+  switch (normalizeAuthCallbackError(error)) {
+    case "email_doesnt_match":
+      return {
+        title: t`Email addresses don't match`,
+        description: t`To connect Google or Apple, choose an account with the same email address as your trizum cloud account.`,
+      };
+    case "invalid_token":
+      return {
+        title: t`Sign-in link expired`,
+        description: t`This sign-in link is invalid or expired. Request a new link and try again.`,
+      };
+    default:
+      return {
+        title: t`Couldn't connect sign-in method`,
+        description: t`trizum could not finish connecting that sign-in method. Please try again.`,
+      };
+  }
+}
+
+function normalizeAuthCallbackError(error: string) {
+  return safelyDecodeURIComponent(error)
+    .trim()
+    .toLowerCase()
+    .replaceAll("'", "")
+    .replaceAll("’", "");
+}
+
+function safelyDecodeURIComponent(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/packages/pwa/src/routes/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/settings_.cloud-sync.tsx
@@ -7,6 +7,7 @@ import { Dialog, Modal, ModalOverlay } from "react-aria-components";
 import { AnimatePresence, motion } from "motion/react";
 import { toast } from "sonner";
 import { BackButton } from "#src/components/BackButton.js";
+import { getAuthCallbackErrorContent } from "#src/lib/authCallbackErrors.ts";
 import {
   authClient,
   deleteAuthUserAccount,
@@ -109,6 +110,7 @@ function CloudSyncSettings() {
   const [isSignInDialogOpen, setIsSignInDialogOpen] = useState(true);
   const [isCloudSyncSwitchOpen, setIsCloudSyncSwitchOpen] = useState(false);
   const [cloudActionDialog, setCloudActionDialog] = useState<CloudActionDialogType | null>(null);
+  const [authCallbackDialogError, setAuthCallbackDialogError] = useState<string | null>(null);
   const [isDeleteAccountDialogOpen, setIsDeleteAccountDialogOpen] = useState(false);
   const [deleteAccountConfirmation, setDeleteAccountConfirmation] = useState("");
   const [deleteAccountError, setDeleteAccountError] = useState<string | null>(null);
@@ -292,7 +294,15 @@ function CloudSyncSettings() {
       return;
     }
 
-    setAuthError(getAuthCallbackErrorMessage(authCallbackError));
+    setAuthError(getAuthCallbackErrorContent(authCallbackError).description);
+  }, [authCallbackError, userId]);
+
+  useEffect(() => {
+    if (!authCallbackError || !userId) {
+      return;
+    }
+
+    setAuthCallbackDialogError(authCallbackError);
   }, [authCallbackError, userId]);
 
   useEffect(() => {
@@ -962,6 +972,22 @@ function CloudSyncSettings() {
         onSubmit={onDeleteAccountSubmit}
       />
 
+      <AuthCallbackErrorDialog
+        error={authCallbackDialogError}
+        isOpen={Boolean(authCallbackDialogError)}
+        onOpenChange={(isOpen) => {
+          if (isOpen) {
+            return;
+          }
+
+          setAuthCallbackDialogError(null);
+
+          if (authCallbackError) {
+            void navigate({ to: "/settings/cloud-sync", replace: true });
+          }
+        }}
+      />
+
       <AnimatePresence>{isSignInSuccessVisible ? <SignInSuccessOverlay /> : null}</AnimatePresence>
 
       <ModalSheet
@@ -999,6 +1025,75 @@ function CloudSyncSettings() {
         </ModalSheetContent>
       </ModalSheet>
     </div>
+  );
+}
+
+function AuthCallbackErrorDialog({
+  error,
+  isOpen,
+  onOpenChange,
+}: {
+  error: string | null;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  const content = error ? getAuthCallbackErrorContent(error) : null;
+
+  return (
+    <ModalOverlay
+      isDismissable
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      className={({ isEntering, isExiting }) =>
+        cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
+          isEntering && "duration-200 ease-out animate-in fade-in",
+          isExiting && "duration-150 ease-in animate-out fade-out",
+        )
+      }
+    >
+      <Modal
+        className={({ isEntering, isExiting }) =>
+          cn(
+            "w-full max-w-[420px] outline-none",
+            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
+            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
+          )
+        }
+      >
+        <Dialog
+          aria-label={content?.title ?? t`Authentication error`}
+          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
+        >
+          {content ? (
+            <div className="flex flex-col gap-5 p-5 sm:p-6">
+              <div className="flex flex-col gap-3">
+                <span className="flex size-10 items-center justify-center rounded-full bg-danger-50 text-danger-600 dark:bg-danger-950/50 dark:text-danger-300">
+                  <Icon icon="lucide.circle-alert" width={20} height={20} />
+                </span>
+                <div className="flex flex-col gap-2">
+                  <h2 className="text-lg font-medium">{content.title}</h2>
+                  <p className="text-sm text-accent-700 dark:text-accent-50">
+                    {content.description}
+                  </p>
+                </div>
+              </div>
+
+              <Button
+                className="font-semibold"
+                color="accent"
+                onPress={() => {
+                  onOpenChange(false);
+                }}
+                type="button"
+              >
+                <Trans>Got it</Trans>
+              </Button>
+            </div>
+          ) : null}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
   );
 }
 
@@ -1631,15 +1726,6 @@ function getDeleteAccountErrorMessage(message: string) {
   }
 
   return message;
-}
-
-function getAuthCallbackErrorMessage(error: string) {
-  switch (error) {
-    case "INVALID_TOKEN":
-      return t`Sign-in link is invalid or expired`;
-    default:
-      return t`Authentication failed`;
-  }
 }
 
 function isEmailFieldErrorMessage(message: string) {


### PR DESCRIPTION
## Description

Shows a cloud-sync dialog when an OAuth account-linking callback returns an error in the URL. The known `email_doesn't_match` error now explains that Google or Apple can only be linked when the provider email matches the user's trizum cloud account email, and unknown callback errors use a generic connection failure message.

Also adds a small callback-error mapper test, updates Lingui catalogs with Spanish translations, and includes a patch changeset for `@trizum/pwa`.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [x] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not included; the dialog is only reached after a signed-in OAuth callback error.

## Additional Notes

Validation run locally:

- `vp run lingui:extract`
- `vp run check`
- `vp run test`
- `vp run build`
