### PR TITLE
fix(mobile): resolve TestFlight entitlement path

### DIFF
--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -523,9 +523,15 @@ platform :ios do
       UI.user_error!("Unable to find App Store Connect bundle ID #{IOS_APP_IDENTIFIER}.")
     end
 
+    existing_capabilities = bundle_id.get_capabilities
     IOS_REQUIRED_BUNDLE_ID_CAPABILITIES.each do |capability_type|
+      if existing_capabilities.any? { |capability| capability.is_type?(capability_type) }
+        UI.message("Bundle ID capability #{capability_type} is enabled for #{IOS_APP_IDENTIFIER}")
+        next
+      end
+
       UI.message("Ensuring Bundle ID capability #{capability_type} for #{IOS_APP_IDENTIFIER}")
-      bundle_id.update_capability(capability_type, enabled: true)
+      bundle_id.create_capability(capability_type)
     end
   end
 

--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -20,9 +20,6 @@ IOS_BUILD_PROCESSING_TIMEOUT_SECONDS = 10 * 60
 IOS_SCREENSHOT_PROCESSING_TIMEOUT_SECONDS = 5 * 60
 IOS_VERSION_CHECK_WAIT_RETRY_LIMIT = 5
 IOS_ENTITLEMENTS_PATH = File.expand_path("../App/App.entitlements", __dir__)
-IOS_REQUIRED_BUNDLE_ID_CAPABILITIES = [
-  Spaceship::ConnectAPI::BundleIdCapability::Type::ASSOCIATED_DOMAINS
-].freeze
 
 default_platform(:ios)
 
@@ -500,8 +497,6 @@ platform :ios do
       )
     end
 
-    ensure_app_store_bundle_id_capabilities
-
     get_provisioning_profile(
       app_identifier: IOS_APP_IDENTIFIER,
       api_key: api_key,
@@ -515,24 +510,6 @@ platform :ios do
 
     profile_path = Actions.lane_context[SharedValues::SIGH_PROFILE_PATH]
     install_ci_provisioning_profile(path: profile_path)
-  end
-
-  def ensure_app_store_bundle_id_capabilities
-    bundle_id = Spaceship::ConnectAPI::BundleId.find(IOS_APP_IDENTIFIER)
-    unless bundle_id
-      UI.user_error!("Unable to find App Store Connect bundle ID #{IOS_APP_IDENTIFIER}.")
-    end
-
-    existing_capabilities = bundle_id.get_capabilities
-    IOS_REQUIRED_BUNDLE_ID_CAPABILITIES.each do |capability_type|
-      if existing_capabilities.any? { |capability| capability.is_type?(capability_type) }
-        UI.message("Bundle ID capability #{capability_type} is enabled for #{IOS_APP_IDENTIFIER}")
-        next
-      end
-
-      UI.message("Ensuring Bundle ID capability #{capability_type} for #{IOS_APP_IDENTIFIER}")
-      bundle_id.create_capability(capability_type)
-    end
   end
 
   def install_ci_provisioning_profile(path:)
@@ -565,7 +542,7 @@ platform :ios do
       if actual_value.nil?
         missing_entitlements << key
       elsif expected_value.is_a?(Array)
-        missing_values = expected_value - Array(actual_value)
+        missing_values = missing_profile_entitlement_values(expected_value, actual_value)
         missing_entitlements << "#{key} (#{missing_values.join(", ")})" unless missing_values.empty?
       elsif actual_value != expected_value
         missing_entitlements << key
@@ -579,6 +556,24 @@ platform :ios do
       "#{missing_entitlements.join(", ")}. Regenerate the App Store profile after enabling " \
       "Sign in with Apple and Associated Domains for #{IOS_APP_IDENTIFIER}."
     )
+  end
+
+  def missing_profile_entitlement_values(expected_values, profile_value)
+    expected_values.reject do |expected_value|
+      Array(profile_value).any? do |allowed_value|
+        profile_entitlement_value_matches?(allowed_value, expected_value)
+      end
+    end
+  end
+
+  def profile_entitlement_value_matches?(allowed_value, expected_value)
+    return true if allowed_value == expected_value
+
+    allowed_string = allowed_value.to_s
+    expected_string = expected_value.to_s
+    return true if allowed_string == "*"
+
+    allowed_string.end_with?("*") && expected_string.start_with?(allowed_string.delete_suffix("*"))
   end
 
   def version_segments(version)

