### PR TITLE
fix(pwa): center cloud sync switch dialog

### DIFF
--- a/.changeset/center-cloud-sync-switch-dialog.md
+++ b/.changeset/center-cloud-sync-switch-dialog.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Show the cloud data switch prompt as a centered, non-dismissable modal with a blocking backdrop.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -79,7 +79,7 @@ msgstr "Accent color"
 msgid "Account created"
 msgstr "Account created"
 
-#: src/routes/settings_.cloud-sync.tsx:615
+#: src/routes/settings_.cloud-sync.tsx:605
 msgid "Account deleted"
 msgstr "Account deleted"
 
@@ -108,7 +108,7 @@ msgstr "Add"
 msgid "Add an expense"
 msgstr "Add an expense"
 
-#: src/routes/settings_.cloud-sync.tsx:865
+#: src/routes/settings_.cloud-sync.tsx:855
 msgid "Add Apple as a sign-in method"
 msgstr "Add Apple as a sign-in method"
 
@@ -116,7 +116,7 @@ msgstr "Add Apple as a sign-in method"
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Add expenses to this party to unlock totals, rankings, and individual spend."
 
-#: src/routes/settings_.cloud-sync.tsx:884
+#: src/routes/settings_.cloud-sync.tsx:874
 msgid "Add Google as a sign-in method"
 msgstr "Add Google as a sign-in method"
 
@@ -186,7 +186,7 @@ msgstr "Amount must be greater than 0"
 msgid "Angolan Kwanza"
 msgstr "Angolan Kwanza"
 
-#: src/routes/settings_.cloud-sync.tsx:861
+#: src/routes/settings_.cloud-sync.tsx:851
 msgid "Apple"
 msgstr "Apple"
 
@@ -194,7 +194,7 @@ msgstr "Apple"
 msgid "Apple connected"
 msgstr "Apple connected"
 
-#: src/routes/settings_.cloud-sync.tsx:864
+#: src/routes/settings_.cloud-sync.tsx:854
 msgid "Apple is connected to this account"
 msgstr "Apple is connected to this account"
 
@@ -263,14 +263,14 @@ msgstr "Attachments"
 msgid "Australian Dollar"
 msgstr "Australian Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:1065
+#: src/routes/settings_.cloud-sync.tsx:1106
 msgid "Authentication error"
 msgstr "Authentication error"
 
-#: src/routes/settings_.cloud-sync.tsx:411
-#: src/routes/settings_.cloud-sync.tsx:425
-#: src/routes/settings_.cloud-sync.tsx:442
-#: src/routes/settings_.cloud-sync.tsx:450
+#: src/routes/settings_.cloud-sync.tsx:401
+#: src/routes/settings_.cloud-sync.tsx:415
+#: src/routes/settings_.cloud-sync.tsx:432
+#: src/routes/settings_.cloud-sync.tsx:440
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
@@ -304,11 +304,11 @@ msgid "Back to home"
 msgstr "Back to home"
 
 #: src/routes/reset-password.tsx:102
-#: src/routes/settings_.cloud-sync.tsx:1142
+#: src/routes/settings_.cloud-sync.tsx:1183
 msgid "Back to settings"
 msgstr "Back to settings"
 
-#: src/routes/settings_.cloud-sync.tsx:685
+#: src/routes/settings_.cloud-sync.tsx:675
 msgid "Back to sign in"
 msgstr "Back to sign in"
 
@@ -444,8 +444,8 @@ msgstr "Can't add an expense to a party that doesn't exist"
 msgid "Canadian Dollar"
 msgstr "Canadian Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:1524
-#: src/routes/settings_.cloud-sync.tsx:1692
+#: src/routes/settings_.cloud-sync.tsx:1565
+#: src/routes/settings_.cloud-sync.tsx:1733
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -481,11 +481,11 @@ msgstr "Changes sync automatically across all your devices"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/routes/settings_.cloud-sync.tsx:492
+#: src/routes/settings_.cloud-sync.tsx:482
 msgid "Check your email for the password link"
 msgstr "Check your email for the password link"
 
-#: src/routes/settings_.cloud-sync.tsx:381
+#: src/routes/settings_.cloud-sync.tsx:371
 msgid "Check your email for the sign-in link"
 msgstr "Check your email for the sign-in link"
 
@@ -586,7 +586,7 @@ msgstr "Complete your profile"
 msgid "Configure Profile"
 msgstr "Configure Profile"
 
-#: src/routes/settings_.cloud-sync.tsx:1475
+#: src/routes/settings_.cloud-sync.tsx:1516
 msgid "Confirm action"
 msgstr "Confirm action"
 
@@ -596,7 +596,7 @@ msgstr "Confirm action"
 msgid "Confirm transfer"
 msgstr "Confirm transfer"
 
-#: src/routes/settings_.cloud-sync.tsx:1667
+#: src/routes/settings_.cloud-sync.tsx:1708
 msgid "Confirmation"
 msgstr "Confirmation"
 
@@ -613,15 +613,15 @@ msgstr "Congolese Franc"
 msgid "Connect"
 msgstr "Connect"
 
-#: src/routes/settings_.cloud-sync.tsx:1553
+#: src/routes/settings_.cloud-sync.tsx:1594
 msgid "Connect Apple"
 msgstr "Connect Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:1560
+#: src/routes/settings_.cloud-sync.tsx:1601
 msgid "Connect Apple?"
 msgstr "Connect Apple?"
 
-#: src/routes/settings_.cloud-sync.tsx:1564
+#: src/routes/settings_.cloud-sync.tsx:1605
 msgid "Connect Google"
 msgstr "Connect Google"
 
@@ -629,12 +629,12 @@ msgstr "Connect Google"
 msgid "Connect Google, Apple, or a password to the same account."
 msgstr "Connect Google, Apple, or a password to the same account."
 
-#: src/routes/settings_.cloud-sync.tsx:1571
+#: src/routes/settings_.cloud-sync.tsx:1612
 msgid "Connect Google?"
 msgstr "Connect Google?"
 
-#: src/routes/settings_.cloud-sync.tsx:867
-#: src/routes/settings_.cloud-sync.tsx:886
+#: src/routes/settings_.cloud-sync.tsx:857
+#: src/routes/settings_.cloud-sync.tsx:876
 msgid "Connected"
 msgstr "Connected"
 
@@ -647,7 +647,7 @@ msgstr "Connected to this account"
 msgid "Connected: {linkedProviderLabels}"
 msgstr "Connected: {linkedProviderLabels}"
 
-#: src/routes/settings_.cloud-sync.tsx:858
+#: src/routes/settings_.cloud-sync.tsx:848
 msgid "Connections"
 msgstr "Connections"
 
@@ -655,11 +655,11 @@ msgstr "Connections"
 msgid "Contact Us"
 msgstr "Contact Us"
 
-#: src/routes/settings_.cloud-sync.tsx:709
+#: src/routes/settings_.cloud-sync.tsx:699
 msgid "Continue with Apple"
 msgstr "Continue with Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:724
+#: src/routes/settings_.cloud-sync.tsx:714
 msgid "Continue with Google"
 msgstr "Continue with Google"
 
