### PR TITLE
fix(mobile): avoid conflicting TestFlight signing flags

### DIFF
--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -69,7 +69,7 @@ platform :ios do
       end
 
       if refresh_provisioning_profile?(options[:type])
-        refresh_provisioning_profile(type: options[:type])
+        refresh_provisioning_profile
       elsif ENV["IOS_PROVISIONING_PROFILE_BASE64"]
         profile_path = "#{Dir.tmpdir}/profile.mobileprovision"
         File.write(profile_path, Base64.decode64(ENV["IOS_PROVISIONING_PROFILE_BASE64"]))
@@ -489,7 +489,7 @@ platform :ios do
     type.to_s == "appstore" && ENV["IOS_REFRESH_PROVISIONING_PROFILE"] == "true"
   end
 
-  def refresh_provisioning_profile(type:)
+  def refresh_provisioning_profile
     api_key = Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
     unless api_key
       UI.user_error!(
@@ -500,8 +500,6 @@ platform :ios do
     get_provisioning_profile(
       app_identifier: IOS_APP_IDENTIFIER,
       api_key: api_key,
-      adhoc: type.to_s == "adhoc",
-      development: false,
       force: true,
       filename: "appstore.mobileprovision",
       output_path: Dir.tmpdir,


### PR DESCRIPTION
## Description

Fixes the iOS TestFlight signing failure seen in PR #192 by omitting mutually exclusive `get_provisioning_profile` flags when refreshing the App Store provisioning profile. The refresh lane is already gated to App Store profiles, so passing `adhoc: false` and `development: false` is unnecessary and Fastlane 2.231 rejects the option combination.

## Related Issues

Related to #192

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this changes CI signing configuration only.

## Additional Notes

Additional validation:

- `ruby -c fastlane/Fastfile`
- `FASTLANE_SKIP_UPDATE_CHECK=1 mise exec -- bundle exec fastlane lanes`

I did not run `deploy_pr_testflight` locally because it requires App Store Connect and signing secrets.