--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -20,6 +20,9 @@ IOS_BUILD_PROCESSING_TIMEOUT_SECONDS = 10 * 60
 IOS_SCREENSHOT_PROCESSING_TIMEOUT_SECONDS = 5 * 60
 IOS_VERSION_CHECK_WAIT_RETRY_LIMIT = 5
 IOS_ENTITLEMENTS_PATH = File.expand_path("../App/App.entitlements", __dir__)
+IOS_REQUIRED_BUNDLE_ID_CAPABILITIES = [
+  Spaceship::ConnectAPI::BundleIdCapability::Type::ASSOCIATED_DOMAINS
+].freeze
 
 default_platform(:ios)
 
@@ -497,6 +500,8 @@ platform :ios do
       )
     end
 
+    ensure_app_store_bundle_id_capabilities
+
     get_provisioning_profile(
       app_identifier: IOS_APP_IDENTIFIER,
       api_key: api_key,
@@ -510,6 +515,18 @@ platform :ios do
 
     profile_path = Actions.lane_context[SharedValues::SIGH_PROFILE_PATH]
     install_ci_provisioning_profile(path: profile_path)
+  end
+
+  def ensure_app_store_bundle_id_capabilities
+    bundle_id = Spaceship::ConnectAPI::BundleId.find(IOS_APP_IDENTIFIER)
+    unless bundle_id
+      UI.user_error!("Unable to find App Store Connect bundle ID #{IOS_APP_IDENTIFIER}.")
+    end
+
+    IOS_REQUIRED_BUNDLE_ID_CAPABILITIES.each do |capability_type|
+      UI.message("Ensuring Bundle ID capability #{capability_type} for #{IOS_APP_IDENTIFIER}")
+      bundle_id.update_capability(capability_type, enabled: true)
+    end
   end
 
   def install_ci_provisioning_profile(path:)

--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -19,7 +19,7 @@ IOS_APPSTORE_PROFILE_NAME = "App Store Profile"
 IOS_BUILD_PROCESSING_TIMEOUT_SECONDS = 10 * 60
 IOS_SCREENSHOT_PROCESSING_TIMEOUT_SECONDS = 5 * 60
 IOS_VERSION_CHECK_WAIT_RETRY_LIMIT = 5
-IOS_ENTITLEMENTS_PATH = "App/App.entitlements"
+IOS_ENTITLEMENTS_PATH = File.expand_path("../App/App.entitlements", __dir__)
 
 default_platform(:ios)
 
@@ -529,6 +529,10 @@ platform :ios do
 
   def validate_profile_entitlements(profile)
     required_entitlements = Plist.parse_xml(IOS_ENTITLEMENTS_PATH)
+    if required_entitlements.nil?
+      UI.user_error!("Unable to read app entitlements at #{IOS_ENTITLEMENTS_PATH}")
+    end
+
     profile_entitlements = profile["Entitlements"] || {}
     missing_entitlements = []
 


### PR DESCRIPTION
## Description

Fixes the next iOS TestFlight failures seen in PR #192 after #201 landed.

The Fastlane entitlement validation now resolves `App.entitlements` from the Fastfile location instead of relying on the current working directory, reports a clear error if the plist cannot be read, and treats provisioning-profile array values as an allowlist so wildcard entries can satisfy concrete app entitlements during signing.

## Related Issues

Related to #192
Related to #201

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this changes CI signing configuration only.

## Additional Notes

Additional validation:

- `ruby -c fastlane/Fastfile`
- `FASTLANE_SKIP_UPDATE_CHECK=1 mise exec -- bundle exec fastlane lanes`
- local wildcard entitlement matcher check
- `vp run check`
- `vp run test`
- `vp run build`

Release-flow validation passed via `ios:testflight`: https://github.com/HorusGoul/trizum/actions/runs/27957779577