@@ -683,11 +683,11 @@ msgstr "Costa Rican Colón"
 msgid "Could not apply cloud settings"
 msgstr "Could not apply cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:478
+#: src/routes/settings_.cloud-sync.tsx:468
 msgid "Could not connect sign-in method"
 msgstr "Could not connect sign-in method"
 
-#: src/routes/settings_.cloud-sync.tsx:621
+#: src/routes/settings_.cloud-sync.tsx:611
 msgid "Could not delete account"
 msgstr "Could not delete account"
 
@@ -699,7 +699,7 @@ msgstr "Could not load cloud settings"
 msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
-#: src/routes/settings_.cloud-sync.tsx:256
+#: src/routes/settings_.cloud-sync.tsx:246
 #: src/routes/settings.tsx:388
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
@@ -712,15 +712,15 @@ msgstr "Could not reset password"
 msgid "Could not save cloud settings"
 msgstr "Could not save cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:495
+#: src/routes/settings_.cloud-sync.tsx:485
 msgid "Could not send password email"
 msgstr "Could not send password email"
 
-#: src/routes/settings_.cloud-sync.tsx:384
+#: src/routes/settings_.cloud-sync.tsx:374
 msgid "Could not send sign-in link"
 msgstr "Could not send sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:543
+#: src/routes/settings_.cloud-sync.tsx:533
 msgid "Could not sign out"
 msgstr "Could not sign out"
 
@@ -826,13 +826,13 @@ msgstr "Decimal point"
 msgid "Delete"
 msgstr "Delete"
 
-#: src/routes/settings_.cloud-sync.tsx:933
-#: src/routes/settings_.cloud-sync.tsx:1646
-#: src/routes/settings_.cloud-sync.tsx:1681
+#: src/routes/settings_.cloud-sync.tsx:923
+#: src/routes/settings_.cloud-sync.tsx:1687
+#: src/routes/settings_.cloud-sync.tsx:1722
 msgid "Delete account"
 msgstr "Delete account"
 
-#: src/routes/settings_.cloud-sync.tsx:1652
+#: src/routes/settings_.cloud-sync.tsx:1693
 msgid "Delete account?"
 msgstr "Delete account?"
 
@@ -849,7 +849,7 @@ msgstr "Description must be less than 500 characters"
 msgid "Destination party"
 msgstr "Destination party"
 
-#: src/routes/settings_.cloud-sync.tsx:930
+#: src/routes/settings_.cloud-sync.tsx:920
 msgid "Destructive actions"
 msgstr "Destructive actions"
 
@@ -889,14 +889,14 @@ msgstr "Editing {expenseName}"
 msgid "Egyptian Pound"
 msgstr "Egyptian Pound"
 
-#: src/routes/settings_.cloud-sync.tsx:657
-#: src/routes/settings_.cloud-sync.tsx:743
-#: src/routes/settings_.cloud-sync.tsx:809
-#: src/routes/settings_.cloud-sync.tsx:902
+#: src/routes/settings_.cloud-sync.tsx:647
+#: src/routes/settings_.cloud-sync.tsx:733
+#: src/routes/settings_.cloud-sync.tsx:799
+#: src/routes/settings_.cloud-sync.tsx:892
 msgid "Email"
 msgstr "Email"
 
-#: src/routes/settings_.cloud-sync.tsx:912
+#: src/routes/settings_.cloud-sync.tsx:902
 msgid "Email a password reset link"
 msgstr "Email a password reset link"
 
@@ -912,15 +912,15 @@ msgstr "Email addresses don't match"
 msgid "Email link"
 msgstr "Email link"
 
-#: src/routes/settings_.cloud-sync.tsx:820
+#: src/routes/settings_.cloud-sync.tsx:810
 msgid "Email me a sign-in link"
 msgstr "Email me a sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:1575
+#: src/routes/settings_.cloud-sync.tsx:1616
 msgid "Email password link"
 msgstr "Email password link"
 
-#: src/routes/settings_.cloud-sync.tsx:1588
+#: src/routes/settings_.cloud-sync.tsx:1629
 msgid "Email password link?"
 msgstr "Email password link?"
 
@@ -1096,8 +1096,8 @@ msgstr "Fijian Dollar"
 msgid "Filter totals and rankings"
 msgstr "Filter totals and rankings"
 
-#: src/routes/settings_.cloud-sync.tsx:1194
-#: src/routes/settings_.cloud-sync.tsx:1205
+#: src/routes/settings_.cloud-sync.tsx:1235
+#: src/routes/settings_.cloud-sync.tsx:1246
 msgid "Finishing sign in"
 msgstr "Finishing sign in"
 
@@ -1105,7 +1105,7 @@ msgstr "Finishing sign in"
 msgid "For payments through Bizum or similar services"
 msgstr "For payments through Bizum or similar services"
 
-#: src/routes/settings_.cloud-sync.tsx:798
+#: src/routes/settings_.cloud-sync.tsx:788
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
@@ -1158,7 +1158,7 @@ msgstr "Go back to home"
 msgid "Gold (troy ounce)"
 msgstr "Gold (troy ounce)"
 
-#: src/routes/settings_.cloud-sync.tsx:880
+#: src/routes/settings_.cloud-sync.tsx:870
 msgid "Google"
 msgstr "Google"
 
@@ -1166,11 +1166,11 @@ msgstr "Google"
 msgid "Google connected"
 msgstr "Google connected"
 
-#: src/routes/settings_.cloud-sync.tsx:883
+#: src/routes/settings_.cloud-sync.tsx:873
 msgid "Google is connected to this account"
 msgstr "Google is connected to this account"
 
-#: src/routes/settings_.cloud-sync.tsx:1090
+#: src/routes/settings_.cloud-sync.tsx:1131
 msgid "Got it"
 msgstr "Got it"
 
@@ -1798,7 +1798,7 @@ msgstr "Optional description for this expense"
 msgid "or enter code"
 msgstr "or enter code"
 
-#: src/routes/settings_.cloud-sync.tsx:731
+#: src/routes/settings_.cloud-sync.tsx:721
 msgid "or use email"
 msgstr "or use email"
 
@@ -1928,12 +1928,12 @@ msgstr "Party stats"
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
-#: src/routes/settings_.cloud-sync.tsx:753
-#: src/routes/settings_.cloud-sync.tsx:909
+#: src/routes/settings_.cloud-sync.tsx:743
+#: src/routes/settings_.cloud-sync.tsx:899
 msgid "Password"
 msgstr "Password"
 
-#: src/routes/settings_.cloud-sync.tsx:493
+#: src/routes/settings_.cloud-sync.tsx:483
 msgid "Password email sent"
 msgstr "Password email sent"
 
@@ -1978,7 +1978,7 @@ msgstr "Pay"
 msgid "People that owe you money"
 msgstr "People that owe you money"
 
-#: src/routes/settings_.cloud-sync.tsx:934
+#: src/routes/settings_.cloud-sync.tsx:924
 msgid "Permanently delete your trizum cloud account"
 msgstr "Permanently delete your trizum cloud account"
 
