### PR TITLE
docs(privacy): update cloud account disclosures

### DIFF
--- a/.changeset/privacy-cloud-accounts.md
+++ b/.changeset/privacy-cloud-accounts.md
@@ -1,0 +1,9 @@
+---
+"@trizum/mobile": patch
+"@trizum/pwa": patch
+---
+
+Update privacy and store metadata disclosures for trizum cloud accounts.
+
+- Covers account sign-in, linked Google and Apple providers, Cloudflare-backed storage, authentication emails, sessions, and cloud account deletion.
+- Keeps store metadata clear that accounts are optional for getting started and only needed for trizum cloud sync across devices.

--- a/packages/mobile/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/packages/mobile/android/fastlane/metadata/android/en-US/full_description.txt
@@ -14,7 +14,7 @@ trizum makes splitting bills with friends and family effortless. Whether you're 
 
 • <b>Settlement Suggestions</b>: Get optimized suggestions to settle debts with the fewest transactions.
 
-• <b>Privacy Focused</b>: Your data stays on your devices. No accounts required to get started.
+• <b>Privacy Focused</b>: Your data is stored on your devices by default. No account is required to get started; sign in only if you choose to use trizum cloud across devices.
 
 <b>PERFECT FOR</b>
 
@@ -25,4 +25,3 @@ trizum makes splitting bills with friends and family effortless. Whether you're 
 • Event organizers tracking costs
 
 trizum is free to use. Start splitting bills the smart way today!
-

--- a/packages/mobile/android/fastlane/metadata/android/es-ES/full_description.txt
+++ b/packages/mobile/android/fastlane/metadata/android/es-ES/full_description.txt
@@ -14,7 +14,7 @@ trizum hace que dividir gastos con amigos y familiares sea muy fácil. Ya sea qu
 
 • <b>Sugerencias de liquidación</b>: Obtén sugerencias optimizadas para saldar deudas con el menor número de transacciones.
 
-• <b>Enfocado en la privacidad</b>: Tus datos permanecen en tus dispositivos. No se requieren cuentas para comenzar.
+• <b>Enfocado en la privacidad</b>: Tus datos se guardan en tus dispositivos de forma predeterminada. No necesitas una cuenta para comenzar; inicia sesión solo si quieres usar trizum cloud en varios dispositivos.
 
 <b>PERFECTO PARA</b>
 
@@ -25,4 +25,3 @@ trizum hace que dividir gastos con amigos y familiares sea muy fácil. Ya sea qu
 • Organizadores de eventos controlando costes
 
 trizum es gratis. ¡Empieza a dividir gastos de forma inteligente hoy!
-

--- a/packages/mobile/ios/App/fastlane/metadata/en-US/description.txt
+++ b/packages/mobile/ios/App/fastlane/metadata/en-US/description.txt
@@ -14,7 +14,7 @@ KEY FEATURES
 
 • Settlement Suggestions: Get optimized suggestions to settle debts with the fewest transactions.
 
-• Privacy Focused: Your data stays on your devices. No accounts required to get started.
+• Privacy Focused: Your data is stored on your devices by default. No account is required to get started; sign in only if you choose to use trizum cloud across devices.
 
 PERFECT FOR
 

--- a/packages/mobile/ios/App/fastlane/metadata/es-ES/description.txt
+++ b/packages/mobile/ios/App/fastlane/metadata/es-ES/description.txt
@@ -14,7 +14,7 @@ CARACTERÍSTICAS PRINCIPALES
 
 • Sugerencias de liquidación: Obtén sugerencias optimizadas para saldar deudas con el menor número de transacciones.
 
-• Enfocado en la privacidad: Tus datos permanecen en tus dispositivos. No se requieren cuentas para comenzar.
+• Enfocado en la privacidad: Tus datos se guardan en tus dispositivos de forma predeterminada. No necesitas una cuenta para comenzar; inicia sesión solo si quieres usar trizum cloud en varios dispositivos.
 
 PERFECTO PARA
 
@@ -25,4 +25,3 @@ PERFECTO PARA
 • Organizadores de eventos controlando costes
 
 trizum es gratis. ¡Empieza a dividir gastos de forma inteligente hoy!
