### PR TITLE
fix(pwa): stop requesting names for social sign-in

### DIFF
--- a/.changeset/quiet-social-name-prompts.md
+++ b/.changeset/quiet-social-name-prompts.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Stop requesting name/profile data during Apple and Google sign-in.

--- a/packages/pwa/api/auth.ts
+++ b/packages/pwa/api/auth.ts
@@ -146,7 +146,10 @@ function createSocialProviders(env: ApiEnv): NonNullable<BetterAuthOptions["soci
     providers.google = {
       clientId: googleClientId,
       clientSecret: env.GOOGLE_CLIENT_SECRET,
+      disableDefaultScope: true,
+      mapProfileToUser: mapEmailOnlySocialProfileToUser,
       prompt: "select_account",
+      scope: ["openid", "email"],
     };
   }
 
@@ -158,8 +161,11 @@ function createSocialProviders(env: ApiEnv): NonNullable<BetterAuthOptions["soci
     providers.apple = async () => ({
       clientId: appleClientId,
       clientSecret: env.APPLE_CLIENT_SECRET ?? (await generateAppleClientSecret(env)),
+      disableDefaultScope: true,
       appBundleIdentifier: appleAppBundleIdentifier,
       audience: [appleClientId, appleAppBundleIdentifier],
+      mapProfileToUser: mapEmailOnlySocialProfileToUser,
+      scope: ["email"],
     });
   }
 
@@ -200,6 +206,12 @@ function hasAppleClientSecretConfig(env: ApiEnv) {
   return Boolean(
     env.APPLE_CLIENT_SECRET || (env.APPLE_TEAM_ID && env.APPLE_KEY_ID && env.APPLE_PRIVATE_KEY),
   );
+}
+
+function mapEmailOnlySocialProfileToUser(profile: { email?: string | null }) {
+  return {
+    name: profile.email ?? "",
+  };
 }
 
 async function generateAppleClientSecret(env: ApiEnv) {

--- a/packages/pwa/src/lib/auth-client.ts
+++ b/packages/pwa/src/lib/auth-client.ts
@@ -29,10 +29,6 @@ interface NativeSocialIdToken {
   token: string;
   user?: {
     email?: string;
-    name?: {
-      firstName?: string;
-      lastName?: string;
-    };
   };
 }
 
@@ -223,7 +219,7 @@ async function getNativeAppleIdToken(): Promise<NativeSocialIdToken> {
   const result = await AppleSignIn.signIn({
     nonce,
     redirectUrl: getAuthSettingsCallbackURL(),
-    scopes: [SignInScope.Email, SignInScope.FullName],
+    scopes: [SignInScope.Email],
   });
 
   return {
@@ -231,10 +227,6 @@ async function getNativeAppleIdToken(): Promise<NativeSocialIdToken> {
     token: result.idToken,
     user: {
       email: result.email ?? undefined,
-      name: {
-        firstName: result.givenName ?? undefined,
-        lastName: result.familyName ?? undefined,
-      },
     },
   };
 }


### PR DESCRIPTION
## Description

- Limit Google OAuth to `openid` and `email` scopes, and Apple OAuth to `email`, so social sign-in no longer asks users for name/profile access.
- Keep Better Auth's required account name populated from email without requesting provider profile data.
- Remove the native Apple `FullName` scope and stop forwarding native Apple name fields during ID-token sign-in.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable; not applicable, covered by auth config/type validation)
- [x] I've run `vp run lingui:extract` (if I added new strings; no new strings, pre-commit also ran extraction)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; no UI changes.

## Additional Notes

Existing social accounts keep their stored profile data. New Apple/Google sign-ins should no longer prompt for name/profile permissions beyond email.