@@ -2198,7 +2198,7 @@ msgstr "Search emoji"
 msgid "Search emoji..."
 msgstr "Search emoji..."
 
-#: src/routes/settings_.cloud-sync.tsx:899
+#: src/routes/settings_.cloud-sync.tsx:889
 msgid "Security"
 msgstr "Security"
 
@@ -2210,7 +2210,7 @@ msgstr "See spending totals and rankings"
 msgid "Select emoji"
 msgstr "Select emoji"
 
-#: src/routes/settings_.cloud-sync.tsx:673
+#: src/routes/settings_.cloud-sync.tsx:663
 msgid "Send password link"
 msgstr "Send password link"
 
@@ -2226,11 +2226,11 @@ msgstr "Serbian Dinar"
 msgid "Set up"
 msgstr "Set up"
 
-#: src/routes/settings_.cloud-sync.tsx:912
+#: src/routes/settings_.cloud-sync.tsx:902
 msgid "Set up password sign-in"
 msgstr "Set up password sign-in"
 
-#: src/routes/settings_.cloud-sync.tsx:1588
+#: src/routes/settings_.cloud-sync.tsx:1629
 msgid "Set up password?"
 msgstr "Set up password?"
 
@@ -2290,34 +2290,34 @@ msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amoun
 msgid "Sierra Leonean Leone"
 msgstr "Sierra Leonean Leone"
 
-#: src/routes/settings_.cloud-sync.tsx:1138
+#: src/routes/settings_.cloud-sync.tsx:1179
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/routes/settings_.cloud-sync.tsx:1725
+#: src/routes/settings_.cloud-sync.tsx:1766
 msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
-#: src/routes/settings_.cloud-sync.tsx:1158
+#: src/routes/settings_.cloud-sync.tsx:1199
 msgid "Sign in to trizum cloud"
 msgstr "Sign in to trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:785
+#: src/routes/settings_.cloud-sync.tsx:775
 msgid "Sign in with magic link"
 msgstr "Sign in with magic link"
 
-#: src/routes/settings_.cloud-sync.tsx:770
-#: src/routes/settings_.cloud-sync.tsx:835
+#: src/routes/settings_.cloud-sync.tsx:760
+#: src/routes/settings_.cloud-sync.tsx:825
 msgid "Sign in with password"
 msgstr "Sign in with password"
 
-#: src/routes/settings_.cloud-sync.tsx:921
-#: src/routes/settings_.cloud-sync.tsx:1022
-#: src/routes/settings_.cloud-sync.tsx:1592
+#: src/routes/settings_.cloud-sync.tsx:911
+#: src/routes/settings_.cloud-sync.tsx:1061
+#: src/routes/settings_.cloud-sync.tsx:1633
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/routes/settings_.cloud-sync.tsx:1599
+#: src/routes/settings_.cloud-sync.tsx:1640
 msgid "Sign out?"
 msgstr "Sign out?"
 
@@ -2329,15 +2329,15 @@ msgstr "Sign-in link expired"
 msgid "Sign-in link is invalid or expired"
 msgstr "Sign-in link is invalid or expired"
 
-#: src/routes/settings_.cloud-sync.tsx:382
+#: src/routes/settings_.cloud-sync.tsx:372
 msgid "Sign-in link sent"
 msgstr "Sign-in link sent"
 
-#: src/routes/settings_.cloud-sync.tsx:476
+#: src/routes/settings_.cloud-sync.tsx:466
 msgid "Sign-in method connected"
 msgstr "Sign-in method connected"
 
-#: src/routes/settings_.cloud-sync.tsx:422
+#: src/routes/settings_.cloud-sync.tsx:412
 msgid "Sign-in method is not configured"
 msgstr "Sign-in method is not configured"
 
@@ -2345,14 +2345,14 @@ msgstr "Sign-in method is not configured"
 msgid "Sign-in methods"
 msgstr "Sign-in methods"
 
-#: src/routes/settings_.cloud-sync.tsx:416
-#: src/routes/settings_.cloud-sync.tsx:446
-#: src/routes/settings_.cloud-sync.tsx:904
-#: src/routes/settings_.cloud-sync.tsx:1274
+#: src/routes/settings_.cloud-sync.tsx:406
+#: src/routes/settings_.cloud-sync.tsx:436
+#: src/routes/settings_.cloud-sync.tsx:894
+#: src/routes/settings_.cloud-sync.tsx:1315
 msgid "Signed in"
 msgstr "Signed in"
 
-#: src/routes/settings_.cloud-sync.tsx:540
+#: src/routes/settings_.cloud-sync.tsx:530
 msgid "Signed out"
 msgstr "Signed out"
 
@@ -2429,7 +2429,7 @@ msgstr "Start tracking expenses with your group"
 msgid "Stats"
 msgstr "Stats"
 
-#: src/routes/settings_.cloud-sync.tsx:922
+#: src/routes/settings_.cloud-sync.tsx:912
 msgid "Stop trizum cloud on this device"
 msgstr "Stop trizum cloud on this device"
 
@@ -2582,11 +2582,11 @@ msgstr "This application uses the following open source libraries and tools. Bel
 msgid "This debt is no longer available"
 msgstr "This debt is no longer available"
 
-#: src/routes/settings_.cloud-sync.tsx:1004
-msgid "This device already has local trizum data. Using trizum cloud here will switch this device to your cloud data, and the local list on this device will stop being used."
-msgstr "This device already has local trizum data. Using trizum cloud here will switch this device to your cloud data, and the local list on this device will stop being used."
+#: src/routes/settings_.cloud-sync.tsx:1039
+msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
+msgstr "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 
-#: src/routes/settings_.cloud-sync.tsx:561
+#: src/routes/settings_.cloud-sync.tsx:551
 msgid "This device is already using trizum cloud"
 msgstr "This device is already using trizum cloud"
 
@@ -2606,7 +2606,7 @@ msgstr "This isn't a valid ID"
 msgid "This party needs another active participant besides you to receive the transferred debt."
 msgstr "This party needs another active participant besides you to receive the transferred debt."
 
-#: src/routes/settings_.cloud-sync.tsx:1655
+#: src/routes/settings_.cloud-sync.tsx:1696
 msgid "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 msgstr "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 
@@ -2618,7 +2618,7 @@ msgstr "This project uses various open source libraries and tools."
 msgid "This sign-in link is invalid or expired. Request a new link and try again."
 msgstr "This sign-in link is invalid or expired. Request a new link and try again."
 
-#: src/routes/settings_.cloud-sync.tsx:1594
+#: src/routes/settings_.cloud-sync.tsx:1635
 msgid "This stops trizum cloud on this device. Your local data stays on this device."
 msgstr "This stops trizum cloud on this device. Your local data stays on this device."
 
@@ -2701,26 +2701,26 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:853
+#: src/routes/settings_.cloud-sync.tsx:843
 #: src/routes/settings.tsx:216
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:223
-#: src/routes/settings_.cloud-sync.tsx:556
+#: src/routes/settings_.cloud-sync.tsx:213
+#: src/routes/settings_.cloud-sync.tsx:546
 msgid "trizum cloud data is invalid"
 msgstr "trizum cloud data is invalid"
 