-

--- a/packages/mobile/ios/App/fastlane/metadata/review_information/notes.txt
+++ b/packages/mobile/ios/App/fastlane/metadata/review_information/notes.txt
@@ -1,2 +1,1 @@
-trizum is an offline-first app that works without user accounts. No login is required to use the app. Simply create a group and start adding expenses.
-
+trizum is an offline-first app that still works without user accounts for local groups. No login is required to create a group and start adding expenses. trizum cloud sign-in is optional and is used to load a cloud party list across devices.

--- a/packages/pwa/src/routes/privacy-policy.tsx
+++ b/packages/pwa/src/routes/privacy-policy.tsx
@@ -17,9 +17,7 @@ function PrivacyPolicy() {
       </div>
 
       <div className="container flex flex-1 flex-col gap-6 px-4 py-6">
-        <p className="text-sm text-accent-600 dark:text-accent-400">
-          Last updated: December 9, 2025
-        </p>
+        <p className="text-sm text-accent-600 dark:text-accent-400">Last updated: June 23, 2026</p>
 
         <p className="text-accent-700 dark:text-accent-300">
           This Privacy Policy describes how trizum (&quot;we&quot;, &quot;our&quot;, or
@@ -66,6 +64,22 @@ function PrivacyPolicy() {
                 </strong>{" "}
                 Photos and receipts you attach to expenses
               </li>
+              <li>
+                <strong className="font-semibold text-accent-900 dark:text-accent-100">
+                  Account and Sign-In Information:
+                </strong>{" "}
+                If you use trizum cloud, we collect information needed to create and manage your
+                account, such as your email address, password authentication data, linked Google or
+                Apple sign-in methods, email verification status, and password or sign-in link
+                requests
+              </li>
+              <li>
+                <strong className="font-semibold text-accent-900 dark:text-accent-100">
+                  Cloud Account Settings:
+                </strong>{" "}
+                If you use trizum cloud, we store the document pointer that connects your account to
+                your cloud party list so your devices can load the same data
+              </li>
             </ul>
           </div>
 
@@ -93,6 +107,14 @@ function PrivacyPolicy() {
                 </strong>{" "}
                 Information about data synchronization between your devices
               </li>
+              <li>
+                <strong className="font-semibold text-accent-900 dark:text-accent-100">
+                  Authentication Data:
+                </strong>{" "}
+                Session identifiers, cookies or native app bearer tokens, IP address, user agent,
+                provider identifiers, and OAuth token metadata used to keep you signed in and secure
+                your trizum cloud account
+              </li>
             </ul>
           </div>
         </section>
@@ -106,6 +128,9 @@ function PrivacyPolicy() {
           </p>
           <ul className="ml-6 list-disc space-y-2 text-accent-700 dark:text-accent-300">
             <li>Provide and maintain the Service</li>
+            <li>Create, authenticate, secure, and manage trizum cloud accounts</li>
+            <li>Send sign-in links, email verification links, and password reset emails</li>
+            <li>Link Google, Apple, and password sign-in methods to the same trizum account</li>
             <li>Enable real-time synchronization of your expense data across your devices</li>
             <li>Allow collaboration with other participants in your expense groups</li>
             <li>Calculate balances and settlements between participants</li>
@@ -127,7 +152,8 @@ function PrivacyPolicy() {
             <p className="text-accent-700 dark:text-accent-300">
               trizum uses an offline-first architecture. Your data is primarily stored locally on
               your device using IndexedDB. This means your expense data is available even when
-              you&apos;re offline.
+              you&apos;re offline. trizum may also use browser storage, cookies, or native app
+              storage for settings, cloud account state, and sign-in tokens.
             </p>
           </div>
 
@@ -144,6 +170,12 @@ function PrivacyPolicy() {
               <li>Access to your data from multiple devices</li>
               <li>Automatic conflict resolution when changes occur simultaneously</li>
             </ul>
+            <p className="text-accent-700 dark:text-accent-300">
+              If you sign in to trizum cloud, your account data and cloud account settings are
+              stored in Cloudflare D1. Cloud account settings include the party list document
+              pointer associated with your account. This lets your signed-in devices find the same
+              cloud party list.
+            </p>
           </div>
 
           <div className="flex flex-col gap-3">
@@ -151,10 +183,12 @@ function PrivacyPolicy() {
               3.3 Data Encryption
             </h3>
             <p className="text-accent-700 dark:text-accent-300">
-              Data transmitted between your device and our servers is encrypted using secure
-              WebSocket connections (WSS). However, please note that data stored on our servers is
-              not end-to-end encrypted and may be accessible to us for the purposes of providing the
-              Service and synchronization.
+              Data transmitted between your device and our servers is encrypted using HTTPS and
+              secure WebSocket connections (WSS). OAuth tokens stored by our authentication system
+              are encrypted. However, please note that expense data, media files, and sync documents
+              stored on our servers are not end-to-end encrypted and may be accessible to us for the
+              purposes of providing the Service, synchronization, support, security, and abuse
+              prevention.
             </p>
           </div>
 
@@ -163,10 +197,12 @@ function PrivacyPolicy() {
               3.4 Access Model
             </h3>
             <p className="text-accent-700 dark:text-accent-300">
-              trizum uses a peer-to-peer sharing model based on link-based access. Expense groups
-              (parties) are accessed through shareable links. Anyone who has access to a link can
-              view and modify the expense group associated with that link. Please keep your expense
-              group links secure and only share them with trusted individuals.
+              trizum uses a link-based access model for expense groups (parties). Anyone who has
+              access to a party link can view and modify the expense group associated with that
+              link. A trizum cloud account lets you sign in and load your cloud party list across
+              devices, but it does not make party links private or revoke access from people who
+              already have a party link. Please keep your expense group links secure and only share
+              them with trusted individuals.
             </p>
           </div>
         </section>
@@ -192,9 +228,10 @@ function PrivacyPolicy() {
               <strong className="font-semibold text-accent-900 dark:text-accent-100">
                 Important:
               </strong>{" "}
-              We do not require user accounts or authentication. Access to expense groups is
-              controlled solely by link sharing. If someone gains access to a link, they can access
-              the associated expense group.
+              You can use trizum without creating an account. Accounts are used for trizum cloud
+              sign-in, linked sign-in methods, and loading your cloud party list on multiple
+              devices. Access to individual expense groups is still controlled by link sharing. If
+              someone gains access to a link, they can access the associated expense group.
             </p>
           </div>
 
@@ -206,6 +243,30 @@ function PrivacyPolicy() {
               We use the following third-party services:
             </p>
             <ul className="ml-6 list-disc space-y-2 text-accent-700 dark:text-accent-300">
+              <li>
+                <strong className="font-semibold text-accent-900 dark:text-accent-100">
+                  Cloudflare:
+                </strong>{" "}
+                We use Cloudflare Workers, D1, Send Email, logs, and related infrastructure to host
+                the Service, store account and cloud account settings, send authentication emails,
+                and operate trizum cloud.
+              </li>
+              <li>
+                <strong className="font-semibold text-accent-900 dark:text-accent-100">
+                  Google:
+                </strong>{" "}
+                If you choose to continue with Google or link Google as a sign-in method, Google
+                provides authentication information such as your email address and provider
+                identifier.
+              </li>
+              <li>
+                <strong className="font-semibold text-accent-900 dark:text-accent-100">
+                  Apple:
+                </strong>{" "}
+                If you choose to continue with Apple or link Apple as a sign-in method, Apple
+                provides authentication information such as your email address and provider
+                identifier.
+              </li>
               <li>
                 <strong className="font-semibold text-accent-900 dark:text-accent-100">
                   Sentry:
@@ -253,7 +314,15 @@ function PrivacyPolicy() {
               <li>Delete individual expenses or participants within the app</li>
               <li>Delete entire expense groups</li>
               <li>Clear your local data by clearing your browser&apos;s IndexedDB storage</li>
+              <li>Sign out of trizum cloud on a device from cloud settings</li>
+              <li>Delete your trizum cloud account from cloud settings</li>
             </ul>
+            <p className="text-accent-700 dark:text-accent-300">
+              Deleting your trizum cloud account deletes your account profile, sessions, linked
+              sign-in methods, and cloud account settings. It does not automatically delete expense
+              group data that is still available through shared links or synchronized with other
+              participants. To remove expense group data, delete it inside the Service.
+            </p>
           </div>
 
           <div className="flex flex-col gap-3">
@@ -268,12 +337,14 @@ function PrivacyPolicy() {
 
           <div className="flex flex-col gap-3">
             <h3 className="text-xl font-semibold text-accent-900 dark:text-accent-100">
-              5.3 Opt-Out of Error Reporting
+              5.3 Error Reporting and Operational Logs
             </h3>
             <p className="text-accent-700 dark:text-accent-300">
-              Error reporting through Sentry is only active in production builds. If you prefer not
-              to have error data collected, you may use a development build or contact us to discuss
-              alternatives.
+              Error reporting through Sentry is only active in production builds. trizum cloud also
+              uses operational logs and traces to run authentication, cloud settings, and sync
+              services. These logs are intended for security, abuse prevention, debugging, and
+              reliability. Contact us if you have questions about error reporting or operational
+              logging.
             </p>
           </div>
         </section>
@@ -289,13 +360,17 @@ function PrivacyPolicy() {
             collaboration between users.
           </p>
           <p className="text-accent-700 dark:text-accent-300">
-            All data that has not been accessed for 12 months may be automatically deleted from our
-            synchronization servers.
+            trizum cloud account data is retained while your account remains active. Authentication
+            sessions and verification or reset records expire according to the authentication
+            system&apos;s security rules. Cloud account settings are deleted when you delete your
+            trizum cloud account.
           </p>
           <p className="text-accent-700 dark:text-accent-300">
-            When you delete an expense group or its data through the Service, it will be removed
-            from our synchronization servers. Please note that this policy may change in the future
-            with the introduction of paid plans and freemium limits.
+            Expense group and sync data that has not been accessed for 12 months may be
+            automatically deleted from our synchronization servers. When you delete an expense group
+            or its data through the Service, the deletion is synchronized to other devices that can
+            access the group. Please note that this policy may change in the future with the
+            introduction of paid plans and freemium limits.
           </p>
         </section>
 
@@ -316,7 +391,8 @@ function PrivacyPolicy() {
           </h2>
           <p className="text-accent-700 dark:text-accent-300">
             Your data may be stored and processed in servers located outside your country of
-            residence. By using the Service, you consent to the transfer of your data to these
+            residence, including by infrastructure and sign-in providers used to operate the
+            Service. By using the Service, you consent to the transfer of your data to these
             locations.
           </p>
         </section>
@@ -329,7 +405,10 @@ function PrivacyPolicy() {
             We implement reasonable security measures to protect your data, including:
           </p>
           <ul className="ml-6 list-disc space-y-2 text-accent-700 dark:text-accent-300">
-            <li>Encrypted data transmission (WSS)</li>
+            <li>Encrypted data transmission (HTTPS and WSS)</li>
+            <li>Secure cookies for web sign-in where supported</li>
+            <li>Bearer token handling for native app sign-in</li>
+            <li>Encrypted OAuth token storage for linked sign-in providers</li>
             <li>Secure server infrastructure</li>
             <li>Regular security assessments</li>
           </ul>


### PR DESCRIPTION
## Description

Updates the privacy policy and mobile store metadata so they match the current trizum cloud account implementation. The policy now covers account sign-in data, linked Google/Apple providers, Cloudflare-backed account storage, auth emails, sessions/tokens, operational logging, cloud account deletion, and the remaining link-based party access model.

The mobile store descriptions and App Store review notes now keep the offline-first/no-account-to-start positioning while making clear that sign-in exists for optional trizum cloud sync across devices.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [x] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [ ] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable. Copy and metadata changes only.

## Additional Notes

- `vp run lingui:extract` produced no catalog changes because the existing privacy policy route is not Lingui-marked.
- No runtime behavior changed.