-#: src/routes/settings_.cloud-sync.tsx:244
-#: src/routes/settings_.cloud-sync.tsx:575
+#: src/routes/settings_.cloud-sync.tsx:234
+#: src/routes/settings_.cloud-sync.tsx:565
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud enabled on this device"
 
-#: src/routes/settings_.cloud-sync.tsx:551
+#: src/routes/settings_.cloud-sync.tsx:541
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud is not set up yet"
 
-#: src/routes/settings_.cloud-sync.tsx:206
+#: src/routes/settings_.cloud-sync.tsx:196
 msgid "trizum cloud started"
 msgstr "trizum cloud started"
 
@@ -2732,11 +2732,11 @@ msgstr "trizum could not finish connecting that sign-in method. Please try again
 msgid "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 msgstr "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 
-#: src/routes/settings_.cloud-sync.tsx:1555
+#: src/routes/settings_.cloud-sync.tsx:1596
 msgid "trizum will open Apple so you can add it as a sign-in method for this account."
 msgstr "trizum will open Apple so you can add it as a sign-in method for this account."
 
-#: src/routes/settings_.cloud-sync.tsx:1566
+#: src/routes/settings_.cloud-sync.tsx:1607
 msgid "trizum will open Google so you can add it as a sign-in method for this account."
 msgstr "trizum will open Google so you can add it as a sign-in method for this account."
 
@@ -2745,7 +2745,7 @@ msgstr "trizum will open Google so you can add it as a sign-in method for this a
 msgid "Try again"
 msgstr "Try again"
 
-#: src/routes/settings_.cloud-sync.tsx:1244
+#: src/routes/settings_.cloud-sync.tsx:1285
 msgid "Try another email"
 msgstr "Try another email"
 
@@ -2769,7 +2769,7 @@ msgstr "Turkish Lira"
 msgid "Turkmenistani Manat"
 msgstr "Turkmenistani Manat"
 
-#: src/routes/settings_.cloud-sync.tsx:1665
+#: src/routes/settings_.cloud-sync.tsx:1706
 msgid "Type \"delete account\" to confirm."
 msgstr "Type \"delete account\" to confirm."
 
@@ -2870,7 +2870,7 @@ msgstr "US Dollar"
 msgid "US Dollar (Next day)"
 msgstr "US Dollar (Next day)"
 
-#: src/routes/settings_.cloud-sync.tsx:1019
+#: src/routes/settings_.cloud-sync.tsx:1051
 msgid "Use cloud data"
 msgstr "Use cloud data"
 
@@ -2886,7 +2886,8 @@ msgstr "Use it on this device to continue with your cloud data."
 msgid "Use personal mode to filter only your expenses."
 msgstr "Use personal mode to filter only your expenses."
 
-#: src/routes/settings_.cloud-sync.tsx:1001
+#: src/routes/settings_.cloud-sync.tsx:1026
+#: src/routes/settings_.cloud-sync.tsx:1036
 msgid "Use trizum cloud on this device?"
 msgstr "Use trizum cloud on this device?"
 
@@ -2951,15 +2952,15 @@ msgstr "Viewing as {participantName}"
 msgid "Warning: Split amounts don't match total expense"
 msgstr "Warning: Split amounts don't match total expense"
 
-#: src/routes/settings_.cloud-sync.tsx:1238
+#: src/routes/settings_.cloud-sync.tsx:1279
 msgid "We sent a sign-in link to {email}. Open it to finish signing in."
 msgstr "We sent a sign-in link to {email}. Open it to finish signing in."
 
-#: src/routes/settings_.cloud-sync.tsx:1577
+#: src/routes/settings_.cloud-sync.tsx:1618
 msgid "We will email a password link to {email}. Your current password keeps working until you change it."
 msgstr "We will email a password link to {email}. Your current password keeps working until you change it."
 
-#: src/routes/settings_.cloud-sync.tsx:1582
+#: src/routes/settings_.cloud-sync.tsx:1623
 msgid "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 msgstr "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -75,7 +75,7 @@ msgstr "Color de acento"
 msgid "Account created"
 msgstr "Cuenta creada"
 
-#: src/routes/settings_.cloud-sync.tsx:615
+#: src/routes/settings_.cloud-sync.tsx:605
 msgid "Account deleted"
 msgstr "Cuenta eliminada"
 
@@ -104,7 +104,7 @@ msgstr "Sumar"
 msgid "Add an expense"
 msgstr "Añadir un gasto"
 
-#: src/routes/settings_.cloud-sync.tsx:865
+#: src/routes/settings_.cloud-sync.tsx:855
 msgid "Add Apple as a sign-in method"
 msgstr "Añadir Apple como método de inicio de sesión"
 
@@ -112,7 +112,7 @@ msgstr "Añadir Apple como método de inicio de sesión"
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto individual."
 
-#: src/routes/settings_.cloud-sync.tsx:884
+#: src/routes/settings_.cloud-sync.tsx:874
 msgid "Add Google as a sign-in method"
 msgstr "Añadir Google como método de inicio de sesión"
 
@@ -178,7 +178,7 @@ msgstr "La cantidad debe ser mayor que 0"
 msgid "Angolan Kwanza"
 msgstr "Kwanza Angoleño"
 
-#: src/routes/settings_.cloud-sync.tsx:861
+#: src/routes/settings_.cloud-sync.tsx:851
 msgid "Apple"
 msgstr "Apple"
 
@@ -186,7 +186,7 @@ msgstr "Apple"
 msgid "Apple connected"
 msgstr "Apple conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:864
+#: src/routes/settings_.cloud-sync.tsx:854
 msgid "Apple is connected to this account"
 msgstr "Apple está conectado a esta cuenta"
 
@@ -251,14 +251,14 @@ msgstr "Adjuntos"
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
-#: src/routes/settings_.cloud-sync.tsx:1065
+#: src/routes/settings_.cloud-sync.tsx:1106
 msgid "Authentication error"
 msgstr "Error de autenticación"
 
-#: src/routes/settings_.cloud-sync.tsx:411
-#: src/routes/settings_.cloud-sync.tsx:425
-#: src/routes/settings_.cloud-sync.tsx:442
-#: src/routes/settings_.cloud-sync.tsx:450
+#: src/routes/settings_.cloud-sync.tsx:401
+#: src/routes/settings_.cloud-sync.tsx:415
+#: src/routes/settings_.cloud-sync.tsx:432
+#: src/routes/settings_.cloud-sync.tsx:440
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
@@ -292,11 +292,11 @@ msgid "Back to home"
 msgstr "Volver al inicio"
 
 #: src/routes/reset-password.tsx:102
-#: src/routes/settings_.cloud-sync.tsx:1142
+#: src/routes/settings_.cloud-sync.tsx:1183
 msgid "Back to settings"
 msgstr "Volver a configuración"
 
-#: src/routes/settings_.cloud-sync.tsx:685
+#: src/routes/settings_.cloud-sync.tsx:675
 msgid "Back to sign in"
 msgstr "Volver a iniciar sesión"
 
@@ -424,8 +424,8 @@ msgstr "¿Puedo usar trizum sin una cuenta?"
 msgid "Canadian Dollar"
 msgstr "Dólar Canadiense"
 
-#: src/routes/settings_.cloud-sync.tsx:1524
-#: src/routes/settings_.cloud-sync.tsx:1692
+#: src/routes/settings_.cloud-sync.tsx:1565
+#: src/routes/settings_.cloud-sync.tsx:1733
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -461,11 +461,11 @@ msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
-#: src/routes/settings_.cloud-sync.tsx:492
+#: src/routes/settings_.cloud-sync.tsx:482
 msgid "Check your email for the password link"
 msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:381
+#: src/routes/settings_.cloud-sync.tsx:371
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
@@ -562,7 +562,7 @@ msgstr "Completa tu perfil"
 msgid "Configure Profile"
 msgstr "Configurar perfil"
 
-#: src/routes/settings_.cloud-sync.tsx:1475
+#: src/routes/settings_.cloud-sync.tsx:1516
 msgid "Confirm action"
 msgstr "Confirmar acción"
 
@@ -572,7 +572,7 @@ msgstr "Confirmar acción"
 msgid "Confirm transfer"
 msgstr "Confirmar transferencia"
 
-#: src/routes/settings_.cloud-sync.tsx:1667
+#: src/routes/settings_.cloud-sync.tsx:1708
 msgid "Confirmation"
 msgstr "Confirmación"
 
@@ -589,15 +589,15 @@ msgstr "Franco Congoleño"
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/routes/settings_.cloud-sync.tsx:1553
+#: src/routes/settings_.cloud-sync.tsx:1594
 msgid "Connect Apple"
 msgstr "Conectar Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:1560
+#: src/routes/settings_.cloud-sync.tsx:1601
 msgid "Connect Apple?"
 msgstr "¿Conectar Apple?"
 
-#: src/routes/settings_.cloud-sync.tsx:1564
+#: src/routes/settings_.cloud-sync.tsx:1605
 msgid "Connect Google"
 msgstr "Conectar Google"
 
@@ -605,12 +605,12 @@ msgstr "Conectar Google"
 msgid "Connect Google, Apple, or a password to the same account."
 msgstr "Conecta Google, Apple o una contraseña a la misma cuenta."
 
-#: src/routes/settings_.cloud-sync.tsx:1571
+#: src/routes/settings_.cloud-sync.tsx:1612
 msgid "Connect Google?"
 msgstr "¿Conectar Google?"
 
-#: src/routes/settings_.cloud-sync.tsx:867
-#: src/routes/settings_.cloud-sync.tsx:886
+#: src/routes/settings_.cloud-sync.tsx:857
+#: src/routes/settings_.cloud-sync.tsx:876
 msgid "Connected"
 msgstr "Conectado"
 
@@ -623,7 +623,7 @@ msgstr "Conectado a esta cuenta"
 msgid "Connected: {linkedProviderLabels}"
 msgstr "Conectado: {linkedProviderLabels}"
 
-#: src/routes/settings_.cloud-sync.tsx:858
+#: src/routes/settings_.cloud-sync.tsx:848
 msgid "Connections"
 msgstr "Conexiones"
 
@@ -631,11 +631,11 @@ msgstr "Conexiones"
 msgid "Contact Us"
 msgstr "Contacto"
 
-#: src/routes/settings_.cloud-sync.tsx:709
+#: src/routes/settings_.cloud-sync.tsx:699
 msgid "Continue with Apple"
 msgstr "Continuar con Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:724
+#: src/routes/settings_.cloud-sync.tsx:714
 msgid "Continue with Google"
 msgstr "Continuar con Google"
 
@@ -659,11 +659,11 @@ msgstr "Colón Costarricense"
 msgid "Could not apply cloud settings"
 msgstr "No se pudo aplicar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:478
+#: src/routes/settings_.cloud-sync.tsx:468
 msgid "Could not connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:621
+#: src/routes/settings_.cloud-sync.tsx:611
 msgid "Could not delete account"
 msgstr "No se pudo eliminar la cuenta"
 
@@ -675,7 +675,7 @@ msgstr "No se pudo cargar la configuración en la nube"
 msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:256
+#: src/routes/settings_.cloud-sync.tsx:246
 #: src/routes/settings.tsx:388
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
@@ -688,15 +688,15 @@ msgstr "No se pudo restablecer la contraseña"
 msgid "Could not save cloud settings"
 msgstr "No se pudo guardar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:495
+#: src/routes/settings_.cloud-sync.tsx:485
 msgid "Could not send password email"
 msgstr "No se pudo enviar el correo de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:384
+#: src/routes/settings_.cloud-sync.tsx:374
 msgid "Could not send sign-in link"
 msgstr "No se pudo enviar el enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:543
+#: src/routes/settings_.cloud-sync.tsx:533
 msgid "Could not sign out"
 msgstr "No se pudo cerrar sesión"
 
@@ -798,13 +798,13 @@ msgstr "Punto decimal"
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/routes/settings_.cloud-sync.tsx:933
-#: src/routes/settings_.cloud-sync.tsx:1646
-#: src/routes/settings_.cloud-sync.tsx:1681
+#: src/routes/settings_.cloud-sync.tsx:923
+#: src/routes/settings_.cloud-sync.tsx:1687
+#: src/routes/settings_.cloud-sync.tsx:1722
 msgid "Delete account"
 msgstr "Eliminar cuenta"
 
-#: src/routes/settings_.cloud-sync.tsx:1652
+#: src/routes/settings_.cloud-sync.tsx:1693
 msgid "Delete account?"
 msgstr "¿Eliminar cuenta?"
 
@@ -821,7 +821,7 @@ msgstr "La descripción debe tener menos de 500 caracteres"
 msgid "Destination party"
 msgstr "Grupo de destino"
 
-#: src/routes/settings_.cloud-sync.tsx:930
+#: src/routes/settings_.cloud-sync.tsx:920
 msgid "Destructive actions"
 msgstr "Acciones destructivas"
 
@@ -861,14 +861,14 @@ msgstr "Editando {expenseName}"
 msgid "Egyptian Pound"
 msgstr "Libra Egipcia"
 
-#: src/routes/settings_.cloud-sync.tsx:657
-#: src/routes/settings_.cloud-sync.tsx:743
-#: src/routes/settings_.cloud-sync.tsx:809
-#: src/routes/settings_.cloud-sync.tsx:902
+#: src/routes/settings_.cloud-sync.tsx:647
+#: src/routes/settings_.cloud-sync.tsx:733
+#: src/routes/settings_.cloud-sync.tsx:799
+#: src/routes/settings_.cloud-sync.tsx:892
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: src/routes/settings_.cloud-sync.tsx:912
+#: src/routes/settings_.cloud-sync.tsx:902
 msgid "Email a password reset link"
 msgstr "Enviar un enlace para restablecer la contraseña"
 
@@ -884,15 +884,15 @@ msgstr "Los correos no coinciden"
 msgid "Email link"
 msgstr "Enviar enlace"
 
-#: src/routes/settings_.cloud-sync.tsx:820
+#: src/routes/settings_.cloud-sync.tsx:810
 msgid "Email me a sign-in link"
 msgstr "Enviarme un enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1575
+#: src/routes/settings_.cloud-sync.tsx:1616
 msgid "Email password link"
 msgstr "Enviar enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:1588
+#: src/routes/settings_.cloud-sync.tsx:1629
 msgid "Email password link?"
 msgstr "¿Enviar enlace de contraseña?"
 
@@ -1052,8 +1052,8 @@ msgstr "Dólar Fiyiano"
 msgid "Filter totals and rankings"
 msgstr "Filtra totales y rankings"
 
-#: src/routes/settings_.cloud-sync.tsx:1194
-#: src/routes/settings_.cloud-sync.tsx:1205
+#: src/routes/settings_.cloud-sync.tsx:1235
+#: src/routes/settings_.cloud-sync.tsx:1246
 msgid "Finishing sign in"
 msgstr "Terminando el inicio de sesión"
 
@@ -1061,7 +1061,7 @@ msgstr "Terminando el inicio de sesión"
 msgid "For payments through Bizum or similar services"
 msgstr "Para pagos mediante Bizum o servicios similares"
 
-#: src/routes/settings_.cloud-sync.tsx:798
+#: src/routes/settings_.cloud-sync.tsx:788
 msgid "Forgot password?"
 msgstr "¿Olvidaste tu contraseña?"
 
@@ -1114,7 +1114,7 @@ msgstr "Volver al inicio"
 msgid "Gold (troy ounce)"
 msgstr "Oro (onza troy)"
 
-#: src/routes/settings_.cloud-sync.tsx:880
+#: src/routes/settings_.cloud-sync.tsx:870
 msgid "Google"
 msgstr "Google"
 
@@ -1122,11 +1122,11 @@ msgstr "Google"
 msgid "Google connected"
 msgstr "Google conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:883
+#: src/routes/settings_.cloud-sync.tsx:873
 msgid "Google is connected to this account"
 msgstr "Google está conectado a esta cuenta"
 
-#: src/routes/settings_.cloud-sync.tsx:1090
+#: src/routes/settings_.cloud-sync.tsx:1131
 msgid "Got it"
 msgstr "Entendido"
 
@@ -1738,7 +1738,7 @@ msgstr "Abrir paréntesis"
 msgid "or enter code"
 msgstr "o introduce código"
 
-#: src/routes/settings_.cloud-sync.tsx:731
+#: src/routes/settings_.cloud-sync.tsx:721
 msgid "or use email"
 msgstr "o usa el correo"
 
@@ -1860,12 +1860,12 @@ msgstr "Estadísticas del grupo"
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
-#: src/routes/settings_.cloud-sync.tsx:753
-#: src/routes/settings_.cloud-sync.tsx:909
+#: src/routes/settings_.cloud-sync.tsx:743
+#: src/routes/settings_.cloud-sync.tsx:899
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:493
+#: src/routes/settings_.cloud-sync.tsx:483
 msgid "Password email sent"
 msgstr "Correo de contraseña enviado"
 
@@ -1910,7 +1910,7 @@ msgstr "Pagar"
 msgid "People that owe you money"
 msgstr "Personas que te deben dinero"
 
-#: src/routes/settings_.cloud-sync.tsx:934
+#: src/routes/settings_.cloud-sync.tsx:924
 msgid "Permanently delete your trizum cloud account"
 msgstr "Eliminar permanentemente tu cuenta de trizum cloud"
 
@@ -2126,7 +2126,7 @@ msgstr "Buscar emoji"
 msgid "Search emoji..."
 msgstr "Buscar emoji..."
 
-#: src/routes/settings_.cloud-sync.tsx:899
+#: src/routes/settings_.cloud-sync.tsx:889
 msgid "Security"
 msgstr "Seguridad"
 
@@ -2138,7 +2138,7 @@ msgstr "Ver totales y clasificación de gasto"
 msgid "Select emoji"
 msgstr "Seleccionar emoji"
 
-#: src/routes/settings_.cloud-sync.tsx:673
+#: src/routes/settings_.cloud-sync.tsx:663
 msgid "Send password link"
 msgstr "Enviar enlace de contraseña"
 
@@ -2154,11 +2154,11 @@ msgstr "Dinar Serbio"
 msgid "Set up"
 msgstr "Configurar"
 
-#: src/routes/settings_.cloud-sync.tsx:912
+#: src/routes/settings_.cloud-sync.tsx:902
 msgid "Set up password sign-in"
 msgstr "Configurar inicio de sesión con contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:1588
+#: src/routes/settings_.cloud-sync.tsx:1629
 msgid "Set up password?"
 msgstr "¿Configurar contraseña?"
 
@@ -2218,34 +2218,34 @@ msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantida
 msgid "Sierra Leonean Leone"
 msgstr "Leone de Sierra Leona"
 
-#: src/routes/settings_.cloud-sync.tsx:1138
+#: src/routes/settings_.cloud-sync.tsx:1179
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1725
+#: src/routes/settings_.cloud-sync.tsx:1766
 msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
-#: src/routes/settings_.cloud-sync.tsx:1158
+#: src/routes/settings_.cloud-sync.tsx:1199
 msgid "Sign in to trizum cloud"
 msgstr "Iniciar sesión en trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:785
+#: src/routes/settings_.cloud-sync.tsx:775
 msgid "Sign in with magic link"
 msgstr "Iniciar sesión con enlace mágico"
 
-#: src/routes/settings_.cloud-sync.tsx:770
-#: src/routes/settings_.cloud-sync.tsx:835
+#: src/routes/settings_.cloud-sync.tsx:760
+#: src/routes/settings_.cloud-sync.tsx:825
 msgid "Sign in with password"
 msgstr "Iniciar sesión con contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:921
-#: src/routes/settings_.cloud-sync.tsx:1022
-#: src/routes/settings_.cloud-sync.tsx:1592
+#: src/routes/settings_.cloud-sync.tsx:911
+#: src/routes/settings_.cloud-sync.tsx:1061
+#: src/routes/settings_.cloud-sync.tsx:1633
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1599
+#: src/routes/settings_.cloud-sync.tsx:1640
 msgid "Sign out?"
 msgstr "¿Cerrar sesión?"
 
@@ -2257,15 +2257,15 @@ msgstr "El enlace de inicio de sesión ha caducado"
 msgid "Sign-in link is invalid or expired"
 msgstr "El enlace de inicio de sesión no es válido o ha caducado"
 
-#: src/routes/settings_.cloud-sync.tsx:382
+#: src/routes/settings_.cloud-sync.tsx:372
 msgid "Sign-in link sent"
 msgstr "Enlace de inicio de sesión enviado"
 
-#: src/routes/settings_.cloud-sync.tsx:476
+#: src/routes/settings_.cloud-sync.tsx:466
 msgid "Sign-in method connected"
 msgstr "Método de inicio de sesión conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:422
+#: src/routes/settings_.cloud-sync.tsx:412
 msgid "Sign-in method is not configured"
 msgstr "El método de inicio de sesión no está configurado"
 
@@ -2273,14 +2273,14 @@ msgstr "El método de inicio de sesión no está configurado"
 msgid "Sign-in methods"
 msgstr "Métodos de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:416
-#: src/routes/settings_.cloud-sync.tsx:446
-#: src/routes/settings_.cloud-sync.tsx:904
-#: src/routes/settings_.cloud-sync.tsx:1274
+#: src/routes/settings_.cloud-sync.tsx:406
+#: src/routes/settings_.cloud-sync.tsx:436
+#: src/routes/settings_.cloud-sync.tsx:894
+#: src/routes/settings_.cloud-sync.tsx:1315
 msgid "Signed in"
 msgstr "Sesión iniciada"
 
-#: src/routes/settings_.cloud-sync.tsx:540
+#: src/routes/settings_.cloud-sync.tsx:530
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
@@ -2353,7 +2353,7 @@ msgstr "Comienza a registrar gastos con tu grupo"
 msgid "Stats"
 msgstr "Estadísticas"
 
-#: src/routes/settings_.cloud-sync.tsx:922
+#: src/routes/settings_.cloud-sync.tsx:912
 msgid "Stop trizum cloud on this device"
 msgstr "Detener trizum cloud en este dispositivo"
 
@@ -2506,11 +2506,11 @@ msgstr "Esta aplicación utiliza las siguientes bibliotecas y herramientas de c�
 msgid "This debt is no longer available"
 msgstr "Esta deuda ya no está disponible"
 
-#: src/routes/settings_.cloud-sync.tsx:1004
-msgid "This device already has local trizum data. Using trizum cloud here will switch this device to your cloud data, and the local list on this device will stop being used."
-msgstr "Este dispositivo ya tiene datos locales de trizum. Si usas trizum cloud aquí, este dispositivo cambiará a tus datos en la nube y dejará de usar la lista local de este dispositivo."
+#: src/routes/settings_.cloud-sync.tsx:1039
+msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
+msgstr "Este dispositivo ya tiene datos locales. Si usas trizum cloud aquí, este dispositivo cambiará a tus datos en la nube. Los datos locales de este dispositivo dejarán de usarse."
 
-#: src/routes/settings_.cloud-sync.tsx:561
+#: src/routes/settings_.cloud-sync.tsx:551
 msgid "This device is already using trizum cloud"
 msgstr "Este dispositivo ya usa trizum cloud"
 
@@ -2530,7 +2530,7 @@ msgstr "Este no es un ID válido"
 msgid "This party needs another active participant besides you to receive the transferred debt."
 msgstr "Este grupo necesita otro participante activo además de ti para recibir la deuda transferida."
 
-#: src/routes/settings_.cloud-sync.tsx:1655
+#: src/routes/settings_.cloud-sync.tsx:1696
 msgid "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 msgstr "Esto elimina permanentemente tu cuenta de trizum cloud, los métodos de inicio de sesión y la configuración en la nube. Tus datos locales en este dispositivo se conservarán."
 
@@ -2542,7 +2542,7 @@ msgstr "Este proyecto utiliza varias bibliotecas y herramientas de código abier
 msgid "This sign-in link is invalid or expired. Request a new link and try again."
 msgstr "Este enlace de inicio de sesión no es válido o ha caducado. Solicita un enlace nuevo e inténtalo de nuevo."
 
-#: src/routes/settings_.cloud-sync.tsx:1594
+#: src/routes/settings_.cloud-sync.tsx:1635
 msgid "This stops trizum cloud on this device. Your local data stays on this device."
 msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se quedan en este dispositivo."
 
@@ -2613,26 +2613,26 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/settings_.cloud-sync.tsx:853
+#: src/routes/settings_.cloud-sync.tsx:843
 #: src/routes/settings.tsx:216
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:223
-#: src/routes/settings_.cloud-sync.tsx:556
+#: src/routes/settings_.cloud-sync.tsx:213
+#: src/routes/settings_.cloud-sync.tsx:546
 msgid "trizum cloud data is invalid"
 msgstr "Los datos de trizum cloud no son válidos"
 
-#: src/routes/settings_.cloud-sync.tsx:244
-#: src/routes/settings_.cloud-sync.tsx:575
+#: src/routes/settings_.cloud-sync.tsx:234
+#: src/routes/settings_.cloud-sync.tsx:565
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud activado en este dispositivo"
 
-#: src/routes/settings_.cloud-sync.tsx:551
+#: src/routes/settings_.cloud-sync.tsx:541
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud todavía no está configurado"
 
-#: src/routes/settings_.cloud-sync.tsx:206
+#: src/routes/settings_.cloud-sync.tsx:196
 msgid "trizum cloud started"
 msgstr "trizum cloud iniciado"
 
@@ -2644,11 +2644,11 @@ msgstr "trizum no pudo terminar de conectar ese método de inicio de sesión. In
 msgid "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 msgstr "trizum almacena todos tus datos localmente en tu dispositivo. Cuando estás conectado y compartes un grupo con otros, los cambios se sincronizan automáticamente en todos los dispositivos en tiempo real."
 
-#: src/routes/settings_.cloud-sync.tsx:1555
+#: src/routes/settings_.cloud-sync.tsx:1596
 msgid "trizum will open Apple so you can add it as a sign-in method for this account."
 msgstr "trizum abrirá Apple para que puedas añadirlo como método de inicio de sesión para esta cuenta."
 
-#: src/routes/settings_.cloud-sync.tsx:1566
+#: src/routes/settings_.cloud-sync.tsx:1607
 msgid "trizum will open Google so you can add it as a sign-in method for this account."
 msgstr "trizum abrirá Google para que puedas añadirlo como método de inicio de sesión para esta cuenta."
 
@@ -2657,7 +2657,7 @@ msgstr "trizum abrirá Google para que puedas añadirlo como método de inicio d
 msgid "Try again"
 msgstr "Reintentar"
 
-#: src/routes/settings_.cloud-sync.tsx:1244
+#: src/routes/settings_.cloud-sync.tsx:1285
 msgid "Try another email"
 msgstr "Probar con otro email"
 
@@ -2681,7 +2681,7 @@ msgstr "Lira Turca"
 msgid "Turkmenistani Manat"
 msgstr "Manat Turkmeno"
 
-#: src/routes/settings_.cloud-sync.tsx:1665
+#: src/routes/settings_.cloud-sync.tsx:1706
 msgid "Type \"delete account\" to confirm."
 msgstr "Escribe \"delete account\" para confirmar."
 
@@ -2773,7 +2773,7 @@ msgstr "Dólar Estadounidense"
 msgid "US Dollar (Next day)"
 msgstr "Dólar Estadounidense (Día siguiente)"
 
-#: src/routes/settings_.cloud-sync.tsx:1019
+#: src/routes/settings_.cloud-sync.tsx:1051
 msgid "Use cloud data"
 msgstr "Usar datos en la nube"
 
@@ -2789,7 +2789,8 @@ msgstr "Úsala en este dispositivo para continuar con tus datos en la nube."
 msgid "Use personal mode to filter only your expenses."
 msgstr "Usa el modo personal para filtrar solo tus gastos."
 
-#: src/routes/settings_.cloud-sync.tsx:1001
+#: src/routes/settings_.cloud-sync.tsx:1026
+#: src/routes/settings_.cloud-sync.tsx:1036
 msgid "Use trizum cloud on this device?"
 msgstr "¿Usar trizum cloud en este dispositivo?"
 
@@ -2850,15 +2851,15 @@ msgstr "Viendo como {0}"
 msgid "Viewing as {participantName}"
 msgstr "Viendo como {participantName}"
 
-#: src/routes/settings_.cloud-sync.tsx:1238
+#: src/routes/settings_.cloud-sync.tsx:1279
 msgid "We sent a sign-in link to {email}. Open it to finish signing in."
 msgstr "Hemos enviado un enlace de inicio de sesión a {email}. Ábrelo para terminar de iniciar sesión."
 
-#: src/routes/settings_.cloud-sync.tsx:1577
+#: src/routes/settings_.cloud-sync.tsx:1618
 msgid "We will email a password link to {email}. Your current password keeps working until you change it."
 msgstr "Enviaremos un enlace de contraseña a {email}. Tu contraseña actual seguirá funcionando hasta que la cambies."
 
-#: src/routes/settings_.cloud-sync.tsx:1582
+#: src/routes/settings_.cloud-sync.tsx:1623
 msgid "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 msgstr "Enviaremos un enlace para configurar la contraseña a {email}. El inicio de sesión con contraseña empezará a funcionar cuando añadas una."
 

--- a/packages/pwa/src/routes/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/settings_.cloud-sync.tsx
@@ -30,16 +30,6 @@ import {
 import { Button } from "#src/ui/Button.tsx";
 import { Icon, type IconProps } from "#src/ui/Icon.tsx";
 import { Alert, AlertDescription } from "#src/ui/Alert.tsx";
-import {
-  ModalSheet,
-  ModalSheetAction,
-  ModalSheetActions,
-  ModalSheetContent,
-  ModalSheetDescription,
-  ModalSheetHeader,
-  ModalSheetSection,
-  ModalSheetTitle,
-} from "#src/ui/ModalSheet.js";
 import { AppTextField } from "#src/ui/fields/TextField.js";
 import { IconButton } from "#src/ui/IconButton.js";
 import { cn } from "#src/ui/utils.js";
@@ -990,41 +980,92 @@ function CloudSyncSettings() {
 
       <AnimatePresence>{isSignInSuccessVisible ? <SignInSuccessOverlay /> : null}</AnimatePresence>
 
-      <ModalSheet
-        isDismissable={false}
+      <CloudSyncSwitchDialog
         isOpen={isCloudSyncSwitchOpen}
-        onOpenChange={setIsCloudSyncSwitchOpen}
-      >
-        <ModalSheetHeader>
-          <ModalSheetSection className="flex flex-col gap-2">
-            <ModalSheetTitle>
-              <Trans>Use trizum cloud on this device?</Trans>
-            </ModalSheetTitle>
-            <ModalSheetDescription>
-              <Trans>
-                This device already has local trizum data. Using trizum cloud here will switch this
-                device to your cloud data, and the local list on this device will stop being used.
-              </Trans>
-            </ModalSheetDescription>
-          </ModalSheetSection>
-        </ModalSheetHeader>
-        <ModalSheetContent>
-          <ModalSheetActions>
-            <ModalSheetAction
-              icon="lucide.cloud-download"
-              onPress={() => {
-                activateCloudSyncOnDevice();
-              }}
-            >
-              <Trans>Use cloud data</Trans>
-            </ModalSheetAction>
-            <ModalSheetAction icon="lucide.log-out" onPress={onSignOut} tone="danger">
-              <Trans>Sign out</Trans>
-            </ModalSheetAction>
-          </ModalSheetActions>
-        </ModalSheetContent>
-      </ModalSheet>
+        onSignOut={onSignOut}
+        onUseCloudData={() => {
+          activateCloudSyncOnDevice();
+        }}
+      />
     </div>
+  );
+}
+
+function CloudSyncSwitchDialog({
+  isOpen,
+  onSignOut,
+  onUseCloudData,
+}: {
+  isOpen: boolean;
+  onSignOut: () => void;
+  onUseCloudData: () => void;
+}) {
+  return (
+    <ModalOverlay
+      isDismissable={false}
+      isKeyboardDismissDisabled
+      isOpen={isOpen}
+      className={({ isEntering, isExiting }) =>
+        cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
+          isEntering && "duration-200 ease-out animate-in fade-in",
+          isExiting && "duration-150 ease-in animate-out fade-out",
+        )
+      }
+    >
+      <Modal
+        className={({ isEntering, isExiting }) =>
+          cn(
+            "w-full max-w-[420px] outline-none",
+            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
+            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
+          )
+        }
+      >
+        <Dialog
+          aria-label={t`Use trizum cloud on this device?`}
+          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
+        >
+          <div className="flex flex-col gap-5 p-5 sm:p-6">
+            <div className="flex flex-col gap-3">
+              <span className="flex size-10 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-800 dark:text-accent-50">
+                <Icon icon="lucide.cloud-download" width={20} height={20} />
+              </span>
+              <div className="flex flex-col gap-2">
+                <h2 className="text-lg font-medium">
+                  <Trans>Use trizum cloud on this device?</Trans>
+                </h2>
+                <p className="text-sm text-accent-700 dark:text-accent-50">
+                  <Trans>
+                    This device already has local data. Using trizum cloud here will switch this
+                    device to your cloud data. Your local data on this device will stop being used.
+                  </Trans>
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <Button className="font-semibold" color="accent" onPress={onUseCloudData}>
+                <span className="flex items-center gap-2">
+                  <Icon icon="lucide.cloud-download" width={18} height={18} />
+                  <Trans>Use cloud data</Trans>
+                </span>
+              </Button>
+              <Button
+                className="font-semibold text-danger-700 dark:text-danger-300"
+                color="input-like"
+                onPress={onSignOut}
+              >
+                <span className="flex items-center gap-2">
+                  <Icon icon="lucide.log-out" width={18} height={18} />
+                  <Trans>Sign out</Trans>
+                </span>
+              </Button>
+            </div>
+          </div>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
   );
 }
 


### PR DESCRIPTION
## Description

Fixes the required cloud data switch prompt shown when a signed-in device already has local data:

- Replaces the bottom sheet with a centered non-dismissable modal.
- Adds a blocking backdrop through `ModalOverlay` so the settings page cannot be clicked behind it.
- Removes sheet drag/resizing behavior from this forced decision.
- Updates the prompt copy to talk about local data vs cloud data and avoid mentioning lists.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [x] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not captured locally; this state requires an authenticated cloud account on a device with existing local data.

## Additional Notes

Validation run:

- `vp run check`
- `vp run test`
- `vp run build`
- `vp run lingui:extract`
