### PR TITLE
refactor(pwa): decompose cloud sync settings route

### DIFF
--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -79,7 +79,7 @@ msgstr "Accent color"
 msgid "Account created"
 msgstr "Account created"
 
-#: src/routes/settings_.cloud-sync.tsx:642
+#: src/routes/settings_.cloud-sync.tsx:458
 msgid "Account deleted"
 msgstr "Account deleted"
 
@@ -267,10 +267,10 @@ msgstr "Australian Dollar"
 msgid "Authentication error"
 msgstr "Authentication error"
 
-#: src/routes/settings_.cloud-sync.tsx:434
-#: src/routes/settings_.cloud-sync.tsx:446
-#: src/routes/settings_.cloud-sync.tsx:463
-#: src/routes/settings_.cloud-sync.tsx:476
+#: src/routes/settings_.cloud-sync.tsx:297
+#: src/routes/settings_.cloud-sync.tsx:309
+#: src/routes/settings_.cloud-sync.tsx:326
+#: src/routes/settings_.cloud-sync.tsx:339
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
@@ -308,7 +308,7 @@ msgstr "Back to home"
 msgid "Back to settings"
 msgstr "Back to settings"
 
-#: src/routes/settings_.cloud-sync.tsx:714
+#: src/components/CloudSyncSignInForm.tsx:112
 msgid "Back to sign in"
 msgstr "Back to sign in"
 
@@ -481,11 +481,11 @@ msgstr "Changes sync automatically across all your devices"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/routes/settings_.cloud-sync.tsx:518
+#: src/routes/settings_.cloud-sync.tsx:375
 msgid "Check your email for the password link"
 msgstr "Check your email for the password link"
 
-#: src/routes/settings_.cloud-sync.tsx:404
+#: src/routes/settings_.cloud-sync.tsx:267
 msgid "Check your email for the sign-in link"
 msgstr "Check your email for the sign-in link"
 
@@ -655,11 +655,11 @@ msgstr "Connections"
 msgid "Contact Us"
 msgstr "Contact Us"
 
-#: src/routes/settings_.cloud-sync.tsx:738
+#: src/components/CloudSyncSignInForm.tsx:140
 msgid "Continue with Apple"
 msgstr "Continue with Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:753
+#: src/components/CloudSyncSignInForm.tsx:152
 msgid "Continue with Google"
 msgstr "Continue with Google"
 
@@ -683,11 +683,11 @@ msgstr "Costa Rican Colón"
 msgid "Could not apply cloud settings"
 msgstr "Could not apply cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:504
+#: src/routes/settings_.cloud-sync.tsx:361
 msgid "Could not connect sign-in method"
 msgstr "Could not connect sign-in method"
 
-#: src/routes/settings_.cloud-sync.tsx:648
+#: src/routes/settings_.cloud-sync.tsx:464
 msgid "Could not delete account"
 msgstr "Could not delete account"
 
@@ -699,7 +699,7 @@ msgstr "Could not load cloud settings"
 msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
-#: src/routes/settings_.cloud-sync.tsx:269
+#: src/hooks/useCloudSyncAccountState.ts:156
 #: src/routes/settings.tsx:388
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
@@ -712,15 +712,15 @@ msgstr "Could not reset password"
 msgid "Could not save cloud settings"
 msgstr "Could not save cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:521
+#: src/routes/settings_.cloud-sync.tsx:378
 msgid "Could not send password email"
 msgstr "Could not send password email"
 
-#: src/routes/settings_.cloud-sync.tsx:407
+#: src/routes/settings_.cloud-sync.tsx:270
 msgid "Could not send sign-in link"
 msgstr "Could not send sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:570
+#: src/routes/settings_.cloud-sync.tsx:426
 msgid "Could not sign out"
 msgstr "Could not sign out"
 
@@ -890,9 +890,9 @@ msgid "Egyptian Pound"
 msgstr "Egyptian Pound"
 
 #: src/components/CloudSyncAccountSettings.tsx:68
-#: src/routes/settings_.cloud-sync.tsx:686
-#: src/routes/settings_.cloud-sync.tsx:772
-#: src/routes/settings_.cloud-sync.tsx:838
+#: src/components/CloudSyncSignInForm.tsx:92
+#: src/components/CloudSyncSignInForm.tsx:232
+#: src/components/CloudSyncSignInForm.tsx:305
 msgid "Email"
 msgstr "Email"
 
@@ -912,7 +912,7 @@ msgstr "Email addresses don't match"
 msgid "Email link"
 msgstr "Email link"
 
-#: src/routes/settings_.cloud-sync.tsx:849
+#: src/components/CloudSyncSignInForm.tsx:313
 msgid "Email me a sign-in link"
 msgstr "Email me a sign-in link"
 
@@ -1105,7 +1105,7 @@ msgstr "Finishing sign in"
 msgid "For payments through Bizum or similar services"
 msgstr "For payments through Bizum or similar services"
 
-#: src/routes/settings_.cloud-sync.tsx:827
+#: src/components/CloudSyncSignInForm.tsx:272
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
@@ -1798,7 +1798,7 @@ msgstr "Optional description for this expense"
 msgid "or enter code"
 msgstr "or enter code"
 
-#: src/routes/settings_.cloud-sync.tsx:760
+#: src/components/CloudSyncSignInForm.tsx:159
 msgid "or use email"
 msgstr "or use email"
 
@@ -1929,11 +1929,11 @@ msgid "Party unpinned"
 msgstr "Party unpinned"
 
 #: src/components/CloudSyncAccountSettings.tsx:75
-#: src/routes/settings_.cloud-sync.tsx:782
+#: src/components/CloudSyncSignInForm.tsx:242
 msgid "Password"
 msgstr "Password"
 
-#: src/routes/settings_.cloud-sync.tsx:519
+#: src/routes/settings_.cloud-sync.tsx:376
 msgid "Password email sent"
 msgstr "Password email sent"
 
@@ -2210,7 +2210,7 @@ msgstr "See spending totals and rankings"
 msgid "Select emoji"
 msgstr "Select emoji"
 
-#: src/routes/settings_.cloud-sync.tsx:702
+#: src/components/CloudSyncSignInForm.tsx:103
 msgid "Send password link"
 msgstr "Send password link"
 
@@ -2294,7 +2294,7 @@ msgstr "Sierra Leonean Leone"
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/routes/settings_.cloud-sync.tsx:977
+#: src/routes/settings_.cloud-sync.tsx:655
 msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
@@ -2302,12 +2302,12 @@ msgstr "Sign in again before deleting your account"
 msgid "Sign in to trizum cloud"
 msgstr "Sign in to trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:814
+#: src/components/CloudSyncSignInForm.tsx:262
 msgid "Sign in with magic link"
 msgstr "Sign in with magic link"
 
-#: src/routes/settings_.cloud-sync.tsx:799
-#: src/routes/settings_.cloud-sync.tsx:864
+#: src/components/CloudSyncSignInForm.tsx:256
+#: src/components/CloudSyncSignInForm.tsx:319
 msgid "Sign in with password"
 msgstr "Sign in with password"
 
@@ -2329,15 +2329,15 @@ msgstr "Sign-in link expired"
 msgid "Sign-in link is invalid or expired"
 msgstr "Sign-in link is invalid or expired"
 
-#: src/routes/settings_.cloud-sync.tsx:405
+#: src/routes/settings_.cloud-sync.tsx:268
 msgid "Sign-in link sent"
 msgstr "Sign-in link sent"
 
-#: src/routes/settings_.cloud-sync.tsx:502
+#: src/routes/settings_.cloud-sync.tsx:359
 msgid "Sign-in method connected"
 msgstr "Sign-in method connected"
 
-#: src/routes/settings_.cloud-sync.tsx:443
+#: src/routes/settings_.cloud-sync.tsx:306
 msgid "Sign-in method is not configured"
 msgstr "Sign-in method is not configured"
 
@@ -2347,11 +2347,11 @@ msgstr "Sign-in methods"
 
 #: src/components/CloudSyncAccountSettings.tsx:70
 #: src/components/CloudSyncDialogs.tsx:369
-#: src/routes/settings_.cloud-sync.tsx:375
+#: src/routes/settings_.cloud-sync.tsx:238
 msgid "Signed in"
 msgstr "Signed in"
 
-#: src/routes/settings_.cloud-sync.tsx:567
+#: src/routes/settings_.cloud-sync.tsx:423
 msgid "Signed out"
 msgstr "Signed out"
 
@@ -2585,7 +2585,7 @@ msgstr "This debt is no longer available"
 msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 msgstr "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 
-#: src/routes/settings_.cloud-sync.tsx:588
+#: src/hooks/useCloudSyncAccountState.ts:191
 msgid "This device is already using trizum cloud"
 msgstr "This device is already using trizum cloud"
 
@@ -2700,26 +2700,26 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:882
+#: src/routes/settings_.cloud-sync.tsx:560
 #: src/routes/settings.tsx:216
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:236
-#: src/routes/settings_.cloud-sync.tsx:583
+#: src/hooks/useCloudSyncAccountState.ts:131
+#: src/hooks/useCloudSyncAccountState.ts:186
 msgid "trizum cloud data is invalid"
 msgstr "trizum cloud data is invalid"
 
-#: src/routes/settings_.cloud-sync.tsx:257
-#: src/routes/settings_.cloud-sync.tsx:602
+#: src/hooks/useCloudSyncAccountState.ts:152
+#: src/hooks/useCloudSyncAccountState.ts:210
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud enabled on this device"
 
-#: src/routes/settings_.cloud-sync.tsx:578
+#: src/hooks/useCloudSyncAccountState.ts:181
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud is not set up yet"
 
-#: src/routes/settings_.cloud-sync.tsx:219
+#: src/hooks/useCloudSyncAccountState.ts:114
 msgid "trizum cloud started"
 msgstr "trizum cloud started"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -79,7 +79,7 @@ msgstr "Accent color"
 msgid "Account created"
 msgstr "Account created"
 
-#: src/routes/settings_.cloud-sync.tsx:659
+#: src/routes/settings_.cloud-sync.tsx:642
 msgid "Account deleted"
 msgstr "Account deleted"
 
@@ -108,7 +108,7 @@ msgstr "Add"
 msgid "Add an expense"
 msgstr "Add an expense"
 
-#: src/routes/settings_.cloud-sync.tsx:911
+#: src/components/CloudSyncAccountSettings.tsx:43
 msgid "Add Apple as a sign-in method"
 msgstr "Add Apple as a sign-in method"
 
@@ -116,7 +116,7 @@ msgstr "Add Apple as a sign-in method"
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Add expenses to this party to unlock totals, rankings, and individual spend."
 
-#: src/routes/settings_.cloud-sync.tsx:930
+#: src/components/CloudSyncAccountSettings.tsx:56
 msgid "Add Google as a sign-in method"
 msgstr "Add Google as a sign-in method"
 
@@ -186,7 +186,7 @@ msgstr "Amount must be greater than 0"
 msgid "Angolan Kwanza"
 msgstr "Angolan Kwanza"
 
-#: src/routes/settings_.cloud-sync.tsx:907
+#: src/components/CloudSyncAccountSettings.tsx:39
 msgid "Apple"
 msgstr "Apple"
 
@@ -194,7 +194,7 @@ msgstr "Apple"
 msgid "Apple connected"
 msgstr "Apple connected"
 
-#: src/routes/settings_.cloud-sync.tsx:910
+#: src/components/CloudSyncAccountSettings.tsx:42
 msgid "Apple is connected to this account"
 msgstr "Apple is connected to this account"
 
@@ -263,14 +263,14 @@ msgstr "Attachments"
 msgid "Australian Dollar"
 msgstr "Australian Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:1162
+#: src/components/CloudSyncDialogs.tsx:132
 msgid "Authentication error"
 msgstr "Authentication error"
 
-#: src/routes/settings_.cloud-sync.tsx:451
+#: src/routes/settings_.cloud-sync.tsx:434
+#: src/routes/settings_.cloud-sync.tsx:446
 #: src/routes/settings_.cloud-sync.tsx:463
-#: src/routes/settings_.cloud-sync.tsx:480
-#: src/routes/settings_.cloud-sync.tsx:493
+#: src/routes/settings_.cloud-sync.tsx:476
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
@@ -303,12 +303,12 @@ msgstr "Azerbaijani Manat"
 msgid "Back to home"
 msgstr "Back to home"
 
+#: src/components/CloudSyncDialogs.tsx:209
 #: src/routes/reset-password.tsx:102
-#: src/routes/settings_.cloud-sync.tsx:1239
 msgid "Back to settings"
 msgstr "Back to settings"
 
-#: src/routes/settings_.cloud-sync.tsx:731
+#: src/routes/settings_.cloud-sync.tsx:714
 msgid "Back to sign in"
 msgstr "Back to sign in"
 
@@ -444,8 +444,8 @@ msgstr "Can't add an expense to a party that doesn't exist"
 msgid "Canadian Dollar"
 msgstr "Canadian Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:1621
-#: src/routes/settings_.cloud-sync.tsx:1789
+#: src/components/CloudSyncDialogs.tsx:464
+#: src/components/CloudSyncDialogs.tsx:632
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -481,11 +481,11 @@ msgstr "Changes sync automatically across all your devices"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/routes/settings_.cloud-sync.tsx:535
+#: src/routes/settings_.cloud-sync.tsx:518
 msgid "Check your email for the password link"
 msgstr "Check your email for the password link"
 
-#: src/routes/settings_.cloud-sync.tsx:421
+#: src/routes/settings_.cloud-sync.tsx:404
 msgid "Check your email for the sign-in link"
 msgstr "Check your email for the sign-in link"
 
@@ -586,7 +586,7 @@ msgstr "Complete your profile"
 msgid "Configure Profile"
 msgstr "Configure Profile"
 
-#: src/routes/settings_.cloud-sync.tsx:1572
+#: src/components/CloudSyncDialogs.tsx:415
 msgid "Confirm action"
 msgstr "Confirm action"
 
@@ -596,7 +596,7 @@ msgstr "Confirm action"
 msgid "Confirm transfer"
 msgstr "Confirm transfer"
 
-#: src/routes/settings_.cloud-sync.tsx:1764
+#: src/components/CloudSyncDialogs.tsx:607
 msgid "Confirmation"
 msgstr "Confirmation"
 
@@ -613,15 +613,15 @@ msgstr "Congolese Franc"
 msgid "Connect"
 msgstr "Connect"
 
-#: src/routes/settings_.cloud-sync.tsx:1650
+#: src/components/CloudSyncDialogs.tsx:493
 msgid "Connect Apple"
 msgstr "Connect Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:1657
+#: src/components/CloudSyncDialogs.tsx:500
 msgid "Connect Apple?"
 msgstr "Connect Apple?"
 
-#: src/routes/settings_.cloud-sync.tsx:1661
+#: src/components/CloudSyncDialogs.tsx:504
 msgid "Connect Google"
 msgstr "Connect Google"
 
@@ -629,12 +629,12 @@ msgstr "Connect Google"
 msgid "Connect Google, Apple, or a password to the same account."
 msgstr "Connect Google, Apple, or a password to the same account."
 
-#: src/routes/settings_.cloud-sync.tsx:1668
+#: src/components/CloudSyncDialogs.tsx:511
 msgid "Connect Google?"
 msgstr "Connect Google?"
 
-#: src/routes/settings_.cloud-sync.tsx:913
-#: src/routes/settings_.cloud-sync.tsx:932
+#: src/components/CloudSyncAccountSettings.tsx:45
+#: src/components/CloudSyncAccountSettings.tsx:58
 msgid "Connected"
 msgstr "Connected"
 
@@ -647,7 +647,7 @@ msgstr "Connected to this account"
 msgid "Connected: {linkedProviderLabels}"
 msgstr "Connected: {linkedProviderLabels}"
 
-#: src/routes/settings_.cloud-sync.tsx:904
+#: src/components/CloudSyncAccountSettings.tsx:36
 msgid "Connections"
 msgstr "Connections"
 
@@ -655,11 +655,11 @@ msgstr "Connections"
 msgid "Contact Us"
 msgstr "Contact Us"
 
-#: src/routes/settings_.cloud-sync.tsx:755
+#: src/routes/settings_.cloud-sync.tsx:738
 msgid "Continue with Apple"
 msgstr "Continue with Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:770
+#: src/routes/settings_.cloud-sync.tsx:753
 msgid "Continue with Google"
 msgstr "Continue with Google"
 
@@ -683,11 +683,11 @@ msgstr "Costa Rican Colón"
 msgid "Could not apply cloud settings"
 msgstr "Could not apply cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:521
+#: src/routes/settings_.cloud-sync.tsx:504
 msgid "Could not connect sign-in method"
 msgstr "Could not connect sign-in method"
 
-#: src/routes/settings_.cloud-sync.tsx:665
+#: src/routes/settings_.cloud-sync.tsx:648
 msgid "Could not delete account"
 msgstr "Could not delete account"
 
@@ -699,7 +699,7 @@ msgstr "Could not load cloud settings"
 msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
-#: src/routes/settings_.cloud-sync.tsx:260
+#: src/routes/settings_.cloud-sync.tsx:269
 #: src/routes/settings.tsx:388
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
@@ -712,15 +712,15 @@ msgstr "Could not reset password"
 msgid "Could not save cloud settings"
 msgstr "Could not save cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:538
+#: src/routes/settings_.cloud-sync.tsx:521
 msgid "Could not send password email"
 msgstr "Could not send password email"
 
-#: src/routes/settings_.cloud-sync.tsx:424
+#: src/routes/settings_.cloud-sync.tsx:407
 msgid "Could not send sign-in link"
 msgstr "Could not send sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:587
+#: src/routes/settings_.cloud-sync.tsx:570
 msgid "Could not sign out"
 msgstr "Could not sign out"
 
@@ -826,13 +826,13 @@ msgstr "Decimal point"
 msgid "Delete"
 msgstr "Delete"
 
-#: src/routes/settings_.cloud-sync.tsx:979
-#: src/routes/settings_.cloud-sync.tsx:1743
-#: src/routes/settings_.cloud-sync.tsx:1778
+#: src/components/CloudSyncAccountSettings.tsx:95
+#: src/components/CloudSyncDialogs.tsx:586
+#: src/components/CloudSyncDialogs.tsx:621
 msgid "Delete account"
 msgstr "Delete account"
 
-#: src/routes/settings_.cloud-sync.tsx:1749
+#: src/components/CloudSyncDialogs.tsx:592
 msgid "Delete account?"
 msgstr "Delete account?"
 
@@ -849,7 +849,7 @@ msgstr "Description must be less than 500 characters"
 msgid "Destination party"
 msgstr "Destination party"
 
-#: src/routes/settings_.cloud-sync.tsx:976
+#: src/components/CloudSyncAccountSettings.tsx:92
 msgid "Destructive actions"
 msgstr "Destructive actions"
 
@@ -889,14 +889,14 @@ msgstr "Editing {expenseName}"
 msgid "Egyptian Pound"
 msgstr "Egyptian Pound"
 
-#: src/routes/settings_.cloud-sync.tsx:703
-#: src/routes/settings_.cloud-sync.tsx:789
-#: src/routes/settings_.cloud-sync.tsx:855
-#: src/routes/settings_.cloud-sync.tsx:948
+#: src/components/CloudSyncAccountSettings.tsx:68
+#: src/routes/settings_.cloud-sync.tsx:686
+#: src/routes/settings_.cloud-sync.tsx:772
+#: src/routes/settings_.cloud-sync.tsx:838
 msgid "Email"
 msgstr "Email"
 
-#: src/routes/settings_.cloud-sync.tsx:958
+#: src/components/CloudSyncAccountSettings.tsx:78
 msgid "Email a password reset link"
 msgstr "Email a password reset link"
 
@@ -912,15 +912,15 @@ msgstr "Email addresses don't match"
 msgid "Email link"
 msgstr "Email link"
 
-#: src/routes/settings_.cloud-sync.tsx:866
+#: src/routes/settings_.cloud-sync.tsx:849
 msgid "Email me a sign-in link"
 msgstr "Email me a sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:1672
+#: src/components/CloudSyncDialogs.tsx:515
 msgid "Email password link"
 msgstr "Email password link"
 
-#: src/routes/settings_.cloud-sync.tsx:1685
+#: src/components/CloudSyncDialogs.tsx:528
 msgid "Email password link?"
 msgstr "Email password link?"
 
@@ -1096,8 +1096,8 @@ msgstr "Fijian Dollar"
 msgid "Filter totals and rankings"
 msgstr "Filter totals and rankings"
 
-#: src/routes/settings_.cloud-sync.tsx:1291
-#: src/routes/settings_.cloud-sync.tsx:1302
+#: src/components/CloudSyncDialogs.tsx:267
+#: src/components/CloudSyncDialogs.tsx:278
 msgid "Finishing sign in"
 msgstr "Finishing sign in"
 
@@ -1105,7 +1105,7 @@ msgstr "Finishing sign in"
 msgid "For payments through Bizum or similar services"
 msgstr "For payments through Bizum or similar services"
 
-#: src/routes/settings_.cloud-sync.tsx:844
+#: src/routes/settings_.cloud-sync.tsx:827
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
@@ -1158,7 +1158,7 @@ msgstr "Go back to home"
 msgid "Gold (troy ounce)"
 msgstr "Gold (troy ounce)"
 
-#: src/routes/settings_.cloud-sync.tsx:926
+#: src/components/CloudSyncAccountSettings.tsx:52
 msgid "Google"
 msgstr "Google"
 
@@ -1166,11 +1166,11 @@ msgstr "Google"
 msgid "Google connected"
 msgstr "Google connected"
 
-#: src/routes/settings_.cloud-sync.tsx:929
+#: src/components/CloudSyncAccountSettings.tsx:55
 msgid "Google is connected to this account"
 msgstr "Google is connected to this account"
 
-#: src/routes/settings_.cloud-sync.tsx:1187
+#: src/components/CloudSyncDialogs.tsx:157
 msgid "Got it"
 msgstr "Got it"
 
@@ -1798,7 +1798,7 @@ msgstr "Optional description for this expense"
 msgid "or enter code"
 msgstr "or enter code"
 
-#: src/routes/settings_.cloud-sync.tsx:777
+#: src/routes/settings_.cloud-sync.tsx:760
 msgid "or use email"
 msgstr "or use email"
 
@@ -1928,12 +1928,12 @@ msgstr "Party stats"
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
-#: src/routes/settings_.cloud-sync.tsx:799
-#: src/routes/settings_.cloud-sync.tsx:955
+#: src/components/CloudSyncAccountSettings.tsx:75
+#: src/routes/settings_.cloud-sync.tsx:782
 msgid "Password"
 msgstr "Password"
 
-#: src/routes/settings_.cloud-sync.tsx:536
+#: src/routes/settings_.cloud-sync.tsx:519
 msgid "Password email sent"
 msgstr "Password email sent"
 
@@ -1978,7 +1978,7 @@ msgstr "Pay"
 msgid "People that owe you money"
 msgstr "People that owe you money"
 
-#: src/routes/settings_.cloud-sync.tsx:980
+#: src/components/CloudSyncAccountSettings.tsx:96
 msgid "Permanently delete your trizum cloud account"
 msgstr "Permanently delete your trizum cloud account"
 
@@ -2198,7 +2198,7 @@ msgstr "Search emoji"
 msgid "Search emoji..."
 msgstr "Search emoji..."
 
-#: src/routes/settings_.cloud-sync.tsx:945
+#: src/components/CloudSyncAccountSettings.tsx:65
 msgid "Security"
 msgstr "Security"
 
@@ -2210,7 +2210,7 @@ msgstr "See spending totals and rankings"
 msgid "Select emoji"
 msgstr "Select emoji"
 
-#: src/routes/settings_.cloud-sync.tsx:719
+#: src/routes/settings_.cloud-sync.tsx:702
 msgid "Send password link"
 msgstr "Send password link"
 
@@ -2226,11 +2226,11 @@ msgstr "Serbian Dinar"
 msgid "Set up"
 msgstr "Set up"
 
-#: src/routes/settings_.cloud-sync.tsx:958
+#: src/components/CloudSyncAccountSettings.tsx:78
 msgid "Set up password sign-in"
 msgstr "Set up password sign-in"
 
-#: src/routes/settings_.cloud-sync.tsx:1685
+#: src/components/CloudSyncDialogs.tsx:528
 msgid "Set up password?"
 msgstr "Set up password?"
 
@@ -2290,34 +2290,34 @@ msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amoun
 msgid "Sierra Leonean Leone"
 msgstr "Sierra Leonean Leone"
 
-#: src/routes/settings_.cloud-sync.tsx:1235
+#: src/components/CloudSyncDialogs.tsx:205
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/routes/settings_.cloud-sync.tsx:1822
+#: src/routes/settings_.cloud-sync.tsx:977
 msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
-#: src/routes/settings_.cloud-sync.tsx:1255
+#: src/components/CloudSyncDialogs.tsx:225
 msgid "Sign in to trizum cloud"
 msgstr "Sign in to trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:831
+#: src/routes/settings_.cloud-sync.tsx:814
 msgid "Sign in with magic link"
 msgstr "Sign in with magic link"
 
-#: src/routes/settings_.cloud-sync.tsx:816
-#: src/routes/settings_.cloud-sync.tsx:881
+#: src/routes/settings_.cloud-sync.tsx:799
+#: src/routes/settings_.cloud-sync.tsx:864
 msgid "Sign in with password"
 msgstr "Sign in with password"
 
-#: src/routes/settings_.cloud-sync.tsx:967
-#: src/routes/settings_.cloud-sync.tsx:1117
-#: src/routes/settings_.cloud-sync.tsx:1689
+#: src/components/CloudSyncAccountSettings.tsx:85
+#: src/components/CloudSyncDialogs.tsx:87
+#: src/components/CloudSyncDialogs.tsx:532
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/routes/settings_.cloud-sync.tsx:1696
+#: src/components/CloudSyncDialogs.tsx:539
 msgid "Sign out?"
 msgstr "Sign out?"
 
@@ -2329,15 +2329,15 @@ msgstr "Sign-in link expired"
 msgid "Sign-in link is invalid or expired"
 msgstr "Sign-in link is invalid or expired"
 
-#: src/routes/settings_.cloud-sync.tsx:422
+#: src/routes/settings_.cloud-sync.tsx:405
 msgid "Sign-in link sent"
 msgstr "Sign-in link sent"
 
-#: src/routes/settings_.cloud-sync.tsx:519
+#: src/routes/settings_.cloud-sync.tsx:502
 msgid "Sign-in method connected"
 msgstr "Sign-in method connected"
 
-#: src/routes/settings_.cloud-sync.tsx:460
+#: src/routes/settings_.cloud-sync.tsx:443
 msgid "Sign-in method is not configured"
 msgstr "Sign-in method is not configured"
 
@@ -2345,13 +2345,13 @@ msgstr "Sign-in method is not configured"
 msgid "Sign-in methods"
 msgstr "Sign-in methods"
 
-#: src/routes/settings_.cloud-sync.tsx:366
-#: src/routes/settings_.cloud-sync.tsx:950
-#: src/routes/settings_.cloud-sync.tsx:1371
+#: src/components/CloudSyncAccountSettings.tsx:70
+#: src/components/CloudSyncDialogs.tsx:369
+#: src/routes/settings_.cloud-sync.tsx:375
 msgid "Signed in"
 msgstr "Signed in"
 
-#: src/routes/settings_.cloud-sync.tsx:584
+#: src/routes/settings_.cloud-sync.tsx:567
 msgid "Signed out"
 msgstr "Signed out"
 
@@ -2428,7 +2428,7 @@ msgstr "Start tracking expenses with your group"
 msgid "Stats"
 msgstr "Stats"
 
-#: src/routes/settings_.cloud-sync.tsx:968
+#: src/components/CloudSyncAccountSettings.tsx:86
 msgid "Stop trizum cloud on this device"
 msgstr "Stop trizum cloud on this device"
 
@@ -2581,11 +2581,11 @@ msgstr "This application uses the following open source libraries and tools. Bel
 msgid "This debt is no longer available"
 msgstr "This debt is no longer available"
 
-#: src/routes/settings_.cloud-sync.tsx:1095
+#: src/components/CloudSyncDialogs.tsx:65
 msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 msgstr "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 
-#: src/routes/settings_.cloud-sync.tsx:605
+#: src/routes/settings_.cloud-sync.tsx:588
 msgid "This device is already using trizum cloud"
 msgstr "This device is already using trizum cloud"
 
@@ -2605,7 +2605,7 @@ msgstr "This isn't a valid ID"
 msgid "This party needs another active participant besides you to receive the transferred debt."
 msgstr "This party needs another active participant besides you to receive the transferred debt."
 
-#: src/routes/settings_.cloud-sync.tsx:1752
+#: src/components/CloudSyncDialogs.tsx:595
 msgid "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 msgstr "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 
@@ -2617,7 +2617,7 @@ msgstr "This project uses various open source libraries and tools."
 msgid "This sign-in link is invalid or expired. Request a new link and try again."
 msgstr "This sign-in link is invalid or expired. Request a new link and try again."
 
-#: src/routes/settings_.cloud-sync.tsx:1691
+#: src/components/CloudSyncDialogs.tsx:534
 msgid "This stops trizum cloud on this device. Your local data stays on this device."
 msgstr "This stops trizum cloud on this device. Your local data stays on this device."
 
@@ -2700,26 +2700,26 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:899
+#: src/routes/settings_.cloud-sync.tsx:882
 #: src/routes/settings.tsx:216
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:227
-#: src/routes/settings_.cloud-sync.tsx:600
+#: src/routes/settings_.cloud-sync.tsx:236
+#: src/routes/settings_.cloud-sync.tsx:583
 msgid "trizum cloud data is invalid"
 msgstr "trizum cloud data is invalid"
 
-#: src/routes/settings_.cloud-sync.tsx:248
-#: src/routes/settings_.cloud-sync.tsx:619
+#: src/routes/settings_.cloud-sync.tsx:257
+#: src/routes/settings_.cloud-sync.tsx:602
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud enabled on this device"
 
-#: src/routes/settings_.cloud-sync.tsx:595
+#: src/routes/settings_.cloud-sync.tsx:578
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud is not set up yet"
 
-#: src/routes/settings_.cloud-sync.tsx:210
+#: src/routes/settings_.cloud-sync.tsx:219
 msgid "trizum cloud started"
 msgstr "trizum cloud started"
 
@@ -2731,11 +2731,11 @@ msgstr "trizum could not finish connecting that sign-in method. Please try again
 msgid "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 msgstr "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 
-#: src/routes/settings_.cloud-sync.tsx:1652
+#: src/components/CloudSyncDialogs.tsx:495
 msgid "trizum will open Apple so you can add it as a sign-in method for this account."
 msgstr "trizum will open Apple so you can add it as a sign-in method for this account."
 
-#: src/routes/settings_.cloud-sync.tsx:1663
+#: src/components/CloudSyncDialogs.tsx:506
 msgid "trizum will open Google so you can add it as a sign-in method for this account."
 msgstr "trizum will open Google so you can add it as a sign-in method for this account."
 
@@ -2744,7 +2744,7 @@ msgstr "trizum will open Google so you can add it as a sign-in method for this a
 msgid "Try again"
 msgstr "Try again"
 
-#: src/routes/settings_.cloud-sync.tsx:1341
+#: src/components/CloudSyncDialogs.tsx:317
 msgid "Try another email"
 msgstr "Try another email"
 
@@ -2768,7 +2768,7 @@ msgstr "Turkish Lira"
 msgid "Turkmenistani Manat"
 msgstr "Turkmenistani Manat"
 
-#: src/routes/settings_.cloud-sync.tsx:1762
+#: src/components/CloudSyncDialogs.tsx:605
 msgid "Type \"delete account\" to confirm."
 msgstr "Type \"delete account\" to confirm."
 
@@ -2869,7 +2869,7 @@ msgstr "US Dollar"
 msgid "US Dollar (Next day)"
 msgstr "US Dollar (Next day)"
 
-#: src/routes/settings_.cloud-sync.tsx:1107
+#: src/components/CloudSyncDialogs.tsx:77
 msgid "Use cloud data"
 msgstr "Use cloud data"
 
@@ -2885,8 +2885,8 @@ msgstr "Use it on this device to continue with your cloud data."
 msgid "Use personal mode to filter only your expenses."
 msgstr "Use personal mode to filter only your expenses."
 
-#: src/routes/settings_.cloud-sync.tsx:1082
-#: src/routes/settings_.cloud-sync.tsx:1092
+#: src/components/CloudSyncDialogs.tsx:52
+#: src/components/CloudSyncDialogs.tsx:62
 msgid "Use trizum cloud on this device?"
 msgstr "Use trizum cloud on this device?"
 
@@ -2951,15 +2951,15 @@ msgstr "Viewing as {participantName}"
 msgid "Warning: Split amounts don't match total expense"
 msgstr "Warning: Split amounts don't match total expense"
 
-#: src/routes/settings_.cloud-sync.tsx:1335
+#: src/components/CloudSyncDialogs.tsx:311
 msgid "We sent a sign-in link to {email}. Open it to finish signing in."
 msgstr "We sent a sign-in link to {email}. Open it to finish signing in."
 
-#: src/routes/settings_.cloud-sync.tsx:1674
+#: src/components/CloudSyncDialogs.tsx:517
 msgid "We will email a password link to {email}. Your current password keeps working until you change it."
 msgstr "We will email a password link to {email}. Your current password keeps working until you change it."
 
-#: src/routes/settings_.cloud-sync.tsx:1679
+#: src/components/CloudSyncDialogs.tsx:522
 msgid "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 msgstr "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -75,7 +75,7 @@ msgstr "Color de acento"
 msgid "Account created"
 msgstr "Cuenta creada"
 
-#: src/routes/settings_.cloud-sync.tsx:659
+#: src/routes/settings_.cloud-sync.tsx:642
 msgid "Account deleted"
 msgstr "Cuenta eliminada"
 
@@ -104,7 +104,7 @@ msgstr "Sumar"
 msgid "Add an expense"
 msgstr "Añadir un gasto"
 
-#: src/routes/settings_.cloud-sync.tsx:911
+#: src/components/CloudSyncAccountSettings.tsx:43
 msgid "Add Apple as a sign-in method"
 msgstr "Añadir Apple como método de inicio de sesión"
 
@@ -112,7 +112,7 @@ msgstr "Añadir Apple como método de inicio de sesión"
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto individual."
 
-#: src/routes/settings_.cloud-sync.tsx:930
+#: src/components/CloudSyncAccountSettings.tsx:56
 msgid "Add Google as a sign-in method"
 msgstr "Añadir Google como método de inicio de sesión"
 
@@ -178,7 +178,7 @@ msgstr "La cantidad debe ser mayor que 0"
 msgid "Angolan Kwanza"
 msgstr "Kwanza Angoleño"
 
-#: src/routes/settings_.cloud-sync.tsx:907
+#: src/components/CloudSyncAccountSettings.tsx:39
 msgid "Apple"
 msgstr "Apple"
 
@@ -186,7 +186,7 @@ msgstr "Apple"
 msgid "Apple connected"
 msgstr "Apple conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:910
+#: src/components/CloudSyncAccountSettings.tsx:42
 msgid "Apple is connected to this account"
 msgstr "Apple está conectado a esta cuenta"
 
@@ -251,14 +251,14 @@ msgstr "Adjuntos"
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
-#: src/routes/settings_.cloud-sync.tsx:1162
+#: src/components/CloudSyncDialogs.tsx:132
 msgid "Authentication error"
 msgstr "Error de autenticación"
 
-#: src/routes/settings_.cloud-sync.tsx:451
+#: src/routes/settings_.cloud-sync.tsx:434
+#: src/routes/settings_.cloud-sync.tsx:446
 #: src/routes/settings_.cloud-sync.tsx:463
-#: src/routes/settings_.cloud-sync.tsx:480
-#: src/routes/settings_.cloud-sync.tsx:493
+#: src/routes/settings_.cloud-sync.tsx:476
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
@@ -291,12 +291,12 @@ msgstr "Manat Azerbaiyano"
 msgid "Back to home"
 msgstr "Volver al inicio"
 
+#: src/components/CloudSyncDialogs.tsx:209
 #: src/routes/reset-password.tsx:102
-#: src/routes/settings_.cloud-sync.tsx:1239
 msgid "Back to settings"
 msgstr "Volver a configuración"
 
-#: src/routes/settings_.cloud-sync.tsx:731
+#: src/routes/settings_.cloud-sync.tsx:714
 msgid "Back to sign in"
 msgstr "Volver a iniciar sesión"
 
@@ -424,8 +424,8 @@ msgstr "¿Puedo usar trizum sin una cuenta?"
 msgid "Canadian Dollar"
 msgstr "Dólar Canadiense"
 
-#: src/routes/settings_.cloud-sync.tsx:1621
-#: src/routes/settings_.cloud-sync.tsx:1789
+#: src/components/CloudSyncDialogs.tsx:464
+#: src/components/CloudSyncDialogs.tsx:632
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -461,11 +461,11 @@ msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
-#: src/routes/settings_.cloud-sync.tsx:535
+#: src/routes/settings_.cloud-sync.tsx:518
 msgid "Check your email for the password link"
 msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:421
+#: src/routes/settings_.cloud-sync.tsx:404
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
@@ -562,7 +562,7 @@ msgstr "Completa tu perfil"
 msgid "Configure Profile"
 msgstr "Configurar perfil"
 
-#: src/routes/settings_.cloud-sync.tsx:1572
+#: src/components/CloudSyncDialogs.tsx:415
 msgid "Confirm action"
 msgstr "Confirmar acción"
 
@@ -572,7 +572,7 @@ msgstr "Confirmar acción"
 msgid "Confirm transfer"
 msgstr "Confirmar transferencia"
 
-#: src/routes/settings_.cloud-sync.tsx:1764
+#: src/components/CloudSyncDialogs.tsx:607
 msgid "Confirmation"
 msgstr "Confirmación"
 
@@ -589,15 +589,15 @@ msgstr "Franco Congoleño"
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/routes/settings_.cloud-sync.tsx:1650
+#: src/components/CloudSyncDialogs.tsx:493
 msgid "Connect Apple"
 msgstr "Conectar Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:1657
+#: src/components/CloudSyncDialogs.tsx:500
 msgid "Connect Apple?"
 msgstr "¿Conectar Apple?"
 
-#: src/routes/settings_.cloud-sync.tsx:1661
+#: src/components/CloudSyncDialogs.tsx:504
 msgid "Connect Google"
 msgstr "Conectar Google"
 
@@ -605,12 +605,12 @@ msgstr "Conectar Google"
 msgid "Connect Google, Apple, or a password to the same account."
 msgstr "Conecta Google, Apple o una contraseña a la misma cuenta."
 
-#: src/routes/settings_.cloud-sync.tsx:1668
+#: src/components/CloudSyncDialogs.tsx:511
 msgid "Connect Google?"
 msgstr "¿Conectar Google?"
 
-#: src/routes/settings_.cloud-sync.tsx:913
-#: src/routes/settings_.cloud-sync.tsx:932
+#: src/components/CloudSyncAccountSettings.tsx:45
+#: src/components/CloudSyncAccountSettings.tsx:58
 msgid "Connected"
 msgstr "Conectado"
 
@@ -623,7 +623,7 @@ msgstr "Conectado a esta cuenta"
 msgid "Connected: {linkedProviderLabels}"
 msgstr "Conectado: {linkedProviderLabels}"
 
-#: src/routes/settings_.cloud-sync.tsx:904
+#: src/components/CloudSyncAccountSettings.tsx:36
 msgid "Connections"
 msgstr "Conexiones"
 
@@ -631,11 +631,11 @@ msgstr "Conexiones"
 msgid "Contact Us"
 msgstr "Contacto"
 
-#: src/routes/settings_.cloud-sync.tsx:755
+#: src/routes/settings_.cloud-sync.tsx:738
 msgid "Continue with Apple"
 msgstr "Continuar con Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:770
+#: src/routes/settings_.cloud-sync.tsx:753
 msgid "Continue with Google"
 msgstr "Continuar con Google"
 
@@ -659,11 +659,11 @@ msgstr "Colón Costarricense"
 msgid "Could not apply cloud settings"
 msgstr "No se pudo aplicar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:521
+#: src/routes/settings_.cloud-sync.tsx:504
 msgid "Could not connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:665
+#: src/routes/settings_.cloud-sync.tsx:648
 msgid "Could not delete account"
 msgstr "No se pudo eliminar la cuenta"
 
@@ -675,7 +675,7 @@ msgstr "No se pudo cargar la configuración en la nube"
 msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:260
+#: src/routes/settings_.cloud-sync.tsx:269
 #: src/routes/settings.tsx:388
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
@@ -688,15 +688,15 @@ msgstr "No se pudo restablecer la contraseña"
 msgid "Could not save cloud settings"
 msgstr "No se pudo guardar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:538
+#: src/routes/settings_.cloud-sync.tsx:521
 msgid "Could not send password email"
 msgstr "No se pudo enviar el correo de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:424
+#: src/routes/settings_.cloud-sync.tsx:407
 msgid "Could not send sign-in link"
 msgstr "No se pudo enviar el enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:587
+#: src/routes/settings_.cloud-sync.tsx:570
 msgid "Could not sign out"
 msgstr "No se pudo cerrar sesión"
 
@@ -798,13 +798,13 @@ msgstr "Punto decimal"
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/routes/settings_.cloud-sync.tsx:979
-#: src/routes/settings_.cloud-sync.tsx:1743
-#: src/routes/settings_.cloud-sync.tsx:1778
+#: src/components/CloudSyncAccountSettings.tsx:95
+#: src/components/CloudSyncDialogs.tsx:586
+#: src/components/CloudSyncDialogs.tsx:621
 msgid "Delete account"
 msgstr "Eliminar cuenta"
 
-#: src/routes/settings_.cloud-sync.tsx:1749
+#: src/components/CloudSyncDialogs.tsx:592
 msgid "Delete account?"
 msgstr "¿Eliminar cuenta?"
 
@@ -821,7 +821,7 @@ msgstr "La descripción debe tener menos de 500 caracteres"
 msgid "Destination party"
 msgstr "Grupo de destino"
 
-#: src/routes/settings_.cloud-sync.tsx:976
+#: src/components/CloudSyncAccountSettings.tsx:92
 msgid "Destructive actions"
 msgstr "Acciones destructivas"
 
@@ -861,14 +861,14 @@ msgstr "Editando {expenseName}"
 msgid "Egyptian Pound"
 msgstr "Libra Egipcia"
 
-#: src/routes/settings_.cloud-sync.tsx:703
-#: src/routes/settings_.cloud-sync.tsx:789
-#: src/routes/settings_.cloud-sync.tsx:855
-#: src/routes/settings_.cloud-sync.tsx:948
+#: src/components/CloudSyncAccountSettings.tsx:68
+#: src/routes/settings_.cloud-sync.tsx:686
+#: src/routes/settings_.cloud-sync.tsx:772
+#: src/routes/settings_.cloud-sync.tsx:838
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: src/routes/settings_.cloud-sync.tsx:958
+#: src/components/CloudSyncAccountSettings.tsx:78
 msgid "Email a password reset link"
 msgstr "Enviar un enlace para restablecer la contraseña"
 
@@ -884,15 +884,15 @@ msgstr "Los correos no coinciden"
 msgid "Email link"
 msgstr "Enviar enlace"
 
-#: src/routes/settings_.cloud-sync.tsx:866
+#: src/routes/settings_.cloud-sync.tsx:849
 msgid "Email me a sign-in link"
 msgstr "Enviarme un enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1672
+#: src/components/CloudSyncDialogs.tsx:515
 msgid "Email password link"
 msgstr "Enviar enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:1685
+#: src/components/CloudSyncDialogs.tsx:528
 msgid "Email password link?"
 msgstr "¿Enviar enlace de contraseña?"
 
@@ -1052,8 +1052,8 @@ msgstr "Dólar Fiyiano"
 msgid "Filter totals and rankings"
 msgstr "Filtra totales y rankings"
 
-#: src/routes/settings_.cloud-sync.tsx:1291
-#: src/routes/settings_.cloud-sync.tsx:1302
+#: src/components/CloudSyncDialogs.tsx:267
+#: src/components/CloudSyncDialogs.tsx:278
 msgid "Finishing sign in"
 msgstr "Terminando el inicio de sesión"
 
@@ -1061,7 +1061,7 @@ msgstr "Terminando el inicio de sesión"
 msgid "For payments through Bizum or similar services"
 msgstr "Para pagos mediante Bizum o servicios similares"
 
-#: src/routes/settings_.cloud-sync.tsx:844
+#: src/routes/settings_.cloud-sync.tsx:827
 msgid "Forgot password?"
 msgstr "¿Olvidaste tu contraseña?"
 
@@ -1114,7 +1114,7 @@ msgstr "Volver al inicio"
 msgid "Gold (troy ounce)"
 msgstr "Oro (onza troy)"
 
-#: src/routes/settings_.cloud-sync.tsx:926
+#: src/components/CloudSyncAccountSettings.tsx:52
 msgid "Google"
 msgstr "Google"
 
@@ -1122,11 +1122,11 @@ msgstr "Google"
 msgid "Google connected"
 msgstr "Google conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:929
+#: src/components/CloudSyncAccountSettings.tsx:55
 msgid "Google is connected to this account"
 msgstr "Google está conectado a esta cuenta"
 
-#: src/routes/settings_.cloud-sync.tsx:1187
+#: src/components/CloudSyncDialogs.tsx:157
 msgid "Got it"
 msgstr "Entendido"
 
@@ -1738,7 +1738,7 @@ msgstr "Abrir paréntesis"
 msgid "or enter code"
 msgstr "o introduce código"
 
-#: src/routes/settings_.cloud-sync.tsx:777
+#: src/routes/settings_.cloud-sync.tsx:760
 msgid "or use email"
 msgstr "o usa el correo"
 
@@ -1860,12 +1860,12 @@ msgstr "Estadísticas del grupo"
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
-#: src/routes/settings_.cloud-sync.tsx:799
-#: src/routes/settings_.cloud-sync.tsx:955
+#: src/components/CloudSyncAccountSettings.tsx:75
+#: src/routes/settings_.cloud-sync.tsx:782
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:536
+#: src/routes/settings_.cloud-sync.tsx:519
 msgid "Password email sent"
 msgstr "Correo de contraseña enviado"
 
@@ -1910,7 +1910,7 @@ msgstr "Pagar"
 msgid "People that owe you money"
 msgstr "Personas que te deben dinero"
 
-#: src/routes/settings_.cloud-sync.tsx:980
+#: src/components/CloudSyncAccountSettings.tsx:96
 msgid "Permanently delete your trizum cloud account"
 msgstr "Eliminar permanentemente tu cuenta de trizum cloud"
 
@@ -2126,7 +2126,7 @@ msgstr "Buscar emoji"
 msgid "Search emoji..."
 msgstr "Buscar emoji..."
 
-#: src/routes/settings_.cloud-sync.tsx:945
+#: src/components/CloudSyncAccountSettings.tsx:65
 msgid "Security"
 msgstr "Seguridad"
 
@@ -2138,7 +2138,7 @@ msgstr "Ver totales y clasificación de gasto"
 msgid "Select emoji"
 msgstr "Seleccionar emoji"
 
-#: src/routes/settings_.cloud-sync.tsx:719
+#: src/routes/settings_.cloud-sync.tsx:702
 msgid "Send password link"
 msgstr "Enviar enlace de contraseña"
 
@@ -2154,11 +2154,11 @@ msgstr "Dinar Serbio"
 msgid "Set up"
 msgstr "Configurar"
 
-#: src/routes/settings_.cloud-sync.tsx:958
+#: src/components/CloudSyncAccountSettings.tsx:78
 msgid "Set up password sign-in"
 msgstr "Configurar inicio de sesión con contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:1685
+#: src/components/CloudSyncDialogs.tsx:528
 msgid "Set up password?"
 msgstr "¿Configurar contraseña?"
 
@@ -2218,34 +2218,34 @@ msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantida
 msgid "Sierra Leonean Leone"
 msgstr "Leone de Sierra Leona"
 
-#: src/routes/settings_.cloud-sync.tsx:1235
+#: src/components/CloudSyncDialogs.tsx:205
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1822
+#: src/routes/settings_.cloud-sync.tsx:977
 msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
-#: src/routes/settings_.cloud-sync.tsx:1255
+#: src/components/CloudSyncDialogs.tsx:225
 msgid "Sign in to trizum cloud"
 msgstr "Iniciar sesión en trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:831
+#: src/routes/settings_.cloud-sync.tsx:814
 msgid "Sign in with magic link"
 msgstr "Iniciar sesión con enlace mágico"
 
-#: src/routes/settings_.cloud-sync.tsx:816
-#: src/routes/settings_.cloud-sync.tsx:881
+#: src/routes/settings_.cloud-sync.tsx:799
+#: src/routes/settings_.cloud-sync.tsx:864
 msgid "Sign in with password"
 msgstr "Iniciar sesión con contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:967
-#: src/routes/settings_.cloud-sync.tsx:1117
-#: src/routes/settings_.cloud-sync.tsx:1689
+#: src/components/CloudSyncAccountSettings.tsx:85
+#: src/components/CloudSyncDialogs.tsx:87
+#: src/components/CloudSyncDialogs.tsx:532
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:1696
+#: src/components/CloudSyncDialogs.tsx:539
 msgid "Sign out?"
 msgstr "¿Cerrar sesión?"
 
@@ -2257,15 +2257,15 @@ msgstr "El enlace de inicio de sesión ha caducado"
 msgid "Sign-in link is invalid or expired"
 msgstr "El enlace de inicio de sesión no es válido o ha caducado"
 
-#: src/routes/settings_.cloud-sync.tsx:422
+#: src/routes/settings_.cloud-sync.tsx:405
 msgid "Sign-in link sent"
 msgstr "Enlace de inicio de sesión enviado"
 
-#: src/routes/settings_.cloud-sync.tsx:519
+#: src/routes/settings_.cloud-sync.tsx:502
 msgid "Sign-in method connected"
 msgstr "Método de inicio de sesión conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:460
+#: src/routes/settings_.cloud-sync.tsx:443
 msgid "Sign-in method is not configured"
 msgstr "El método de inicio de sesión no está configurado"
 
@@ -2273,13 +2273,13 @@ msgstr "El método de inicio de sesión no está configurado"
 msgid "Sign-in methods"
 msgstr "Métodos de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:366
-#: src/routes/settings_.cloud-sync.tsx:950
-#: src/routes/settings_.cloud-sync.tsx:1371
+#: src/components/CloudSyncAccountSettings.tsx:70
+#: src/components/CloudSyncDialogs.tsx:369
+#: src/routes/settings_.cloud-sync.tsx:375
 msgid "Signed in"
 msgstr "Sesión iniciada"
 
-#: src/routes/settings_.cloud-sync.tsx:584
+#: src/routes/settings_.cloud-sync.tsx:567
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
@@ -2352,7 +2352,7 @@ msgstr "Comienza a registrar gastos con tu grupo"
 msgid "Stats"
 msgstr "Estadísticas"
 
-#: src/routes/settings_.cloud-sync.tsx:968
+#: src/components/CloudSyncAccountSettings.tsx:86
 msgid "Stop trizum cloud on this device"
 msgstr "Detener trizum cloud en este dispositivo"
 
@@ -2505,11 +2505,11 @@ msgstr "Esta aplicación utiliza las siguientes bibliotecas y herramientas de c�
 msgid "This debt is no longer available"
 msgstr "Esta deuda ya no está disponible"
 
-#: src/routes/settings_.cloud-sync.tsx:1095
+#: src/components/CloudSyncDialogs.tsx:65
 msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 msgstr "Este dispositivo ya tiene datos locales. Si usas trizum cloud aquí, este dispositivo cambiará a tus datos en la nube. Los datos locales de este dispositivo dejarán de usarse."
 
-#: src/routes/settings_.cloud-sync.tsx:605
+#: src/routes/settings_.cloud-sync.tsx:588
 msgid "This device is already using trizum cloud"
 msgstr "Este dispositivo ya usa trizum cloud"
 
@@ -2529,7 +2529,7 @@ msgstr "Este no es un ID válido"
 msgid "This party needs another active participant besides you to receive the transferred debt."
 msgstr "Este grupo necesita otro participante activo además de ti para recibir la deuda transferida."
 
-#: src/routes/settings_.cloud-sync.tsx:1752
+#: src/components/CloudSyncDialogs.tsx:595
 msgid "This permanently deletes your trizum cloud account, sign-in methods, and cloud settings. Your local data on this device will remain."
 msgstr "Esto elimina permanentemente tu cuenta de trizum cloud, los métodos de inicio de sesión y la configuración en la nube. Tus datos locales en este dispositivo se conservarán."
 
@@ -2541,7 +2541,7 @@ msgstr "Este proyecto utiliza varias bibliotecas y herramientas de código abier
 msgid "This sign-in link is invalid or expired. Request a new link and try again."
 msgstr "Este enlace de inicio de sesión no es válido o ha caducado. Solicita un enlace nuevo e inténtalo de nuevo."
 
-#: src/routes/settings_.cloud-sync.tsx:1691
+#: src/components/CloudSyncDialogs.tsx:534
 msgid "This stops trizum cloud on this device. Your local data stays on this device."
 msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se quedan en este dispositivo."
 
@@ -2612,26 +2612,26 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/settings_.cloud-sync.tsx:899
+#: src/routes/settings_.cloud-sync.tsx:882
 #: src/routes/settings.tsx:216
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:227
-#: src/routes/settings_.cloud-sync.tsx:600
+#: src/routes/settings_.cloud-sync.tsx:236
+#: src/routes/settings_.cloud-sync.tsx:583
 msgid "trizum cloud data is invalid"
 msgstr "Los datos de trizum cloud no son válidos"
 
-#: src/routes/settings_.cloud-sync.tsx:248
-#: src/routes/settings_.cloud-sync.tsx:619
+#: src/routes/settings_.cloud-sync.tsx:257
+#: src/routes/settings_.cloud-sync.tsx:602
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud activado en este dispositivo"
 
-#: src/routes/settings_.cloud-sync.tsx:595
+#: src/routes/settings_.cloud-sync.tsx:578
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud todavía no está configurado"
 
-#: src/routes/settings_.cloud-sync.tsx:210
+#: src/routes/settings_.cloud-sync.tsx:219
 msgid "trizum cloud started"
 msgstr "trizum cloud iniciado"
 
@@ -2643,11 +2643,11 @@ msgstr "trizum no pudo terminar de conectar ese método de inicio de sesión. In
 msgid "trizum stores all your data locally on your device. When you're online and share a group with others, changes sync automatically across all devices in real-time."
 msgstr "trizum almacena todos tus datos localmente en tu dispositivo. Cuando estás conectado y compartes un grupo con otros, los cambios se sincronizan automáticamente en todos los dispositivos en tiempo real."
 
-#: src/routes/settings_.cloud-sync.tsx:1652
+#: src/components/CloudSyncDialogs.tsx:495
 msgid "trizum will open Apple so you can add it as a sign-in method for this account."
 msgstr "trizum abrirá Apple para que puedas añadirlo como método de inicio de sesión para esta cuenta."
 
-#: src/routes/settings_.cloud-sync.tsx:1663
+#: src/components/CloudSyncDialogs.tsx:506
 msgid "trizum will open Google so you can add it as a sign-in method for this account."
 msgstr "trizum abrirá Google para que puedas añadirlo como método de inicio de sesión para esta cuenta."
 
@@ -2656,7 +2656,7 @@ msgstr "trizum abrirá Google para que puedas añadirlo como método de inicio d
 msgid "Try again"
 msgstr "Reintentar"
 
-#: src/routes/settings_.cloud-sync.tsx:1341
+#: src/components/CloudSyncDialogs.tsx:317
 msgid "Try another email"
 msgstr "Probar con otro email"
 
@@ -2680,7 +2680,7 @@ msgstr "Lira Turca"
 msgid "Turkmenistani Manat"
 msgstr "Manat Turkmeno"
 
-#: src/routes/settings_.cloud-sync.tsx:1762
+#: src/components/CloudSyncDialogs.tsx:605
 msgid "Type \"delete account\" to confirm."
 msgstr "Escribe \"delete account\" para confirmar."
 
@@ -2772,7 +2772,7 @@ msgstr "Dólar Estadounidense"
 msgid "US Dollar (Next day)"
 msgstr "Dólar Estadounidense (Día siguiente)"
 
-#: src/routes/settings_.cloud-sync.tsx:1107
+#: src/components/CloudSyncDialogs.tsx:77
 msgid "Use cloud data"
 msgstr "Usar datos en la nube"
 
@@ -2788,8 +2788,8 @@ msgstr "Úsala en este dispositivo para continuar con tus datos en la nube."
 msgid "Use personal mode to filter only your expenses."
 msgstr "Usa el modo personal para filtrar solo tus gastos."
 
-#: src/routes/settings_.cloud-sync.tsx:1082
-#: src/routes/settings_.cloud-sync.tsx:1092
+#: src/components/CloudSyncDialogs.tsx:52
+#: src/components/CloudSyncDialogs.tsx:62
 msgid "Use trizum cloud on this device?"
 msgstr "¿Usar trizum cloud en este dispositivo?"
 
@@ -2850,15 +2850,15 @@ msgstr "Viendo como {0}"
 msgid "Viewing as {participantName}"
 msgstr "Viendo como {participantName}"
 
-#: src/routes/settings_.cloud-sync.tsx:1335
+#: src/components/CloudSyncDialogs.tsx:311
 msgid "We sent a sign-in link to {email}. Open it to finish signing in."
 msgstr "Hemos enviado un enlace de inicio de sesión a {email}. Ábrelo para terminar de iniciar sesión."
 
-#: src/routes/settings_.cloud-sync.tsx:1674
+#: src/components/CloudSyncDialogs.tsx:517
 msgid "We will email a password link to {email}. Your current password keeps working until you change it."
 msgstr "Enviaremos un enlace de contraseña a {email}. Tu contraseña actual seguirá funcionando hasta que la cambies."
 
-#: src/routes/settings_.cloud-sync.tsx:1679
+#: src/components/CloudSyncDialogs.tsx:522
 msgid "We will email a password setup link to {email}. Password sign-in starts working after you add one."
 msgstr "Enviaremos un enlace para configurar la contraseña a {email}. El inicio de sesión con contraseña empezará a funcionar cuando añadas una."
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -75,7 +75,7 @@ msgstr "Color de acento"
 msgid "Account created"
 msgstr "Cuenta creada"
 
-#: src/routes/settings_.cloud-sync.tsx:642
+#: src/routes/settings_.cloud-sync.tsx:458
 msgid "Account deleted"
 msgstr "Cuenta eliminada"
 
@@ -255,10 +255,10 @@ msgstr "Dólar Australiano"
 msgid "Authentication error"
 msgstr "Error de autenticación"
 
-#: src/routes/settings_.cloud-sync.tsx:434
-#: src/routes/settings_.cloud-sync.tsx:446
-#: src/routes/settings_.cloud-sync.tsx:463
-#: src/routes/settings_.cloud-sync.tsx:476
+#: src/routes/settings_.cloud-sync.tsx:297
+#: src/routes/settings_.cloud-sync.tsx:309
+#: src/routes/settings_.cloud-sync.tsx:326
+#: src/routes/settings_.cloud-sync.tsx:339
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
@@ -296,7 +296,7 @@ msgstr "Volver al inicio"
 msgid "Back to settings"
 msgstr "Volver a configuración"
 
-#: src/routes/settings_.cloud-sync.tsx:714
+#: src/components/CloudSyncSignInForm.tsx:112
 msgid "Back to sign in"
 msgstr "Volver a iniciar sesión"
 
@@ -461,11 +461,11 @@ msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
-#: src/routes/settings_.cloud-sync.tsx:518
+#: src/routes/settings_.cloud-sync.tsx:375
 msgid "Check your email for the password link"
 msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:404
+#: src/routes/settings_.cloud-sync.tsx:267
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
@@ -631,11 +631,11 @@ msgstr "Conexiones"
 msgid "Contact Us"
 msgstr "Contacto"
 
-#: src/routes/settings_.cloud-sync.tsx:738
+#: src/components/CloudSyncSignInForm.tsx:140
 msgid "Continue with Apple"
 msgstr "Continuar con Apple"
 
-#: src/routes/settings_.cloud-sync.tsx:753
+#: src/components/CloudSyncSignInForm.tsx:152
 msgid "Continue with Google"
 msgstr "Continuar con Google"
 
@@ -659,11 +659,11 @@ msgstr "Colón Costarricense"
 msgid "Could not apply cloud settings"
 msgstr "No se pudo aplicar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:504
+#: src/routes/settings_.cloud-sync.tsx:361
 msgid "Could not connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:648
+#: src/routes/settings_.cloud-sync.tsx:464
 msgid "Could not delete account"
 msgstr "No se pudo eliminar la cuenta"
 
@@ -675,7 +675,7 @@ msgstr "No se pudo cargar la configuración en la nube"
 msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:269
+#: src/hooks/useCloudSyncAccountState.ts:156
 #: src/routes/settings.tsx:388
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
@@ -688,15 +688,15 @@ msgstr "No se pudo restablecer la contraseña"
 msgid "Could not save cloud settings"
 msgstr "No se pudo guardar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:521
+#: src/routes/settings_.cloud-sync.tsx:378
 msgid "Could not send password email"
 msgstr "No se pudo enviar el correo de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:407
+#: src/routes/settings_.cloud-sync.tsx:270
 msgid "Could not send sign-in link"
 msgstr "No se pudo enviar el enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:570
+#: src/routes/settings_.cloud-sync.tsx:426
 msgid "Could not sign out"
 msgstr "No se pudo cerrar sesión"
 
@@ -862,9 +862,9 @@ msgid "Egyptian Pound"
 msgstr "Libra Egipcia"
 
 #: src/components/CloudSyncAccountSettings.tsx:68
-#: src/routes/settings_.cloud-sync.tsx:686
-#: src/routes/settings_.cloud-sync.tsx:772
-#: src/routes/settings_.cloud-sync.tsx:838
+#: src/components/CloudSyncSignInForm.tsx:92
+#: src/components/CloudSyncSignInForm.tsx:232
+#: src/components/CloudSyncSignInForm.tsx:305
 msgid "Email"
 msgstr "Correo electrónico"
 
@@ -884,7 +884,7 @@ msgstr "Los correos no coinciden"
 msgid "Email link"
 msgstr "Enviar enlace"
 
-#: src/routes/settings_.cloud-sync.tsx:849
+#: src/components/CloudSyncSignInForm.tsx:313
 msgid "Email me a sign-in link"
 msgstr "Enviarme un enlace de inicio de sesión"
 
@@ -1061,7 +1061,7 @@ msgstr "Terminando el inicio de sesión"
 msgid "For payments through Bizum or similar services"
 msgstr "Para pagos mediante Bizum o servicios similares"
 
-#: src/routes/settings_.cloud-sync.tsx:827
+#: src/components/CloudSyncSignInForm.tsx:272
 msgid "Forgot password?"
 msgstr "¿Olvidaste tu contraseña?"
 
@@ -1738,7 +1738,7 @@ msgstr "Abrir paréntesis"
 msgid "or enter code"
 msgstr "o introduce código"
 
-#: src/routes/settings_.cloud-sync.tsx:760
+#: src/components/CloudSyncSignInForm.tsx:159
 msgid "or use email"
 msgstr "o usa el correo"
 
@@ -1861,11 +1861,11 @@ msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
 #: src/components/CloudSyncAccountSettings.tsx:75
-#: src/routes/settings_.cloud-sync.tsx:782
+#: src/components/CloudSyncSignInForm.tsx:242
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:519
+#: src/routes/settings_.cloud-sync.tsx:376
 msgid "Password email sent"
 msgstr "Correo de contraseña enviado"
 
@@ -2138,7 +2138,7 @@ msgstr "Ver totales y clasificación de gasto"
 msgid "Select emoji"
 msgstr "Seleccionar emoji"
 
-#: src/routes/settings_.cloud-sync.tsx:702
+#: src/components/CloudSyncSignInForm.tsx:103
 msgid "Send password link"
 msgstr "Enviar enlace de contraseña"
 
@@ -2222,7 +2222,7 @@ msgstr "Leone de Sierra Leona"
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:977
+#: src/routes/settings_.cloud-sync.tsx:655
 msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
@@ -2230,12 +2230,12 @@ msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 msgid "Sign in to trizum cloud"
 msgstr "Iniciar sesión en trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:814
+#: src/components/CloudSyncSignInForm.tsx:262
 msgid "Sign in with magic link"
 msgstr "Iniciar sesión con enlace mágico"
 
-#: src/routes/settings_.cloud-sync.tsx:799
-#: src/routes/settings_.cloud-sync.tsx:864
+#: src/components/CloudSyncSignInForm.tsx:256
+#: src/components/CloudSyncSignInForm.tsx:319
 msgid "Sign in with password"
 msgstr "Iniciar sesión con contraseña"
 
@@ -2257,15 +2257,15 @@ msgstr "El enlace de inicio de sesión ha caducado"
 msgid "Sign-in link is invalid or expired"
 msgstr "El enlace de inicio de sesión no es válido o ha caducado"
 
-#: src/routes/settings_.cloud-sync.tsx:405
+#: src/routes/settings_.cloud-sync.tsx:268
 msgid "Sign-in link sent"
 msgstr "Enlace de inicio de sesión enviado"
 
-#: src/routes/settings_.cloud-sync.tsx:502
+#: src/routes/settings_.cloud-sync.tsx:359
 msgid "Sign-in method connected"
 msgstr "Método de inicio de sesión conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:443
+#: src/routes/settings_.cloud-sync.tsx:306
 msgid "Sign-in method is not configured"
 msgstr "El método de inicio de sesión no está configurado"
 
@@ -2275,11 +2275,11 @@ msgstr "Métodos de inicio de sesión"
 
 #: src/components/CloudSyncAccountSettings.tsx:70
 #: src/components/CloudSyncDialogs.tsx:369
-#: src/routes/settings_.cloud-sync.tsx:375
+#: src/routes/settings_.cloud-sync.tsx:238
 msgid "Signed in"
 msgstr "Sesión iniciada"
 
-#: src/routes/settings_.cloud-sync.tsx:567
+#: src/routes/settings_.cloud-sync.tsx:423
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
@@ -2509,7 +2509,7 @@ msgstr "Esta deuda ya no está disponible"
 msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 msgstr "Este dispositivo ya tiene datos locales. Si usas trizum cloud aquí, este dispositivo cambiará a tus datos en la nube. Los datos locales de este dispositivo dejarán de usarse."
 
-#: src/routes/settings_.cloud-sync.tsx:588
+#: src/hooks/useCloudSyncAccountState.ts:191
 msgid "This device is already using trizum cloud"
 msgstr "Este dispositivo ya usa trizum cloud"
 
@@ -2612,26 +2612,26 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/settings_.cloud-sync.tsx:882
+#: src/routes/settings_.cloud-sync.tsx:560
 #: src/routes/settings.tsx:216
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/routes/settings_.cloud-sync.tsx:236
-#: src/routes/settings_.cloud-sync.tsx:583
+#: src/hooks/useCloudSyncAccountState.ts:131
+#: src/hooks/useCloudSyncAccountState.ts:186
 msgid "trizum cloud data is invalid"
 msgstr "Los datos de trizum cloud no son válidos"
 
-#: src/routes/settings_.cloud-sync.tsx:257
-#: src/routes/settings_.cloud-sync.tsx:602
+#: src/hooks/useCloudSyncAccountState.ts:152
+#: src/hooks/useCloudSyncAccountState.ts:210
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud activado en este dispositivo"
 
-#: src/routes/settings_.cloud-sync.tsx:578
+#: src/hooks/useCloudSyncAccountState.ts:181
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud todavía no está configurado"
 
-#: src/routes/settings_.cloud-sync.tsx:219
+#: src/hooks/useCloudSyncAccountState.ts:114
 msgid "trizum cloud started"
 msgstr "trizum cloud iniciado"
 

--- a/packages/pwa/src/components/CloudSyncAccountSettings.tsx
+++ b/packages/pwa/src/components/CloudSyncAccountSettings.tsx
@@ -1,0 +1,236 @@
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { type ReactNode } from "react";
+import type { LinkedAuthAccount } from "#src/lib/auth-client.ts";
+import { Button } from "#src/ui/Button.tsx";
+import { Icon, type IconProps } from "#src/ui/Icon.tsx";
+import { cn } from "#src/ui/utils.js";
+
+export function CloudSyncAccountSettings({
+  email,
+  hasPasswordAccount,
+  isAuthPending,
+  isDeleteAccountPending,
+  linkedProviderIds,
+  onConnectApple,
+  onConnectGoogle,
+  onDeleteAccount,
+  onPasswordLink,
+  onSignOut,
+  passwordResetMessage,
+}: {
+  email: string;
+  hasPasswordAccount: boolean;
+  isAuthPending: boolean;
+  isDeleteAccountPending: boolean;
+  linkedProviderIds: Set<LinkedAuthAccount["providerId"]>;
+  onConnectApple: () => void;
+  onConnectGoogle: () => void;
+  onDeleteAccount: () => void;
+  onPasswordLink: () => void;
+  onSignOut: () => void;
+  passwordResetMessage: string | null;
+}) {
+  return (
+    <div className="container mt-4 flex flex-col gap-8 px-4 pb-8 pb-safe">
+      <CloudSettingsSection icon="lucide.link" title={t`Connections`}>
+        <CloudSettingsItem
+          icon="brand.apple"
+          title={t`Apple`}
+          description={
+            linkedProviderIds.has("apple")
+              ? t`Apple is connected to this account`
+              : t`Add Apple as a sign-in method`
+          }
+          statusLabel={linkedProviderIds.has("apple") ? t`Connected` : undefined}
+          isConnected={linkedProviderIds.has("apple")}
+          isDisabled={isAuthPending || linkedProviderIds.has("apple")}
+          onPress={linkedProviderIds.has("apple") ? undefined : onConnectApple}
+        />
+        <CloudSettingsItem
+          icon="brand.google"
+          title={t`Google`}
+          description={
+            linkedProviderIds.has("google")
+              ? t`Google is connected to this account`
+              : t`Add Google as a sign-in method`
+          }
+          statusLabel={linkedProviderIds.has("google") ? t`Connected` : undefined}
+          isConnected={linkedProviderIds.has("google")}
+          isDisabled={isAuthPending || linkedProviderIds.has("google")}
+          onPress={linkedProviderIds.has("google") ? undefined : onConnectGoogle}
+        />
+      </CloudSettingsSection>
+
+      <CloudSettingsSection icon="lucide.shield-check" title={t`Security`}>
+        <CloudSettingsItem
+          icon="lucide.mail"
+          title={t`Email`}
+          description={email}
+          statusLabel={t`Signed in`}
+          isConnected
+        />
+        <CloudSettingsItem
+          icon="lucide.key-round"
+          title={t`Password`}
+          description={
+            passwordResetMessage ??
+            (hasPasswordAccount ? t`Email a password reset link` : t`Set up password sign-in`)
+          }
+          isDisabled={isAuthPending}
+          onPress={onPasswordLink}
+        />
+        <CloudSettingsItem
+          icon="lucide.log-out"
+          title={t`Sign out`}
+          description={t`Stop trizum cloud on this device`}
+          isDisabled={isAuthPending}
+          onPress={onSignOut}
+        />
+      </CloudSettingsSection>
+
+      <CloudSettingsSection icon="lucide.triangle-alert" title={t`Destructive actions`}>
+        <CloudSettingsItem
+          icon="lucide.trash-2"
+          title={t`Delete account`}
+          description={t`Permanently delete your trizum cloud account`}
+          isDisabled={isDeleteAccountPending}
+          onPress={onDeleteAccount}
+        />
+      </CloudSettingsSection>
+    </div>
+  );
+}
+
+function CloudSettingsSection({
+  children,
+  icon,
+  title,
+  tone = "default",
+}: {
+  children: ReactNode;
+  icon: IconProps["icon"];
+  title: string;
+  tone?: "default" | "danger";
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <div
+        className={cn(
+          "flex items-center gap-2 px-1 text-sm font-semibold text-accent-700 dark:text-accent-200",
+          tone === "danger" && "text-danger-600 dark:text-danger-300",
+        )}
+      >
+        <Icon icon={icon} width={16} height={16} />
+        <h2>{title}</h2>
+      </div>
+      <div className="flex flex-col gap-1">{children}</div>
+    </section>
+  );
+}
+
+function CloudSettingsItem({
+  description,
+  icon,
+  isConnected,
+  isDisabled,
+  onPress,
+  statusLabel,
+  title,
+  tone = "default",
+}: {
+  description?: ReactNode;
+  icon: IconProps["icon"];
+  isConnected?: boolean;
+  isDisabled?: boolean;
+  onPress?: () => void;
+  statusLabel?: ReactNode;
+  title: string;
+  tone?: "default" | "danger";
+}) {
+  const content = (
+    <span className="flex w-full items-center gap-3">
+      <span
+        className={cn(
+          "flex size-10 shrink-0 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-900 dark:text-accent-50",
+          tone === "danger" &&
+            "bg-danger-50 text-danger-600 dark:bg-danger-950/50 dark:text-danger-300",
+        )}
+      >
+        <Icon icon={icon} width={20} height={20} />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span
+          className={cn(
+            "font-medium leading-tight",
+            tone === "danger" && "text-danger-600 dark:text-danger-300",
+          )}
+        >
+          {title}
+        </span>
+        {description ? (
+          <span
+            className={cn(
+              "whitespace-normal break-words text-sm leading-snug text-accent-700 dark:text-accent-200",
+              tone === "danger" && "text-danger-700 dark:text-danger-300",
+            )}
+          >
+            {description}
+          </span>
+        ) : null}
+      </span>
+      {onPress ? (
+        <span
+          className={cn(
+            "ml-2 flex shrink-0 items-center gap-1 text-sm font-medium text-accent-700 dark:text-accent-100",
+            tone === "danger" && "text-danger-600 dark:text-danger-300",
+          )}
+        >
+          <Icon icon="lucide.chevron-right" width={18} height={18} />
+        </span>
+      ) : statusLabel ? (
+        <span
+          className={cn(
+            "ml-2 shrink-0 rounded-full bg-accent-100 px-2.5 py-1 text-xs font-medium text-accent-700 dark:bg-accent-900 dark:text-accent-100",
+            tone === "danger" &&
+              "bg-danger-50 text-danger-700 dark:bg-danger-950/50 dark:text-danger-300",
+          )}
+        >
+          {statusLabel}
+        </span>
+      ) : isConnected ? (
+        <Icon
+          className="text-accent-600 dark:text-accent-200"
+          icon="lucide.check"
+          width={18}
+          height={18}
+        />
+      ) : null}
+    </span>
+  );
+  const className = cn(
+    "-mx-3 h-auto min-h-16 w-[calc(100%+1.5rem)] justify-start rounded-xl px-3 py-3 text-left",
+    "hover:bg-accent-100/70 dark:hover:bg-accent-900/70",
+    tone === "danger" && "hover:bg-danger-50 dark:hover:bg-danger-950/40",
+  );
+
+  if (onPress) {
+    return (
+      <Button
+        color="transparent"
+        className={className}
+        isDisabled={isDisabled}
+        onPress={onPress}
+        type="button"
+      >
+        {content}
+      </Button>
+    );
+  }
+
+  return (
+    <div className="-mx-3 flex min-h-16 w-[calc(100%+1.5rem)] items-center rounded-xl px-3 py-3 text-left">
+      {content}
+    </div>
+  );
+}

--- a/packages/pwa/src/components/CloudSyncDialogs.tsx
+++ b/packages/pwa/src/components/CloudSyncDialogs.tsx
@@ -1,0 +1,640 @@
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { type FormEvent, type ReactNode } from "react";
+import { Dialog, Modal, ModalOverlay } from "react-aria-components";
+import { motion } from "motion/react";
+import { getAuthCallbackErrorContent } from "#src/lib/authCallbackErrors.ts";
+import { Alert, AlertDescription } from "#src/ui/Alert.tsx";
+import { Button } from "#src/ui/Button.tsx";
+import { Icon, type IconProps } from "#src/ui/Icon.tsx";
+import { IconButton } from "#src/ui/IconButton.js";
+import { AppTextField } from "#src/ui/fields/TextField.js";
+import { cn } from "#src/ui/utils.js";
+
+export type CloudActionDialogType =
+  | "connect-apple"
+  | "connect-google"
+  | "password-link"
+  | "sign-out";
+
+export function CloudSyncSwitchDialog({
+  isOpen,
+  onSignOut,
+  onUseCloudData,
+}: {
+  isOpen: boolean;
+  onSignOut: () => void;
+  onUseCloudData: () => void;
+}) {
+  return (
+    <ModalOverlay
+      isDismissable={false}
+      isKeyboardDismissDisabled
+      isOpen={isOpen}
+      className={({ isEntering, isExiting }) =>
+        cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
+          isEntering && "duration-200 ease-out animate-in fade-in",
+          isExiting && "duration-150 ease-in animate-out fade-out",
+        )
+      }
+    >
+      <Modal
+        className={({ isEntering, isExiting }) =>
+          cn(
+            "w-full max-w-[420px] outline-none",
+            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
+            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
+          )
+        }
+      >
+        <Dialog
+          aria-label={t`Use trizum cloud on this device?`}
+          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
+        >
+          <div className="flex flex-col gap-5 p-5 sm:p-6">
+            <div className="flex flex-col gap-3">
+              <span className="flex size-10 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-800 dark:text-accent-50">
+                <Icon icon="lucide.cloud-download" width={20} height={20} />
+              </span>
+              <div className="flex flex-col gap-2">
+                <h2 className="text-lg font-medium">
+                  <Trans>Use trizum cloud on this device?</Trans>
+                </h2>
+                <p className="text-sm text-accent-700 dark:text-accent-50">
+                  <Trans>
+                    This device already has local data. Using trizum cloud here will switch this
+                    device to your cloud data. Your local data on this device will stop being used.
+                  </Trans>
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <Button className="font-semibold" color="accent" onPress={onUseCloudData}>
+                <span className="flex items-center gap-2">
+                  <Icon icon="lucide.cloud-download" width={18} height={18} />
+                  <Trans>Use cloud data</Trans>
+                </span>
+              </Button>
+              <Button
+                className="font-semibold text-danger-700 dark:text-danger-300"
+                color="input-like"
+                onPress={onSignOut}
+              >
+                <span className="flex items-center gap-2">
+                  <Icon icon="lucide.log-out" width={18} height={18} />
+                  <Trans>Sign out</Trans>
+                </span>
+              </Button>
+            </div>
+          </div>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}
+
+export function AuthCallbackErrorDialog({
+  error,
+  isOpen,
+  onOpenChange,
+}: {
+  error: string | null;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  const content = error ? getAuthCallbackErrorContent(error) : null;
+
+  return (
+    <ModalOverlay
+      isDismissable
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      className={({ isEntering, isExiting }) =>
+        cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
+          isEntering && "duration-200 ease-out animate-in fade-in",
+          isExiting && "duration-150 ease-in animate-out fade-out",
+        )
+      }
+    >
+      <Modal
+        className={({ isEntering, isExiting }) =>
+          cn(
+            "w-full max-w-[420px] outline-none",
+            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
+            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
+          )
+        }
+      >
+        <Dialog
+          aria-label={content?.title ?? t`Authentication error`}
+          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
+        >
+          {content ? (
+            <div className="flex flex-col gap-5 p-5 sm:p-6">
+              <div className="flex flex-col gap-3">
+                <span className="flex size-10 items-center justify-center rounded-full bg-danger-50 text-danger-600 dark:bg-danger-950/50 dark:text-danger-300">
+                  <Icon icon="lucide.circle-alert" width={20} height={20} />
+                </span>
+                <div className="flex flex-col gap-2">
+                  <h2 className="text-lg font-medium">{content.title}</h2>
+                  <p className="text-sm text-accent-700 dark:text-accent-50">
+                    {content.description}
+                  </p>
+                </div>
+              </div>
+
+              <Button
+                className="font-semibold"
+                color="accent"
+                onPress={() => {
+                  onOpenChange(false);
+                }}
+                type="button"
+              >
+                <Trans>Got it</Trans>
+              </Button>
+            </div>
+          ) : null}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}
+
+export function CloudSyncSignInDialog({
+  children,
+  isOpen,
+  onOpenChange,
+  showHeader,
+}: {
+  children: ReactNode;
+  isOpen: boolean;
+  onOpenChange: () => void;
+  showHeader: boolean;
+}) {
+  return (
+    <ModalOverlay
+      isDismissable
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onOpenChange();
+        }
+      }}
+      className={({ isEntering, isExiting }) =>
+        cn(
+          "fixed inset-0 z-50 flex items-stretch justify-center bg-accent-950/35 p-0 backdrop-blur-md sm:items-center sm:px-safe-or-4 sm:py-safe-offset-6",
+          isEntering && "duration-200 ease-out animate-in fade-in",
+          isExiting && "duration-150 ease-in animate-out fade-out",
+        )
+      }
+    >
+      <Modal
+        className={({ isEntering, isExiting }) =>
+          cn(
+            "h-full w-full outline-none sm:h-auto sm:max-w-[420px]",
+            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
+            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
+          )
+        }
+      >
+        <Dialog
+          aria-label={t`Sign in`}
+          className="relative flex h-[100dvh] max-h-[100dvh] flex-col overflow-hidden bg-white shadow-2xl outline-none sm:h-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-lg sm:border sm:border-accent-200 dark:bg-accent-950 dark:sm:border-accent-800"
+        >
+          <IconButton
+            aria-label={t`Back to settings`}
+            className="absolute right-safe-offset-2 top-safe-offset-2 sm:right-2 sm:top-2"
+            icon="lucide.x"
+            onPress={onOpenChange}
+          />
+          <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto pb-safe-offset-5 pt-safe-offset-14 px-safe-or-5 sm:p-6 sm:pt-14">
+            {showHeader ? (
+              <div className="flex flex-col items-center gap-3 text-center">
+                <img
+                  alt=""
+                  className="size-12 rounded-xl"
+                  height={48}
+                  src="/pwa-64x64.png"
+                  width={48}
+                />
+                <h2 className="text-lg font-medium">
+                  <Trans>Sign in to trizum cloud</Trans>
+                </h2>
+              </div>
+            ) : null}
+
+            {children}
+          </div>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}
+
+export function AuthErrorAlert({ message }: { message: string }) {
+  return (
+    <Alert variant="destructive">
+      <Icon icon="lucide.circle-alert" />
+      <AlertDescription>{message}</AlertDescription>
+    </Alert>
+  );
+}
+
+export function AuthButtonIcon({
+  icon,
+  isPending,
+}: {
+  icon: IconProps["icon"];
+  isPending: boolean;
+}) {
+  return (
+    <Icon
+      className={cn(isPending && "animate-spin")}
+      icon={isPending ? "lucide.loader-circle" : icon}
+      width={18}
+      height={18}
+    />
+  );
+}
+
+export function CloudAuthLoadingState() {
+  return (
+    <output
+      aria-label={t`Finishing sign in`}
+      className="flex flex-1 flex-col items-center justify-center gap-4 py-8 text-center"
+    >
+      <motion.span
+        animate={{ rotate: 360 }}
+        className="flex size-12 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-900 dark:text-accent-50"
+        transition={{ duration: 0.9, ease: "linear", repeat: Infinity }}
+      >
+        <Icon icon="lucide.loader-circle" width={24} height={24} />
+      </motion.span>
+      <p className="text-sm font-medium text-accent-700 dark:text-accent-50">
+        <Trans>Finishing sign in</Trans>
+      </p>
+    </output>
+  );
+}
+
+export function MagicLinkSentState({
+  email,
+  message,
+  onTryAgain,
+}: {
+  email: string;
+  message: string;
+  onTryAgain: () => void;
+}) {
+  return (
+    <motion.div
+      className="flex flex-1 flex-col items-center justify-center gap-5 py-8 text-center"
+      initial={{ opacity: 0, y: 12, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: 0.2, ease: "easeOut" }}
+    >
+      <motion.span
+        className="flex size-16 items-center justify-center rounded-full bg-success-100 text-success-700 dark:bg-success-950/60 dark:text-success-200"
+        initial={{ scale: 0.72 }}
+        animate={{ scale: [0.72, 1.08, 1] }}
+        transition={{ delay: 0.04, duration: 0.38, ease: "easeOut" }}
+      >
+        <Icon icon="lucide.mail-check" width={28} height={28} />
+      </motion.span>
+      <div className="flex flex-col gap-2">
+        <h3 className="text-base font-medium">{message}</h3>
+        <p className="text-sm text-accent-700 dark:text-accent-50">
+          <Trans>We sent a sign-in link to {email}. Open it to finish signing in.</Trans>
+        </p>
+      </div>
+      <Button color="input-like" onPress={onTryAgain} type="button">
+        <span className="flex items-center gap-2">
+          <Icon icon="lucide.refresh-cw" width={18} height={18} />
+          <Trans>Try another email</Trans>
+        </span>
+      </Button>
+    </motion.div>
+  );
+}
+
+export function SignInSuccessOverlay({ exitAnimationMs }: { exitAnimationMs: number }) {
+  return (
+    <motion.div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-white/90 backdrop-blur-md py-safe-offset-6 px-safe-or-4 dark:bg-accent-950/90"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: exitAnimationMs / 1000, ease: "easeOut" }}
+    >
+      <motion.div
+        className="w-full max-w-[420px]"
+        initial={{ opacity: 0, y: 12, scale: 0.96 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        exit={{ opacity: 0, y: -8, scale: 0.98 }}
+        transition={{ duration: 0.2, ease: "easeOut" }}
+      >
+        <SignInSuccessAnimation />
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function SignInSuccessAnimation() {
+  return (
+    <motion.div
+      className="flex flex-col items-center gap-3 px-5 py-8 text-center"
+      initial={{ opacity: 0, scale: 0.96 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.98 }}
+      transition={{ duration: 0.18, ease: "easeOut" }}
+    >
+      <motion.span
+        className="flex size-16 items-center justify-center rounded-full bg-success-100 text-success-700 dark:bg-success-950/60 dark:text-success-200"
+        initial={{ scale: 0.6 }}
+        animate={{ scale: [0.6, 1.1, 1] }}
+        transition={{ duration: 0.42, ease: "easeOut" }}
+      >
+        <Icon icon="lucide.check" width={32} height={32} />
+      </motion.span>
+      <motion.p
+        className="text-base font-medium"
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.12, duration: 0.2, ease: "easeOut" }}
+      >
+        <Trans>Signed in</Trans>
+      </motion.p>
+    </motion.div>
+  );
+}
+
+export function CloudActionConfirmationDialog({
+  action,
+  email,
+  hasPasswordAccount,
+  isPending,
+  onConfirm,
+  onOpenChange,
+}: {
+  action: CloudActionDialogType | null;
+  email: string;
+  hasPasswordAccount: boolean;
+  isPending: boolean;
+  onConfirm: (action: CloudActionDialogType) => Promise<void>;
+  onOpenChange: (isOpen: boolean) => void;
+}) {
+  const config = action ? getCloudActionDialogConfig({ action, email, hasPasswordAccount }) : null;
+
+  return (
+    <ModalOverlay
+      isDismissable={!isPending}
+      isOpen={Boolean(action)}
+      onOpenChange={onOpenChange}
+      className={({ isEntering, isExiting }) =>
+        cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
+          isEntering && "duration-200 ease-out animate-in fade-in",
+          isExiting && "duration-150 ease-in animate-out fade-out",
+        )
+      }
+    >
+      <Modal
+        className={({ isEntering, isExiting }) =>
+          cn(
+            "w-full max-w-[420px] outline-none",
+            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
+            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
+          )
+        }
+      >
+        <Dialog
+          aria-label={config?.title ?? t`Confirm action`}
+          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
+        >
+          {config && action ? (
+            <div className="flex flex-col gap-5 p-5 sm:p-6">
+              <div className="flex flex-col gap-3">
+                <span
+                  className={cn(
+                    "flex size-10 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-800 dark:text-accent-50",
+                    config.tone === "danger" &&
+                      "bg-danger-50 text-danger-500 dark:bg-danger-950/50 dark:text-danger-300",
+                  )}
+                >
+                  <Icon icon={config.icon} width={20} height={20} />
+                </span>
+                <div className="flex flex-col gap-2">
+                  <h2 className="text-lg font-medium">{config.title}</h2>
+                  <p className="text-sm text-accent-700 dark:text-accent-50">
+                    {config.description}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <Button
+                  className={cn(
+                    "font-semibold",
+                    config.tone === "danger" && "bg-danger-500 text-danger-50 dark:bg-danger-500",
+                  )}
+                  color="accent"
+                  isDisabled={isPending}
+                  onPress={() => {
+                    void onConfirm(action);
+                  }}
+                  type="button"
+                >
+                  <span className="flex items-center gap-2">
+                    <AuthButtonIcon icon={config.icon} isPending={isPending} />
+                    {config.actionLabel}
+                  </span>
+                </Button>
+                <Button
+                  color="input-like"
+                  isDisabled={isPending}
+                  onPress={() => {
+                    onOpenChange(false);
+                  }}
+                  type="button"
+                >
+                  <Trans>Cancel</Trans>
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}
+
+function getCloudActionDialogConfig({
+  action,
+  email,
+  hasPasswordAccount,
+}: {
+  action: CloudActionDialogType;
+  email: string;
+  hasPasswordAccount: boolean;
+}): {
+  actionLabel: string;
+  description: ReactNode;
+  icon: IconProps["icon"];
+  title: string;
+  tone?: "danger";
+} {
+  switch (action) {
+    case "connect-apple":
+      return {
+        actionLabel: t`Connect Apple`,
+        description: (
+          <Trans>
+            trizum will open Apple so you can add it as a sign-in method for this account.
+          </Trans>
+        ),
+        icon: "brand.apple",
+        title: t`Connect Apple?`,
+      };
+    case "connect-google":
+      return {
+        actionLabel: t`Connect Google`,
+        description: (
+          <Trans>
+            trizum will open Google so you can add it as a sign-in method for this account.
+          </Trans>
+        ),
+        icon: "brand.google",
+        title: t`Connect Google?`,
+      };
+    case "password-link":
+      return {
+        actionLabel: t`Email password link`,
+        description: hasPasswordAccount ? (
+          <Trans>
+            We will email a password link to {email}. Your current password keeps working until you
+            change it.
+          </Trans>
+        ) : (
+          <Trans>
+            We will email a password setup link to {email}. Password sign-in starts working after
+            you add one.
+          </Trans>
+        ),
+        icon: "lucide.key-round",
+        title: hasPasswordAccount ? t`Email password link?` : t`Set up password?`,
+      };
+    case "sign-out":
+      return {
+        actionLabel: t`Sign out`,
+        description: (
+          <Trans>
+            This stops trizum cloud on this device. Your local data stays on this device.
+          </Trans>
+        ),
+        icon: "lucide.log-out",
+        title: t`Sign out?`,
+      };
+  }
+}
+
+export function DeleteAccountDialog({
+  canSubmit,
+  confirmation,
+  errorMessage,
+  isOpen,
+  isPending,
+  onConfirmationChange,
+  onOpenChange,
+  onSubmit,
+}: {
+  canSubmit: boolean;
+  confirmation: string;
+  errorMessage: string | null;
+  isOpen: boolean;
+  isPending: boolean;
+  onConfirmationChange: (value: string) => void;
+  onOpenChange: (isOpen: boolean) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <ModalOverlay
+      isDismissable={!isPending}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      className={({ isEntering, isExiting }) =>
+        cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
+          isEntering && "duration-200 ease-out animate-in fade-in",
+          isExiting && "duration-150 ease-in animate-out fade-out",
+        )
+      }
+    >
+      <Modal
+        className={({ isEntering, isExiting }) =>
+          cn(
+            "w-full max-w-[420px] outline-none",
+            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
+            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
+          )
+        }
+      >
+        <Dialog
+          aria-label={t`Delete account`}
+          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
+        >
+          <form className="flex flex-col gap-5 p-5 sm:p-6" onSubmit={onSubmit}>
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-medium">
+                <Trans>Delete account?</Trans>
+              </h2>
+              <p className="text-sm text-accent-700 dark:text-accent-50">
+                <Trans>
+                  This permanently deletes your trizum cloud account, sign-in methods, and cloud
+                  settings. Your local data on this device will remain.
+                </Trans>
+              </p>
+            </div>
+
+            {errorMessage ? <AuthErrorAlert message={errorMessage} /> : null}
+
+            <AppTextField
+              description={t`Type "delete account" to confirm.`}
+              isDisabled={isPending}
+              label={t`Confirmation`}
+              onChange={onConfirmationChange}
+              value={confirmation}
+            />
+
+            <div className="flex flex-col gap-3">
+              <Button
+                className="bg-danger-500 text-danger-50 dark:bg-danger-500"
+                color="accent"
+                isDisabled={!canSubmit || isPending}
+                type="submit"
+              >
+                <span className="flex items-center gap-2">
+                  <Icon icon="lucide.trash-2" width={18} height={18} />
+                  <Trans>Delete account</Trans>
+                </span>
+              </Button>
+              <Button
+                color="input-like"
+                isDisabled={isPending}
+                onPress={() => {
+                  onOpenChange(false);
+                }}
+                type="button"
+              >
+                <Trans>Cancel</Trans>
+              </Button>
+            </div>
+          </form>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}

--- a/packages/pwa/src/components/CloudSyncSignInForm.tsx
+++ b/packages/pwa/src/components/CloudSyncSignInForm.tsx
@@ -1,0 +1,324 @@
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { type FormEvent } from "react";
+import type { SocialAuthProvider } from "#src/lib/auth-client.ts";
+import { Button } from "#src/ui/Button.tsx";
+import { Icon } from "#src/ui/Icon.tsx";
+import { AppTextField } from "#src/ui/fields/TextField.js";
+import {
+  AuthButtonIcon,
+  AuthErrorAlert,
+  CloudAuthLoadingState,
+  MagicLinkSentState,
+} from "./CloudSyncDialogs.tsx";
+
+const AUTH_SECONDARY_BUTTON_CLASS_NAME =
+  "h-9 text-sm font-medium text-accent-700 dark:text-accent-50";
+
+export type AuthPendingAction =
+  | "apple"
+  | "google"
+  | "magic-link"
+  | "password"
+  | "password-reset"
+  | "sign-out";
+
+export function CloudSyncSignInForm({
+  auth,
+  authEmail,
+  authEmailError,
+  authError,
+  authPassword,
+  authPasswordError,
+  authPendingAction,
+  isAuthPending,
+  isPasswordLoginMode,
+  isPasswordResetMode,
+  isPasswordSignInEnabled,
+  isSignInSuccessVisible,
+  magicLinkMessage,
+  onAuthEmailChange,
+  onAuthPasswordChange,
+  onBackToSignIn,
+  onForgotPassword,
+  onMagicLinkSubmit,
+  onPasswordResetSubmit,
+  onPasswordSignInSubmit,
+  onSocialSignIn,
+  onTryAnotherEmail,
+  onUseMagicLink,
+  onUsePassword,
+  passwordResetMessage,
+}: {
+  auth?: "success";
+  authEmail: string;
+  authEmailError: string | null;
+  authError: string | null;
+  authPassword: string;
+  authPasswordError: string | null;
+  authPendingAction: AuthPendingAction | null;
+  isAuthPending: boolean;
+  isPasswordLoginMode: boolean;
+  isPasswordResetMode: boolean;
+  isPasswordSignInEnabled: boolean;
+  isSignInSuccessVisible: boolean;
+  magicLinkMessage: string | null;
+  onAuthEmailChange: (value: string) => void;
+  onAuthPasswordChange: (value: string) => void;
+  onBackToSignIn: () => void;
+  onForgotPassword: () => void;
+  onMagicLinkSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onPasswordResetSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onPasswordSignInSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onSocialSignIn: (provider: SocialAuthProvider) => void;
+  onTryAnotherEmail: () => void;
+  onUseMagicLink: () => void;
+  onUsePassword: () => void;
+  passwordResetMessage: string | null;
+}) {
+  if (auth === "success" || isSignInSuccessVisible) {
+    return <CloudAuthLoadingState />;
+  }
+
+  if (isPasswordResetMode) {
+    return (
+      <form className="flex flex-col gap-4" onSubmit={onPasswordResetSubmit}>
+        {authError ? <AuthErrorAlert message={authError} /> : null}
+        <AppTextField
+          errorMessage={authEmailError ?? undefined}
+          isDisabled={isAuthPending}
+          isInvalid={Boolean(authEmailError)}
+          isRequired
+          label={t`Email`}
+          onChange={onAuthEmailChange}
+          type="email"
+          value={authEmail}
+        />
+        {passwordResetMessage ? (
+          <p className="text-sm text-accent-700 dark:text-accent-50">{passwordResetMessage}</p>
+        ) : null}
+        <Button color="accent" isDisabled={isAuthPending} type="submit">
+          <span className="flex items-center gap-2">
+            <AuthButtonIcon icon="lucide.mail" isPending={authPendingAction === "password-reset"} />
+            <Trans>Send password link</Trans>
+          </span>
+        </Button>
+        <Button
+          color="transparent"
+          isDisabled={isAuthPending}
+          onPress={onBackToSignIn}
+          type="button"
+        >
+          <Trans>Back to sign in</Trans>
+        </Button>
+      </form>
+    );
+  }
+
+  if (magicLinkMessage) {
+    return (
+      <MagicLinkSentState
+        email={authEmail}
+        message={magicLinkMessage}
+        onTryAgain={onTryAnotherEmail}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-3">
+        <Button
+          color="input-like"
+          isDisabled={isAuthPending}
+          onPress={() => {
+            onSocialSignIn("apple");
+          }}
+        >
+          <span className="flex items-center gap-2">
+            <AuthButtonIcon icon="brand.apple" isPending={authPendingAction === "apple"} />
+            <Trans>Continue with Apple</Trans>
+          </span>
+        </Button>
+        <Button
+          color="input-like"
+          isDisabled={isAuthPending}
+          onPress={() => {
+            onSocialSignIn("google");
+          }}
+        >
+          <span className="flex items-center gap-2">
+            <AuthButtonIcon icon="brand.google" isPending={authPendingAction === "google"} />
+            <Trans>Continue with Google</Trans>
+          </span>
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-3 text-xs font-medium uppercase text-accent-600 dark:text-accent-300">
+        <span className="h-px flex-1 bg-accent-200 dark:bg-accent-700" />
+        <Trans>or use email</Trans>
+        <span className="h-px flex-1 bg-accent-200 dark:bg-accent-700" />
+      </div>
+
+      {isPasswordLoginMode ? (
+        <PasswordSignInForm
+          authEmail={authEmail}
+          authEmailError={authEmailError}
+          authError={authError}
+          authPassword={authPassword}
+          authPasswordError={authPasswordError}
+          authPendingAction={authPendingAction}
+          isAuthPending={isAuthPending}
+          isPasswordSignInEnabled={isPasswordSignInEnabled}
+          onAuthEmailChange={onAuthEmailChange}
+          onAuthPasswordChange={onAuthPasswordChange}
+          onForgotPassword={onForgotPassword}
+          onSubmit={onPasswordSignInSubmit}
+          onUseMagicLink={onUseMagicLink}
+        />
+      ) : (
+        <MagicLinkSignInForm
+          authEmail={authEmail}
+          authEmailError={authEmailError}
+          authError={authError}
+          authPendingAction={authPendingAction}
+          isAuthPending={isAuthPending}
+          onAuthEmailChange={onAuthEmailChange}
+          onSubmit={onMagicLinkSubmit}
+          onUsePassword={onUsePassword}
+        />
+      )}
+    </>
+  );
+}
+
+function PasswordSignInForm({
+  authEmail,
+  authEmailError,
+  authError,
+  authPassword,
+  authPasswordError,
+  authPendingAction,
+  isAuthPending,
+  isPasswordSignInEnabled,
+  onAuthEmailChange,
+  onAuthPasswordChange,
+  onForgotPassword,
+  onSubmit,
+  onUseMagicLink,
+}: {
+  authEmail: string;
+  authEmailError: string | null;
+  authError: string | null;
+  authPassword: string;
+  authPasswordError: string | null;
+  authPendingAction: AuthPendingAction | null;
+  isAuthPending: boolean;
+  isPasswordSignInEnabled: boolean;
+  onAuthEmailChange: (value: string) => void;
+  onAuthPasswordChange: (value: string) => void;
+  onForgotPassword: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onUseMagicLink: () => void;
+}) {
+  return (
+    <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+      {authError ? <AuthErrorAlert message={authError} /> : null}
+      <AppTextField
+        errorMessage={authEmailError ?? undefined}
+        isDisabled={isAuthPending}
+        isInvalid={Boolean(authEmailError)}
+        isRequired
+        label={t`Email`}
+        onChange={onAuthEmailChange}
+        type="email"
+        value={authEmail}
+      />
+      <AppTextField
+        errorMessage={authPasswordError ?? undefined}
+        isDisabled={isAuthPending}
+        isInvalid={Boolean(authPasswordError)}
+        isRequired
+        label={t`Password`}
+        minLength={8}
+        onChange={onAuthPasswordChange}
+        type="password"
+        value={authPassword}
+      />
+      <Button
+        className="font-semibold"
+        color="accent"
+        isDisabled={isAuthPending || !isPasswordSignInEnabled}
+        type="submit"
+      >
+        <span className="flex items-center gap-2">
+          <AuthButtonIcon icon="lucide.log-in" isPending={authPendingAction === "password"} />
+          <Trans>Sign in with password</Trans>
+        </span>
+      </Button>
+      <Button color="input-like" isDisabled={isAuthPending} onPress={onUseMagicLink} type="button">
+        <span className="flex items-center gap-2">
+          <Icon icon="lucide.mail" width={18} height={18} />
+          <Trans>Sign in with magic link</Trans>
+        </span>
+      </Button>
+      <Button
+        className={AUTH_SECONDARY_BUTTON_CLASS_NAME}
+        color="transparent"
+        isDisabled={isAuthPending}
+        onPress={onForgotPassword}
+        type="button"
+      >
+        <Trans>Forgot password?</Trans>
+      </Button>
+    </form>
+  );
+}
+
+function MagicLinkSignInForm({
+  authEmail,
+  authEmailError,
+  authError,
+  authPendingAction,
+  isAuthPending,
+  onAuthEmailChange,
+  onSubmit,
+  onUsePassword,
+}: {
+  authEmail: string;
+  authEmailError: string | null;
+  authError: string | null;
+  authPendingAction: AuthPendingAction | null;
+  isAuthPending: boolean;
+  onAuthEmailChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onUsePassword: () => void;
+}) {
+  return (
+    <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+      {authError ? <AuthErrorAlert message={authError} /> : null}
+      <AppTextField
+        errorMessage={authEmailError ?? undefined}
+        isDisabled={isAuthPending}
+        isInvalid={Boolean(authEmailError)}
+        isRequired
+        label={t`Email`}
+        onChange={onAuthEmailChange}
+        type="email"
+        value={authEmail}
+      />
+      <Button color="accent" isDisabled={isAuthPending} type="submit">
+        <span className="flex items-center gap-2">
+          <AuthButtonIcon icon="lucide.mail" isPending={authPendingAction === "magic-link"} />
+          <Trans>Email me a sign-in link</Trans>
+        </span>
+      </Button>
+      <Button color="input-like" isDisabled={isAuthPending} onPress={onUsePassword} type="button">
+        <span className="flex items-center gap-2">
+          <Icon icon="lucide.key-round" width={18} height={18} />
+          <Trans>Sign in with password</Trans>
+        </span>
+      </Button>
+    </form>
+  );
+}

--- a/packages/pwa/src/hooks/useCloudSyncAccountState.ts
+++ b/packages/pwa/src/hooks/useCloudSyncAccountState.ts
@@ -1,0 +1,223 @@
+import { t } from "@lingui/core/macro";
+import { isValidDocumentId } from "@automerge/automerge-repo/slim";
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { toast } from "sonner";
+import { fetchLinkedAuthAccounts, type LinkedAuthAccount } from "#src/lib/auth-client.ts";
+import {
+  fetchCloudUserSettings,
+  getCloudUserSettingsInput,
+  saveCloudUserSettings,
+  writeCachedCloudUserSettings,
+  type CloudUserSettings,
+} from "#src/lib/cloudSyncSettings.ts";
+import {
+  hasLocalPartyListData,
+  readCachedCloudAccountState,
+  writeCachedCloudAccountState,
+} from "#src/lib/cloudSyncRouteState.ts";
+import type { PartyList } from "#src/models/partyList.js";
+
+const CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS = 30_000;
+
+export function useCloudSyncAccountState({
+  isSignInSuccessVisibleRef,
+  onCloudDataActivated,
+  partyList,
+  userId,
+}: {
+  isSignInSuccessVisibleRef: RefObject<boolean>;
+  onCloudDataActivated: (shouldDelay: boolean) => void;
+  partyList: PartyList;
+  userId: string | undefined;
+}) {
+  const [linkedAccounts, setLinkedAccounts] = useState<LinkedAuthAccount[]>([]);
+  const [cloudSettings, setCloudSettings] = useState<CloudUserSettings | null>(null);
+  const [isCloudSyncSwitchOpen, setIsCloudSyncSwitchOpen] = useState(false);
+  const partyListRef = useRef(partyList);
+  const onCloudDataActivatedRef = useRef(onCloudDataActivated);
+  const linkedProviderIds = new Set(linkedAccounts.map((account) => account.providerId));
+  const hasPasswordAccount = linkedProviderIds.has("credential");
+
+  useEffect(() => {
+    partyListRef.current = partyList;
+  }, [partyList]);
+
+  useEffect(() => {
+    onCloudDataActivatedRef.current = onCloudDataActivated;
+  }, [onCloudDataActivated]);
+
+  useEffect(() => {
+    if (!userId) {
+      setLinkedAccounts([]);
+      setCloudSettings(null);
+      setIsCloudSyncSwitchOpen(false);
+      return;
+    }
+
+    let isCancelled = false;
+    const currentUserId = userId;
+    const cachedAccountState = readCachedCloudAccountState(currentUserId);
+
+    if (cachedAccountState) {
+      setLinkedAccounts(cachedAccountState.linkedAccounts);
+      setCloudSettings(cachedAccountState.cloudSettings);
+    } else {
+      setLinkedAccounts([]);
+      setCloudSettings(null);
+    }
+
+    void loadAccountState({
+      showErrorToast: !cachedAccountState,
+      showStartToast: true,
+    });
+
+    const intervalId = window.setInterval(() => {
+      void loadAccountState({ showErrorToast: false, showStartToast: false });
+    }, CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS);
+
+    return () => {
+      isCancelled = true;
+      window.clearInterval(intervalId);
+    };
+
+    async function loadAccountState({
+      showErrorToast,
+      showStartToast,
+    }: {
+      showErrorToast: boolean;
+      showStartToast: boolean;
+    }) {
+      try {
+        const currentPartyList = partyListRef.current;
+        const [accounts, { settings }] = await Promise.all([
+          fetchLinkedAuthAccounts(),
+          fetchCloudUserSettings(),
+        ]);
+
+        if (isCancelled) {
+          return;
+        }
+
+        let activeSettings = settings;
+
+        if (!activeSettings) {
+          const { settings: savedSettings } = await saveCloudUserSettings(
+            getCloudUserSettingsInput(currentPartyList),
+          );
+
+          if (isCancelled) {
+            return;
+          }
+
+          activeSettings = savedSettings;
+          if (showStartToast) {
+            toast.success(t`trizum cloud started`);
+          }
+        }
+
+        setLinkedAccounts(accounts);
+        setCloudSettings(activeSettings);
+        writeCachedCloudUserSettings(currentUserId, activeSettings);
+        writeCachedCloudAccountState(currentUserId, {
+          cloudSettings: activeSettings,
+          linkedAccounts: accounts,
+        });
+
+        if (!activeSettings) {
+          return;
+        }
+
+        if (!isValidDocumentId(activeSettings.partyListDocumentId)) {
+          toast.error(t`trizum cloud data is invalid`);
+          return;
+        }
+
+        if (activeSettings.partyListDocumentId === currentPartyList.id) {
+          return;
+        }
+
+        if (hasLocalPartyListData(currentPartyList)) {
+          setIsCloudSyncSwitchOpen(true);
+          return;
+        }
+
+        localStorage.setItem("partyListId", activeSettings.partyListDocumentId);
+        setCloudSettings(activeSettings);
+        setIsCloudSyncSwitchOpen(false);
+        writeCachedCloudUserSettings(currentUserId, activeSettings);
+        writeCachedCloudAccountState(currentUserId, {
+          cloudSettings: activeSettings,
+          linkedAccounts: accounts,
+        });
+        toast.success(t`trizum cloud enabled on this device`);
+        onCloudDataActivatedRef.current(isSignInSuccessVisibleRef.current);
+      } catch {
+        if (!isCancelled && showErrorToast) {
+          toast.error(t`Could not load trizum cloud state`);
+        }
+      }
+    }
+  }, [isSignInSuccessVisibleRef, userId]);
+
+  function saveLinkedAccounts(accounts: LinkedAuthAccount[]) {
+    setLinkedAccounts(accounts);
+
+    if (userId) {
+      writeCachedCloudAccountState(userId, {
+        cloudSettings,
+        linkedAccounts: accounts,
+      });
+    }
+  }
+
+  function clearCloudSyncState() {
+    setCloudSettings(null);
+    setLinkedAccounts([]);
+    setIsCloudSyncSwitchOpen(false);
+  }
+
+  function activateCloudSyncOnDevice(settings: CloudUserSettings | null = cloudSettings) {
+    if (!settings) {
+      toast.message(t`trizum cloud is not set up yet`);
+      return;
+    }
+
+    if (!isValidDocumentId(settings.partyListDocumentId)) {
+      toast.error(t`trizum cloud data is invalid`);
+      return;
+    }
+
+    if (settings.partyListDocumentId === partyList.id) {
+      toast.message(t`This device is already using trizum cloud`);
+      return;
+    }
+
+    localStorage.setItem("partyListId", settings.partyListDocumentId);
+
+    if (userId) {
+      setCloudSettings(settings);
+      setIsCloudSyncSwitchOpen(false);
+      writeCachedCloudUserSettings(userId, settings);
+      writeCachedCloudAccountState(userId, {
+        cloudSettings: settings,
+        linkedAccounts,
+      });
+    } else {
+      setCloudSettings(settings);
+      setIsCloudSyncSwitchOpen(false);
+    }
+
+    toast.success(t`trizum cloud enabled on this device`);
+    onCloudDataActivatedRef.current(isSignInSuccessVisibleRef.current);
+  }
+
+  return {
+    activateCloudSyncOnDevice,
+    clearCloudSyncState,
+    hasPasswordAccount,
+    isCloudSyncSwitchOpen,
+    linkedProviderIds,
+    saveLinkedAccounts,
+    setIsCloudSyncSwitchOpen,
+  };
+}

--- a/packages/pwa/src/lib/auth-client.ts
+++ b/packages/pwa/src/lib/auth-client.ts
@@ -49,6 +49,10 @@ export const authClient = createAuthClient({
   plugins: [magicLinkClient()],
 });
 
+type AuthSession = ReturnType<typeof authClient.useSession>;
+
+export type AuthSessionUser = NonNullable<NonNullable<AuthSession["data"]>["user"]>;
+
 export function getAuthBaseURL() {
   if (import.meta.env.VITE_APP_AUTH_URL) {
     return import.meta.env.VITE_APP_AUTH_URL;
@@ -308,6 +312,32 @@ export async function deleteAuthUserAccount() {
 
 function getAuthEndpointURL(path: string) {
   return new URL(`/api/auth${path}`, getAuthBaseURL()).toString();
+}
+
+export function getAuthResultUser(data: unknown): AuthSessionUser | undefined {
+  if (!data || typeof data !== "object" || !("user" in data)) {
+    return undefined;
+  }
+
+  const user = data.user;
+
+  if (!user || typeof user !== "object" || !("id" in user) || !("email" in user)) {
+    return undefined;
+  }
+
+  if (typeof user.id !== "string" || typeof user.email !== "string") {
+    return undefined;
+  }
+
+  return user as AuthSessionUser;
+}
+
+export function getAuthRedirectUrl(data: unknown): string | undefined {
+  if (!data || typeof data !== "object" || !("url" in data)) {
+    return undefined;
+  }
+
+  return typeof data.url === "string" ? data.url : undefined;
 }
 
 function getAuthResultToken(data: unknown) {

--- a/packages/pwa/src/lib/cloudSyncRouteState.ts
+++ b/packages/pwa/src/lib/cloudSyncRouteState.ts
@@ -1,0 +1,140 @@
+import { isValidDocumentId } from "@automerge/automerge-repo/slim";
+import type { LinkedAuthAccount } from "#src/lib/auth-client.ts";
+import type { CloudUserSettings } from "#src/lib/cloudSyncSettings.ts";
+import type { PartyList } from "#src/models/partyList.js";
+
+const CLOUD_ACCOUNT_STATE_CACHE_KEY_PREFIX = "trizumCloudAccountState:";
+
+interface CachedCloudAccountState {
+  cachedAt: number;
+  cloudSettings: CloudUserSettings | null;
+  linkedAccounts: LinkedAuthAccount[];
+}
+
+export function hasLocalPartyListData(partyList: PartyList) {
+  return (
+    hasRecordData(partyList.parties) ||
+    hasRecordData(partyList.pinnedParties) ||
+    hasRecordData(partyList.archivedParties) ||
+    hasRecordData(partyList.lastUsedAt) ||
+    Boolean(partyList.lastOpenedPartyId) ||
+    Boolean(partyList.username.trim()) ||
+    Boolean(partyList.phone.trim()) ||
+    Boolean(partyList.avatarId) ||
+    Boolean(partyList.locale) ||
+    partyList.openLastPartyOnLaunch === true ||
+    partyList.autoOpenCalculator === true ||
+    partyList.hue !== undefined
+  );
+}
+
+export function readCachedCloudAccountState(userId: string) {
+  try {
+    const value = localStorage.getItem(getCloudAccountStateCacheKey(userId));
+
+    if (!value) {
+      return null;
+    }
+
+    const cachedValue = JSON.parse(value) as Partial<CachedCloudAccountState> | null;
+
+    if (!isCachedCloudAccountState(cachedValue)) {
+      return null;
+    }
+
+    return cachedValue;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedCloudAccountState(
+  userId: string,
+  state: Omit<CachedCloudAccountState, "cachedAt">,
+) {
+  try {
+    localStorage.setItem(
+      getCloudAccountStateCacheKey(userId),
+      JSON.stringify({
+        ...state,
+        cachedAt: Date.now(),
+      } satisfies CachedCloudAccountState),
+    );
+  } catch {
+    // localStorage can be unavailable in restricted browser contexts.
+  }
+}
+
+export function clearCachedCloudAccountState(userId: string) {
+  try {
+    localStorage.removeItem(getCloudAccountStateCacheKey(userId));
+  } catch {
+    // localStorage can be unavailable in restricted browser contexts.
+  }
+}
+
+export function isEmailFieldErrorMessage(message: string) {
+  const normalizedMessage = message.toLowerCase();
+
+  return (
+    normalizedMessage.includes("email") &&
+    !normalizedMessage.includes("password") &&
+    (normalizedMessage.includes("invalid") ||
+      normalizedMessage.includes("valid") ||
+      normalizedMessage.includes("required"))
+  );
+}
+
+export function isPasswordFieldErrorMessage(message: string) {
+  const normalizedMessage = message.toLowerCase();
+
+  return (
+    normalizedMessage.includes("password") &&
+    !normalizedMessage.includes("email") &&
+    (normalizedMessage.includes("invalid") ||
+      normalizedMessage.includes("required") ||
+      normalizedMessage.includes("short") ||
+      normalizedMessage.includes("least"))
+  );
+}
+
+function hasRecordData(record: Record<string, unknown> | undefined) {
+  return Object.values(record ?? {}).some(Boolean);
+}
+
+function getCloudAccountStateCacheKey(userId: string) {
+  return `${CLOUD_ACCOUNT_STATE_CACHE_KEY_PREFIX}${userId}`;
+}
+
+function isCachedCloudAccountState(
+  value: Partial<CachedCloudAccountState> | null,
+): value is CachedCloudAccountState {
+  if (!value || typeof value.cachedAt !== "number") {
+    return false;
+  }
+
+  return (
+    (value.cloudSettings === null ||
+      (typeof value.cloudSettings === "object" &&
+        typeof value.cloudSettings.updatedAt === "number" &&
+        typeof value.cloudSettings.partyListDocumentId === "string" &&
+        isValidDocumentId(value.cloudSettings.partyListDocumentId))) &&
+    Array.isArray(value.linkedAccounts) &&
+    value.linkedAccounts.every(isLinkedAuthAccount)
+  );
+}
+
+function isLinkedAuthAccount(value: unknown): value is LinkedAuthAccount {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const account = value as Partial<LinkedAuthAccount>;
+
+  return (
+    typeof account.accountId === "string" &&
+    typeof account.id === "string" &&
+    typeof account.providerId === "string" &&
+    typeof account.userId === "string"
+  );
+}

--- a/packages/pwa/src/routes/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/settings_.cloud-sync.tsx
@@ -2,21 +2,37 @@ import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { isValidDocumentId } from "@automerge/automerge-repo/slim";
 import { createFileRoute, useLocation, useNavigate, useRouter } from "@tanstack/react-router";
-import { useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
-import { Dialog, Modal, ModalOverlay } from "react-aria-components";
-import { AnimatePresence, motion } from "motion/react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { AnimatePresence } from "motion/react";
 import { toast } from "sonner";
 import { BackButton } from "#src/components/BackButton.js";
+import { CloudSyncAccountSettings } from "#src/components/CloudSyncAccountSettings.tsx";
+import {
+  AuthButtonIcon,
+  AuthCallbackErrorDialog,
+  AuthErrorAlert,
+  CloudActionConfirmationDialog,
+  CloudAuthLoadingState,
+  CloudSyncSignInDialog,
+  CloudSyncSwitchDialog,
+  DeleteAccountDialog,
+  MagicLinkSentState,
+  SignInSuccessOverlay,
+  type CloudActionDialogType,
+} from "#src/components/CloudSyncDialogs.tsx";
 import { getAuthCallbackErrorContent } from "#src/lib/authCallbackErrors.ts";
 import { clearNativeAuthToken } from "#src/lib/nativeAuthSession.ts";
 import {
   authClient,
   deleteAuthUserAccount,
   fetchLinkedAuthAccounts,
+  getAuthRedirectUrl,
+  getAuthResultUser,
   linkSocialAuthAccount,
   requestMagicLinkEmail,
   requestPasswordResetEmail,
   signInWithSocialAuthAccount,
+  type AuthSessionUser,
   type LinkedAuthAccount,
   type SocialAuthProvider,
 } from "#src/lib/auth-client.ts";
@@ -28,14 +44,18 @@ import {
   writeCachedCloudUserSettings,
   type CloudUserSettings,
 } from "#src/lib/cloudSyncSettings.ts";
+import {
+  clearCachedCloudAccountState,
+  hasLocalPartyListData,
+  isEmailFieldErrorMessage,
+  isPasswordFieldErrorMessage,
+  readCachedCloudAccountState,
+  writeCachedCloudAccountState,
+} from "#src/lib/cloudSyncRouteState.ts";
 import { Button } from "#src/ui/Button.tsx";
-import { Icon, type IconProps } from "#src/ui/Icon.tsx";
-import { Alert, AlertDescription } from "#src/ui/Alert.tsx";
+import { Icon } from "#src/ui/Icon.tsx";
 import { AppTextField } from "#src/ui/fields/TextField.js";
-import { IconButton } from "#src/ui/IconButton.js";
-import { cn } from "#src/ui/utils.js";
 import { usePartyList } from "#src/hooks/usePartyList.js";
-import type { PartyList } from "#src/models/partyList.js";
 import { Settings } from "#src/routes/settings.tsx";
 import { closeRouteState } from "#src/lib/navigationHistory.ts";
 
@@ -52,7 +72,6 @@ const SIGN_IN_SUCCESS_EXIT_ANIMATION_MS = 180;
 const DIALOG_EXIT_ANIMATION_MS = 180;
 const PASSWORD_SIGN_IN_ENABLE_DELAY_MS = 250;
 const CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS = 30_000;
-const CLOUD_ACCOUNT_STATE_CACHE_KEY_PREFIX = "trizumCloudAccountState:";
 const DELETE_ACCOUNT_CONFIRMATION_TEXT = "delete account";
 const AUTH_SECONDARY_BUTTON_CLASS_NAME =
   "h-9 text-sm font-medium text-accent-700 dark:text-accent-50";
@@ -69,16 +88,6 @@ type AuthPendingAction =
   | "password"
   | "password-reset"
   | "sign-out";
-
-type CloudActionDialogType = "connect-apple" | "connect-google" | "password-link" | "sign-out";
-type AuthSession = ReturnType<typeof authClient.useSession>;
-type AuthSessionUser = NonNullable<NonNullable<AuthSession["data"]>["user"]>;
-
-interface CachedCloudAccountState {
-  cachedAt: number;
-  cloudSettings: CloudUserSettings | null;
-  linkedAccounts: LinkedAuthAccount[];
-}
 
 function CloudSyncSettings() {
   const { partyList } = usePartyList();
@@ -366,32 +375,6 @@ function CloudSyncSettings() {
     toast.success(t`Signed in`);
     setIsSignInSuccessVisible(true);
     void session.refetch();
-  }
-
-  function getAuthResultUser(data: unknown): AuthSessionUser | undefined {
-    if (!data || typeof data !== "object" || !("user" in data)) {
-      return undefined;
-    }
-
-    const user = data.user;
-
-    if (!user || typeof user !== "object" || !("id" in user) || !("email" in user)) {
-      return undefined;
-    }
-
-    if (typeof user.id !== "string" || typeof user.email !== "string") {
-      return undefined;
-    }
-
-    return user as AuthSessionUser;
-  }
-
-  function getAuthRedirectUrl(data: unknown): string | undefined {
-    if (!data || typeof data !== "object" || !("url" in data)) {
-      return undefined;
-    }
-
-    return typeof data.url === "string" ? data.url : undefined;
   }
 
   function onAuthEmailChange(value: string) {
@@ -900,89 +883,27 @@ function CloudSyncSettings() {
         </h1>
       </div>
 
-      <div className="container mt-4 flex flex-col gap-8 px-4 pb-8 pb-safe">
-        <CloudSettingsSection icon="lucide.link" title={t`Connections`}>
-          <CloudSettingsItem
-            icon="brand.apple"
-            title={t`Apple`}
-            description={
-              linkedProviderIds.has("apple")
-                ? t`Apple is connected to this account`
-                : t`Add Apple as a sign-in method`
-            }
-            statusLabel={linkedProviderIds.has("apple") ? t`Connected` : undefined}
-            isConnected={linkedProviderIds.has("apple")}
-            isDisabled={isAuthPending || linkedProviderIds.has("apple")}
-            onPress={
-              linkedProviderIds.has("apple")
-                ? undefined
-                : () => {
-                    setCloudActionDialog("connect-apple");
-                  }
-            }
-          />
-          <CloudSettingsItem
-            icon="brand.google"
-            title={t`Google`}
-            description={
-              linkedProviderIds.has("google")
-                ? t`Google is connected to this account`
-                : t`Add Google as a sign-in method`
-            }
-            statusLabel={linkedProviderIds.has("google") ? t`Connected` : undefined}
-            isConnected={linkedProviderIds.has("google")}
-            isDisabled={isAuthPending || linkedProviderIds.has("google")}
-            onPress={
-              linkedProviderIds.has("google")
-                ? undefined
-                : () => {
-                    setCloudActionDialog("connect-google");
-                  }
-            }
-          />
-        </CloudSettingsSection>
-
-        <CloudSettingsSection icon="lucide.shield-check" title={t`Security`}>
-          <CloudSettingsItem
-            icon="lucide.mail"
-            title={t`Email`}
-            description={user.email}
-            statusLabel={t`Signed in`}
-            isConnected
-          />
-          <CloudSettingsItem
-            icon="lucide.key-round"
-            title={t`Password`}
-            description={
-              passwordResetMessage ??
-              (hasPasswordAccount ? t`Email a password reset link` : t`Set up password sign-in`)
-            }
-            isDisabled={isAuthPending}
-            onPress={() => {
-              setCloudActionDialog("password-link");
-            }}
-          />
-          <CloudSettingsItem
-            icon="lucide.log-out"
-            title={t`Sign out`}
-            description={t`Stop trizum cloud on this device`}
-            isDisabled={isAuthPending}
-            onPress={() => {
-              setCloudActionDialog("sign-out");
-            }}
-          />
-        </CloudSettingsSection>
-
-        <CloudSettingsSection icon="lucide.triangle-alert" title={t`Destructive actions`}>
-          <CloudSettingsItem
-            icon="lucide.trash-2"
-            title={t`Delete account`}
-            description={t`Permanently delete your trizum cloud account`}
-            isDisabled={isDeleteAccountPending}
-            onPress={openDeleteAccountDialog}
-          />
-        </CloudSettingsSection>
-      </div>
+      <CloudSyncAccountSettings
+        email={user.email}
+        hasPasswordAccount={hasPasswordAccount}
+        isAuthPending={isAuthPending}
+        isDeleteAccountPending={isDeleteAccountPending}
+        linkedProviderIds={linkedProviderIds}
+        onConnectApple={() => {
+          setCloudActionDialog("connect-apple");
+        }}
+        onConnectGoogle={() => {
+          setCloudActionDialog("connect-google");
+        }}
+        onDeleteAccount={openDeleteAccountDialog}
+        onPasswordLink={() => {
+          setCloudActionDialog("password-link");
+        }}
+        onSignOut={() => {
+          setCloudActionDialog("sign-out");
+        }}
+        passwordResetMessage={passwordResetMessage}
+      />
 
       <CloudActionConfirmationDialog
         action={cloudActionDialog}
@@ -1034,7 +955,11 @@ function CloudSyncSettings() {
         }}
       />
 
-      <AnimatePresence>{isSignInSuccessVisible ? <SignInSuccessOverlay /> : null}</AnimatePresence>
+      <AnimatePresence>
+        {isSignInSuccessVisible ? (
+          <SignInSuccessOverlay exitAnimationMs={SIGN_IN_SUCCESS_EXIT_ANIMATION_MS} />
+        ) : null}
+      </AnimatePresence>
 
       <CloudSyncSwitchDialog
         isOpen={isCloudSyncSwitchOpen}
@@ -1047,887 +972,10 @@ function CloudSyncSettings() {
   );
 }
 
-function CloudSyncSwitchDialog({
-  isOpen,
-  onSignOut,
-  onUseCloudData,
-}: {
-  isOpen: boolean;
-  onSignOut: () => void;
-  onUseCloudData: () => void;
-}) {
-  return (
-    <ModalOverlay
-      isDismissable={false}
-      isKeyboardDismissDisabled
-      isOpen={isOpen}
-      className={({ isEntering, isExiting }) =>
-        cn(
-          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
-          isEntering && "duration-200 ease-out animate-in fade-in",
-          isExiting && "duration-150 ease-in animate-out fade-out",
-        )
-      }
-    >
-      <Modal
-        className={({ isEntering, isExiting }) =>
-          cn(
-            "w-full max-w-[420px] outline-none",
-            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
-            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
-          )
-        }
-      >
-        <Dialog
-          aria-label={t`Use trizum cloud on this device?`}
-          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
-        >
-          <div className="flex flex-col gap-5 p-5 sm:p-6">
-            <div className="flex flex-col gap-3">
-              <span className="flex size-10 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-800 dark:text-accent-50">
-                <Icon icon="lucide.cloud-download" width={20} height={20} />
-              </span>
-              <div className="flex flex-col gap-2">
-                <h2 className="text-lg font-medium">
-                  <Trans>Use trizum cloud on this device?</Trans>
-                </h2>
-                <p className="text-sm text-accent-700 dark:text-accent-50">
-                  <Trans>
-                    This device already has local data. Using trizum cloud here will switch this
-                    device to your cloud data. Your local data on this device will stop being used.
-                  </Trans>
-                </p>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-3">
-              <Button className="font-semibold" color="accent" onPress={onUseCloudData}>
-                <span className="flex items-center gap-2">
-                  <Icon icon="lucide.cloud-download" width={18} height={18} />
-                  <Trans>Use cloud data</Trans>
-                </span>
-              </Button>
-              <Button
-                className="font-semibold text-danger-700 dark:text-danger-300"
-                color="input-like"
-                onPress={onSignOut}
-              >
-                <span className="flex items-center gap-2">
-                  <Icon icon="lucide.log-out" width={18} height={18} />
-                  <Trans>Sign out</Trans>
-                </span>
-              </Button>
-            </div>
-          </div>
-        </Dialog>
-      </Modal>
-    </ModalOverlay>
-  );
-}
-
-function AuthCallbackErrorDialog({
-  error,
-  isOpen,
-  onOpenChange,
-}: {
-  error: string | null;
-  isOpen: boolean;
-  onOpenChange: (isOpen: boolean) => void;
-}) {
-  const content = error ? getAuthCallbackErrorContent(error) : null;
-
-  return (
-    <ModalOverlay
-      isDismissable
-      isOpen={isOpen}
-      onOpenChange={onOpenChange}
-      className={({ isEntering, isExiting }) =>
-        cn(
-          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
-          isEntering && "duration-200 ease-out animate-in fade-in",
-          isExiting && "duration-150 ease-in animate-out fade-out",
-        )
-      }
-    >
-      <Modal
-        className={({ isEntering, isExiting }) =>
-          cn(
-            "w-full max-w-[420px] outline-none",
-            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
-            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
-          )
-        }
-      >
-        <Dialog
-          aria-label={content?.title ?? t`Authentication error`}
-          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
-        >
-          {content ? (
-            <div className="flex flex-col gap-5 p-5 sm:p-6">
-              <div className="flex flex-col gap-3">
-                <span className="flex size-10 items-center justify-center rounded-full bg-danger-50 text-danger-600 dark:bg-danger-950/50 dark:text-danger-300">
-                  <Icon icon="lucide.circle-alert" width={20} height={20} />
-                </span>
-                <div className="flex flex-col gap-2">
-                  <h2 className="text-lg font-medium">{content.title}</h2>
-                  <p className="text-sm text-accent-700 dark:text-accent-50">
-                    {content.description}
-                  </p>
-                </div>
-              </div>
-
-              <Button
-                className="font-semibold"
-                color="accent"
-                onPress={() => {
-                  onOpenChange(false);
-                }}
-                type="button"
-              >
-                <Trans>Got it</Trans>
-              </Button>
-            </div>
-          ) : null}
-        </Dialog>
-      </Modal>
-    </ModalOverlay>
-  );
-}
-
-function CloudSyncSignInDialog({
-  children,
-  isOpen,
-  onOpenChange,
-  showHeader,
-}: {
-  children: ReactNode;
-  isOpen: boolean;
-  onOpenChange: () => void;
-  showHeader: boolean;
-}) {
-  return (
-    <ModalOverlay
-      isDismissable
-      isOpen={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onOpenChange();
-        }
-      }}
-      className={({ isEntering, isExiting }) =>
-        cn(
-          "fixed inset-0 z-50 flex items-stretch justify-center bg-accent-950/35 p-0 backdrop-blur-md sm:items-center sm:px-safe-or-4 sm:py-safe-offset-6",
-          isEntering && "duration-200 ease-out animate-in fade-in",
-          isExiting && "duration-150 ease-in animate-out fade-out",
-        )
-      }
-    >
-      <Modal
-        className={({ isEntering, isExiting }) =>
-          cn(
-            "h-full w-full outline-none sm:h-auto sm:max-w-[420px]",
-            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
-            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
-          )
-        }
-      >
-        <Dialog
-          aria-label={t`Sign in`}
-          className="relative flex h-[100dvh] max-h-[100dvh] flex-col overflow-hidden bg-white shadow-2xl outline-none sm:h-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-lg sm:border sm:border-accent-200 dark:bg-accent-950 dark:sm:border-accent-800"
-        >
-          <IconButton
-            aria-label={t`Back to settings`}
-            className="absolute right-safe-offset-2 top-safe-offset-2 sm:right-2 sm:top-2"
-            icon="lucide.x"
-            onPress={onOpenChange}
-          />
-          <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto pb-safe-offset-5 pt-safe-offset-14 px-safe-or-5 sm:p-6 sm:pt-14">
-            {showHeader ? (
-              <div className="flex flex-col items-center gap-3 text-center">
-                <img
-                  alt=""
-                  className="size-12 rounded-xl"
-                  height={48}
-                  src="/pwa-64x64.png"
-                  width={48}
-                />
-                <h2 className="text-lg font-medium">
-                  <Trans>Sign in to trizum cloud</Trans>
-                </h2>
-              </div>
-            ) : null}
-
-            {children}
-          </div>
-        </Dialog>
-      </Modal>
-    </ModalOverlay>
-  );
-}
-
-function AuthErrorAlert({ message }: { message: string }) {
-  return (
-    <Alert variant="destructive">
-      <Icon icon="lucide.circle-alert" />
-      <AlertDescription>{message}</AlertDescription>
-    </Alert>
-  );
-}
-
-function AuthButtonIcon({ icon, isPending }: { icon: IconProps["icon"]; isPending: boolean }) {
-  return (
-    <Icon
-      className={cn(isPending && "animate-spin")}
-      icon={isPending ? "lucide.loader-circle" : icon}
-      width={18}
-      height={18}
-    />
-  );
-}
-
-function CloudAuthLoadingState() {
-  return (
-    <output
-      aria-label={t`Finishing sign in`}
-      className="flex flex-1 flex-col items-center justify-center gap-4 py-8 text-center"
-    >
-      <motion.span
-        animate={{ rotate: 360 }}
-        className="flex size-12 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-900 dark:text-accent-50"
-        transition={{ duration: 0.9, ease: "linear", repeat: Infinity }}
-      >
-        <Icon icon="lucide.loader-circle" width={24} height={24} />
-      </motion.span>
-      <p className="text-sm font-medium text-accent-700 dark:text-accent-50">
-        <Trans>Finishing sign in</Trans>
-      </p>
-    </output>
-  );
-}
-
-function MagicLinkSentState({
-  email,
-  message,
-  onTryAgain,
-}: {
-  email: string;
-  message: string;
-  onTryAgain: () => void;
-}) {
-  return (
-    <motion.div
-      className="flex flex-1 flex-col items-center justify-center gap-5 py-8 text-center"
-      initial={{ opacity: 0, y: 12, scale: 0.98 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      transition={{ duration: 0.2, ease: "easeOut" }}
-    >
-      <motion.span
-        className="flex size-16 items-center justify-center rounded-full bg-success-100 text-success-700 dark:bg-success-950/60 dark:text-success-200"
-        initial={{ scale: 0.72 }}
-        animate={{ scale: [0.72, 1.08, 1] }}
-        transition={{ delay: 0.04, duration: 0.38, ease: "easeOut" }}
-      >
-        <Icon icon="lucide.mail-check" width={28} height={28} />
-      </motion.span>
-      <div className="flex flex-col gap-2">
-        <h3 className="text-base font-medium">{message}</h3>
-        <p className="text-sm text-accent-700 dark:text-accent-50">
-          <Trans>We sent a sign-in link to {email}. Open it to finish signing in.</Trans>
-        </p>
-      </div>
-      <Button color="input-like" onPress={onTryAgain} type="button">
-        <span className="flex items-center gap-2">
-          <Icon icon="lucide.refresh-cw" width={18} height={18} />
-          <Trans>Try another email</Trans>
-        </span>
-      </Button>
-    </motion.div>
-  );
-}
-
-function SignInSuccessAnimation() {
-  return (
-    <motion.div
-      className="flex flex-col items-center gap-3 px-5 py-8 text-center"
-      initial={{ opacity: 0, scale: 0.96 }}
-      animate={{ opacity: 1, scale: 1 }}
-      exit={{ opacity: 0, scale: 0.98 }}
-      transition={{ duration: 0.18, ease: "easeOut" }}
-    >
-      <motion.span
-        className="flex size-16 items-center justify-center rounded-full bg-success-100 text-success-700 dark:bg-success-950/60 dark:text-success-200"
-        initial={{ scale: 0.6 }}
-        animate={{ scale: [0.6, 1.1, 1] }}
-        transition={{ duration: 0.42, ease: "easeOut" }}
-      >
-        <Icon icon="lucide.check" width={32} height={32} />
-      </motion.span>
-      <motion.p
-        className="text-base font-medium"
-        initial={{ opacity: 0, y: 6 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.12, duration: 0.2, ease: "easeOut" }}
-      >
-        <Trans>Signed in</Trans>
-      </motion.p>
-    </motion.div>
-  );
-}
-
-function SignInSuccessOverlay() {
-  return (
-    <motion.div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-white/90 backdrop-blur-md py-safe-offset-6 px-safe-or-4 dark:bg-accent-950/90"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: SIGN_IN_SUCCESS_EXIT_ANIMATION_MS / 1000, ease: "easeOut" }}
-    >
-      <motion.div
-        className="w-full max-w-[420px]"
-        initial={{ opacity: 0, y: 12, scale: 0.96 }}
-        animate={{ opacity: 1, y: 0, scale: 1 }}
-        exit={{ opacity: 0, y: -8, scale: 0.98 }}
-        transition={{ duration: 0.2, ease: "easeOut" }}
-      >
-        <SignInSuccessAnimation />
-      </motion.div>
-    </motion.div>
-  );
-}
-
-function CloudSettingsSection({
-  children,
-  icon,
-  title,
-  tone = "default",
-}: {
-  children: ReactNode;
-  icon: IconProps["icon"];
-  title: string;
-  tone?: "default" | "danger";
-}) {
-  return (
-    <section className="flex flex-col gap-2">
-      <div
-        className={cn(
-          "flex items-center gap-2 px-1 text-sm font-semibold text-accent-700 dark:text-accent-200",
-          tone === "danger" && "text-danger-600 dark:text-danger-300",
-        )}
-      >
-        <Icon icon={icon} width={16} height={16} />
-        <h2>{title}</h2>
-      </div>
-      <div className="flex flex-col gap-1">{children}</div>
-    </section>
-  );
-}
-
-function CloudSettingsItem({
-  description,
-  icon,
-  isConnected,
-  isDisabled,
-  onPress,
-  statusLabel,
-  title,
-  tone = "default",
-}: {
-  description?: ReactNode;
-  icon: IconProps["icon"];
-  isConnected?: boolean;
-  isDisabled?: boolean;
-  onPress?: () => void;
-  statusLabel?: ReactNode;
-  title: string;
-  tone?: "default" | "danger";
-}) {
-  const content = (
-    <span className="flex w-full items-center gap-3">
-      <span
-        className={cn(
-          "flex size-10 shrink-0 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-900 dark:text-accent-50",
-          tone === "danger" &&
-            "bg-danger-50 text-danger-600 dark:bg-danger-950/50 dark:text-danger-300",
-        )}
-      >
-        <Icon icon={icon} width={20} height={20} />
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col gap-1">
-        <span
-          className={cn(
-            "font-medium leading-tight",
-            tone === "danger" && "text-danger-600 dark:text-danger-300",
-          )}
-        >
-          {title}
-        </span>
-        {description ? (
-          <span
-            className={cn(
-              "whitespace-normal break-words text-sm leading-snug text-accent-700 dark:text-accent-200",
-              tone === "danger" && "text-danger-700 dark:text-danger-300",
-            )}
-          >
-            {description}
-          </span>
-        ) : null}
-      </span>
-      {onPress ? (
-        <span
-          className={cn(
-            "ml-2 flex shrink-0 items-center gap-1 text-sm font-medium text-accent-700 dark:text-accent-100",
-            tone === "danger" && "text-danger-600 dark:text-danger-300",
-          )}
-        >
-          <Icon icon="lucide.chevron-right" width={18} height={18} />
-        </span>
-      ) : statusLabel ? (
-        <span
-          className={cn(
-            "ml-2 shrink-0 rounded-full bg-accent-100 px-2.5 py-1 text-xs font-medium text-accent-700 dark:bg-accent-900 dark:text-accent-100",
-            tone === "danger" &&
-              "bg-danger-50 text-danger-700 dark:bg-danger-950/50 dark:text-danger-300",
-          )}
-        >
-          {statusLabel}
-        </span>
-      ) : isConnected ? (
-        <Icon
-          className="text-accent-600 dark:text-accent-200"
-          icon="lucide.check"
-          width={18}
-          height={18}
-        />
-      ) : null}
-    </span>
-  );
-  const className = cn(
-    "-mx-3 h-auto min-h-16 w-[calc(100%+1.5rem)] justify-start rounded-xl px-3 py-3 text-left",
-    "hover:bg-accent-100/70 dark:hover:bg-accent-900/70",
-    tone === "danger" && "hover:bg-danger-50 dark:hover:bg-danger-950/40",
-  );
-
-  if (onPress) {
-    return (
-      <Button
-        color="transparent"
-        className={className}
-        isDisabled={isDisabled}
-        onPress={onPress}
-        type="button"
-      >
-        {content}
-      </Button>
-    );
-  }
-
-  return (
-    <div className="-mx-3 flex min-h-16 w-[calc(100%+1.5rem)] items-center rounded-xl px-3 py-3 text-left">
-      {content}
-    </div>
-  );
-}
-
-function CloudActionConfirmationDialog({
-  action,
-  email,
-  hasPasswordAccount,
-  isPending,
-  onConfirm,
-  onOpenChange,
-}: {
-  action: CloudActionDialogType | null;
-  email: string;
-  hasPasswordAccount: boolean;
-  isPending: boolean;
-  onConfirm: (action: CloudActionDialogType) => Promise<void>;
-  onOpenChange: (isOpen: boolean) => void;
-}) {
-  const config = action ? getCloudActionDialogConfig({ action, email, hasPasswordAccount }) : null;
-
-  return (
-    <ModalOverlay
-      isDismissable={!isPending}
-      isOpen={Boolean(action)}
-      onOpenChange={onOpenChange}
-      className={({ isEntering, isExiting }) =>
-        cn(
-          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
-          isEntering && "duration-200 ease-out animate-in fade-in",
-          isExiting && "duration-150 ease-in animate-out fade-out",
-        )
-      }
-    >
-      <Modal
-        className={({ isEntering, isExiting }) =>
-          cn(
-            "w-full max-w-[420px] outline-none",
-            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
-            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
-          )
-        }
-      >
-        <Dialog
-          aria-label={config?.title ?? t`Confirm action`}
-          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
-        >
-          {config && action ? (
-            <div className="flex flex-col gap-5 p-5 sm:p-6">
-              <div className="flex flex-col gap-3">
-                <span
-                  className={cn(
-                    "flex size-10 items-center justify-center rounded-full bg-accent-100 text-accent-700 dark:bg-accent-800 dark:text-accent-50",
-                    config.tone === "danger" &&
-                      "bg-danger-50 text-danger-500 dark:bg-danger-950/50 dark:text-danger-300",
-                  )}
-                >
-                  <Icon icon={config.icon} width={20} height={20} />
-                </span>
-                <div className="flex flex-col gap-2">
-                  <h2 className="text-lg font-medium">{config.title}</h2>
-                  <p className="text-sm text-accent-700 dark:text-accent-50">
-                    {config.description}
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  className={cn(
-                    "font-semibold",
-                    config.tone === "danger" && "bg-danger-500 text-danger-50 dark:bg-danger-500",
-                  )}
-                  color="accent"
-                  isDisabled={isPending}
-                  onPress={() => {
-                    void onConfirm(action);
-                  }}
-                  type="button"
-                >
-                  <span className="flex items-center gap-2">
-                    <AuthButtonIcon icon={config.icon} isPending={isPending} />
-                    {config.actionLabel}
-                  </span>
-                </Button>
-                <Button
-                  color="input-like"
-                  isDisabled={isPending}
-                  onPress={() => {
-                    onOpenChange(false);
-                  }}
-                  type="button"
-                >
-                  <Trans>Cancel</Trans>
-                </Button>
-              </div>
-            </div>
-          ) : null}
-        </Dialog>
-      </Modal>
-    </ModalOverlay>
-  );
-}
-
-function getCloudActionDialogConfig({
-  action,
-  email,
-  hasPasswordAccount,
-}: {
-  action: CloudActionDialogType;
-  email: string;
-  hasPasswordAccount: boolean;
-}): {
-  actionLabel: string;
-  description: ReactNode;
-  icon: IconProps["icon"];
-  title: string;
-  tone?: "danger";
-} {
-  switch (action) {
-    case "connect-apple":
-      return {
-        actionLabel: t`Connect Apple`,
-        description: (
-          <Trans>
-            trizum will open Apple so you can add it as a sign-in method for this account.
-          </Trans>
-        ),
-        icon: "brand.apple",
-        title: t`Connect Apple?`,
-      };
-    case "connect-google":
-      return {
-        actionLabel: t`Connect Google`,
-        description: (
-          <Trans>
-            trizum will open Google so you can add it as a sign-in method for this account.
-          </Trans>
-        ),
-        icon: "brand.google",
-        title: t`Connect Google?`,
-      };
-    case "password-link":
-      return {
-        actionLabel: t`Email password link`,
-        description: hasPasswordAccount ? (
-          <Trans>
-            We will email a password link to {email}. Your current password keeps working until you
-            change it.
-          </Trans>
-        ) : (
-          <Trans>
-            We will email a password setup link to {email}. Password sign-in starts working after
-            you add one.
-          </Trans>
-        ),
-        icon: "lucide.key-round",
-        title: hasPasswordAccount ? t`Email password link?` : t`Set up password?`,
-      };
-    case "sign-out":
-      return {
-        actionLabel: t`Sign out`,
-        description: (
-          <Trans>
-            This stops trizum cloud on this device. Your local data stays on this device.
-          </Trans>
-        ),
-        icon: "lucide.log-out",
-        title: t`Sign out?`,
-      };
-  }
-}
-
-function DeleteAccountDialog({
-  canSubmit,
-  confirmation,
-  errorMessage,
-  isOpen,
-  isPending,
-  onConfirmationChange,
-  onOpenChange,
-  onSubmit,
-}: {
-  canSubmit: boolean;
-  confirmation: string;
-  errorMessage: string | null;
-  isOpen: boolean;
-  isPending: boolean;
-  onConfirmationChange: (value: string) => void;
-  onOpenChange: (isOpen: boolean) => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
-}) {
-  return (
-    <ModalOverlay
-      isDismissable={!isPending}
-      isOpen={isOpen}
-      onOpenChange={onOpenChange}
-      className={({ isEntering, isExiting }) =>
-        cn(
-          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
-          isEntering && "duration-200 ease-out animate-in fade-in",
-          isExiting && "duration-150 ease-in animate-out fade-out",
-        )
-      }
-    >
-      <Modal
-        className={({ isEntering, isExiting }) =>
-          cn(
-            "w-full max-w-[420px] outline-none",
-            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
-            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
-          )
-        }
-      >
-        <Dialog
-          aria-label={t`Delete account`}
-          className="rounded-lg border border-accent-200 bg-white shadow-2xl outline-none dark:border-accent-800 dark:bg-accent-950"
-        >
-          <form className="flex flex-col gap-5 p-5 sm:p-6" onSubmit={onSubmit}>
-            <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-medium">
-                <Trans>Delete account?</Trans>
-              </h2>
-              <p className="text-sm text-accent-700 dark:text-accent-50">
-                <Trans>
-                  This permanently deletes your trizum cloud account, sign-in methods, and cloud
-                  settings. Your local data on this device will remain.
-                </Trans>
-              </p>
-            </div>
-
-            {errorMessage ? <AuthErrorAlert message={errorMessage} /> : null}
-
-            <AppTextField
-              description={t`Type "delete account" to confirm.`}
-              isDisabled={isPending}
-              label={t`Confirmation`}
-              onChange={onConfirmationChange}
-              value={confirmation}
-            />
-
-            <div className="flex flex-col gap-3">
-              <Button
-                className="bg-danger-500 text-danger-50 dark:bg-danger-500"
-                color="accent"
-                isDisabled={!canSubmit || isPending}
-                type="submit"
-              >
-                <span className="flex items-center gap-2">
-                  <Icon icon="lucide.trash-2" width={18} height={18} />
-                  <Trans>Delete account</Trans>
-                </span>
-              </Button>
-              <Button
-                color="input-like"
-                isDisabled={isPending}
-                onPress={() => {
-                  onOpenChange(false);
-                }}
-                type="button"
-              >
-                <Trans>Cancel</Trans>
-              </Button>
-            </div>
-          </form>
-        </Dialog>
-      </Modal>
-    </ModalOverlay>
-  );
-}
-
-function hasLocalPartyListData(partyList: PartyList) {
-  return (
-    hasRecordData(partyList.parties) ||
-    hasRecordData(partyList.pinnedParties) ||
-    hasRecordData(partyList.archivedParties) ||
-    hasRecordData(partyList.lastUsedAt) ||
-    Boolean(partyList.lastOpenedPartyId) ||
-    Boolean(partyList.username.trim()) ||
-    Boolean(partyList.phone.trim()) ||
-    Boolean(partyList.avatarId) ||
-    Boolean(partyList.locale) ||
-    partyList.openLastPartyOnLaunch === true ||
-    partyList.autoOpenCalculator === true ||
-    partyList.hue !== undefined
-  );
-}
-
-function hasRecordData(record: Record<string, unknown> | undefined) {
-  return Object.values(record ?? {}).some(Boolean);
-}
-
 function getDeleteAccountErrorMessage(message: string) {
   if (message.toLowerCase().includes("session")) {
     return t`Sign in again before deleting your account`;
   }
 
   return message;
-}
-
-function isEmailFieldErrorMessage(message: string) {
-  const normalizedMessage = message.toLowerCase();
-
-  return (
-    normalizedMessage.includes("email") &&
-    !normalizedMessage.includes("password") &&
-    (normalizedMessage.includes("invalid") ||
-      normalizedMessage.includes("valid") ||
-      normalizedMessage.includes("required"))
-  );
-}
-
-function isPasswordFieldErrorMessage(message: string) {
-  const normalizedMessage = message.toLowerCase();
-
-  return (
-    normalizedMessage.includes("password") &&
-    !normalizedMessage.includes("email") &&
-    (normalizedMessage.includes("invalid") ||
-      normalizedMessage.includes("required") ||
-      normalizedMessage.includes("short") ||
-      normalizedMessage.includes("least"))
-  );
-}
-
-function readCachedCloudAccountState(userId: string) {
-  try {
-    const value = localStorage.getItem(getCloudAccountStateCacheKey(userId));
-
-    if (!value) {
-      return null;
-    }
-
-    const cachedValue = JSON.parse(value) as Partial<CachedCloudAccountState> | null;
-
-    if (!isCachedCloudAccountState(cachedValue)) {
-      return null;
-    }
-
-    return cachedValue;
-  } catch {
-    return null;
-  }
-}
-
-function writeCachedCloudAccountState(
-  userId: string,
-  state: Omit<CachedCloudAccountState, "cachedAt">,
-) {
-  try {
-    localStorage.setItem(
-      getCloudAccountStateCacheKey(userId),
-      JSON.stringify({
-        ...state,
-        cachedAt: Date.now(),
-      } satisfies CachedCloudAccountState),
-    );
-  } catch {
-    // localStorage can be unavailable in restricted browser contexts.
-  }
-}
-
-function clearCachedCloudAccountState(userId: string) {
-  try {
-    localStorage.removeItem(getCloudAccountStateCacheKey(userId));
-  } catch {
-    // localStorage can be unavailable in restricted browser contexts.
-  }
-}
-
-function getCloudAccountStateCacheKey(userId: string) {
-  return `${CLOUD_ACCOUNT_STATE_CACHE_KEY_PREFIX}${userId}`;
-}
-
-function isCachedCloudAccountState(
-  value: Partial<CachedCloudAccountState> | null,
-): value is CachedCloudAccountState {
-  if (!value || typeof value.cachedAt !== "number") {
-    return false;
-  }
-
-  return (
-    (value.cloudSettings === null ||
-      (typeof value.cloudSettings === "object" &&
-        typeof value.cloudSettings.updatedAt === "number" &&
-        typeof value.cloudSettings.partyListDocumentId === "string" &&
-        isValidDocumentId(value.cloudSettings.partyListDocumentId))) &&
-    Array.isArray(value.linkedAccounts) &&
-    value.linkedAccounts.every(isLinkedAuthAccount)
-  );
-}
-
-function isLinkedAuthAccount(value: unknown): value is LinkedAuthAccount {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const account = value as Partial<LinkedAuthAccount>;
-
-  return (
-    typeof account.accountId === "string" &&
-    typeof account.id === "string" &&
-    typeof account.providerId === "string" &&
-    typeof account.userId === "string"
-  );
 }

--- a/packages/pwa/src/routes/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/settings_.cloud-sync.tsx
@@ -1,6 +1,5 @@
 import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
-import { isValidDocumentId } from "@automerge/automerge-repo/slim";
 import { createFileRoute, useLocation, useNavigate, useRouter } from "@tanstack/react-router";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { AnimatePresence } from "motion/react";
@@ -8,15 +7,15 @@ import { toast } from "sonner";
 import { BackButton } from "#src/components/BackButton.js";
 import { CloudSyncAccountSettings } from "#src/components/CloudSyncAccountSettings.tsx";
 import {
-  AuthButtonIcon,
+  CloudSyncSignInForm,
+  type AuthPendingAction,
+} from "#src/components/CloudSyncSignInForm.tsx";
+import {
   AuthCallbackErrorDialog,
-  AuthErrorAlert,
   CloudActionConfirmationDialog,
-  CloudAuthLoadingState,
   CloudSyncSignInDialog,
   CloudSyncSwitchDialog,
   DeleteAccountDialog,
-  MagicLinkSentState,
   SignInSuccessOverlay,
   type CloudActionDialogType,
 } from "#src/components/CloudSyncDialogs.tsx";
@@ -33,28 +32,15 @@ import {
   requestPasswordResetEmail,
   signInWithSocialAuthAccount,
   type AuthSessionUser,
-  type LinkedAuthAccount,
   type SocialAuthProvider,
 } from "#src/lib/auth-client.ts";
-import {
-  clearCachedCloudUserSettings,
-  fetchCloudUserSettings,
-  getCloudUserSettingsInput,
-  saveCloudUserSettings,
-  writeCachedCloudUserSettings,
-  type CloudUserSettings,
-} from "#src/lib/cloudSyncSettings.ts";
+import { clearCachedCloudUserSettings } from "#src/lib/cloudSyncSettings.ts";
 import {
   clearCachedCloudAccountState,
-  hasLocalPartyListData,
   isEmailFieldErrorMessage,
   isPasswordFieldErrorMessage,
-  readCachedCloudAccountState,
-  writeCachedCloudAccountState,
 } from "#src/lib/cloudSyncRouteState.ts";
-import { Button } from "#src/ui/Button.tsx";
-import { Icon } from "#src/ui/Icon.tsx";
-import { AppTextField } from "#src/ui/fields/TextField.js";
+import { useCloudSyncAccountState } from "#src/hooks/useCloudSyncAccountState.ts";
 import { usePartyList } from "#src/hooks/usePartyList.js";
 import { Settings } from "#src/routes/settings.tsx";
 import { closeRouteState } from "#src/lib/navigationHistory.ts";
@@ -71,23 +57,12 @@ const SIGN_IN_SUCCESS_ANIMATION_MS = 1200;
 const SIGN_IN_SUCCESS_EXIT_ANIMATION_MS = 180;
 const DIALOG_EXIT_ANIMATION_MS = 180;
 const PASSWORD_SIGN_IN_ENABLE_DELAY_MS = 250;
-const CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS = 30_000;
 const DELETE_ACCOUNT_CONFIRMATION_TEXT = "delete account";
-const AUTH_SECONDARY_BUTTON_CLASS_NAME =
-  "h-9 text-sm font-medium text-accent-700 dark:text-accent-50";
 
 interface CloudSyncSearchParams {
   auth?: "success";
   error?: string;
 }
-
-type AuthPendingAction =
-  | "apple"
-  | "google"
-  | "magic-link"
-  | "password"
-  | "password-reset"
-  | "sign-out";
 
 function CloudSyncSettings() {
   const { partyList } = usePartyList();
@@ -111,28 +86,32 @@ function CloudSyncSettings() {
   const [isSignInSuccessVisible, setIsSignInSuccessVisible] = useState(auth === "success");
   const [magicLinkMessage, setMagicLinkMessage] = useState<string | null>(null);
   const [passwordResetMessage, setPasswordResetMessage] = useState<string | null>(null);
-  const [linkedAccounts, setLinkedAccounts] = useState<LinkedAuthAccount[]>([]);
-  const [cloudSettings, setCloudSettings] = useState<CloudUserSettings | null>(null);
   const [authPendingAction, setAuthPendingAction] = useState<AuthPendingAction | null>(null);
   const [isSignInDialogOpen, setIsSignInDialogOpen] = useState(true);
-  const [isCloudSyncSwitchOpen, setIsCloudSyncSwitchOpen] = useState(false);
   const [cloudActionDialog, setCloudActionDialog] = useState<CloudActionDialogType | null>(null);
   const [authCallbackDialogError, setAuthCallbackDialogError] = useState<string | null>(null);
   const [isDeleteAccountDialogOpen, setIsDeleteAccountDialogOpen] = useState(false);
   const [deleteAccountConfirmation, setDeleteAccountConfirmation] = useState("");
   const [deleteAccountError, setDeleteAccountError] = useState<string | null>(null);
   const [isDeleteAccountPending, setIsDeleteAccountPending] = useState(false);
-  const partyListRef = useRef(partyList);
   const isSignInSuccessVisibleRef = useRef(isSignInSuccessVisible);
-  const linkedProviderIds = new Set(linkedAccounts.map((account) => account.providerId));
   const isAuthPending = authPendingAction !== null;
-  const hasPasswordAccount = linkedProviderIds.has("credential");
   const canDeleteAccount =
     deleteAccountConfirmation.trim().toLowerCase() === DELETE_ACCOUNT_CONFIRMATION_TEXT;
-
-  useEffect(() => {
-    partyListRef.current = partyList;
-  }, [partyList]);
+  const {
+    activateCloudSyncOnDevice,
+    clearCloudSyncState,
+    hasPasswordAccount,
+    isCloudSyncSwitchOpen,
+    linkedProviderIds,
+    saveLinkedAccounts,
+    setIsCloudSyncSwitchOpen,
+  } = useCloudSyncAccountState({
+    isSignInSuccessVisibleRef,
+    onCloudDataActivated,
+    partyList,
+    userId,
+  });
 
   useEffect(() => {
     isSignInSuccessVisibleRef.current = isSignInSuccessVisible;
@@ -152,125 +131,9 @@ function CloudSyncSettings() {
 
   useEffect(() => {
     if (!userId) {
-      setLinkedAccounts([]);
-      setCloudSettings(null);
-      setIsCloudSyncSwitchOpen(false);
       setCloudActionDialog(null);
-      return;
     }
-
-    let isCancelled = false;
-    const currentUserId = userId;
-    const cachedAccountState = readCachedCloudAccountState(currentUserId);
-
-    if (cachedAccountState) {
-      setLinkedAccounts(cachedAccountState.linkedAccounts);
-      setCloudSettings(cachedAccountState.cloudSettings);
-    } else {
-      setLinkedAccounts([]);
-      setCloudSettings(null);
-    }
-
-    void loadAccountState({
-      showErrorToast: !cachedAccountState,
-      showStartToast: true,
-    });
-
-    const intervalId = window.setInterval(() => {
-      void loadAccountState({ showErrorToast: false, showStartToast: false });
-    }, CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS);
-
-    return () => {
-      isCancelled = true;
-      window.clearInterval(intervalId);
-    };
-
-    async function loadAccountState({
-      showErrorToast,
-      showStartToast,
-    }: {
-      showErrorToast: boolean;
-      showStartToast: boolean;
-    }) {
-      try {
-        const currentPartyList = partyListRef.current;
-        const [accounts, { settings }] = await Promise.all([
-          fetchLinkedAuthAccounts(),
-          fetchCloudUserSettings(),
-        ]);
-
-        if (isCancelled) {
-          return;
-        }
-
-        let activeSettings = settings;
-
-        if (!activeSettings) {
-          const { settings: savedSettings } = await saveCloudUserSettings(
-            getCloudUserSettingsInput(currentPartyList),
-          );
-
-          if (isCancelled) {
-            return;
-          }
-
-          activeSettings = savedSettings;
-          if (showStartToast) {
-            toast.success(t`trizum cloud started`);
-          }
-        }
-
-        setLinkedAccounts(accounts);
-        setCloudSettings(activeSettings);
-        writeCachedCloudUserSettings(currentUserId, activeSettings);
-        writeCachedCloudAccountState(currentUserId, {
-          cloudSettings: activeSettings,
-          linkedAccounts: accounts,
-        });
-
-        if (!activeSettings) {
-          return;
-        }
-
-        if (!isValidDocumentId(activeSettings.partyListDocumentId)) {
-          toast.error(t`trizum cloud data is invalid`);
-          return;
-        }
-
-        if (activeSettings.partyListDocumentId === currentPartyList.id) {
-          return;
-        }
-
-        if (hasLocalPartyListData(currentPartyList)) {
-          setIsCloudSyncSwitchOpen(true);
-          return;
-        }
-
-        localStorage.setItem("partyListId", activeSettings.partyListDocumentId);
-        setCloudSettings(activeSettings);
-        setIsCloudSyncSwitchOpen(false);
-        writeCachedCloudUserSettings(currentUserId, activeSettings);
-        writeCachedCloudAccountState(currentUserId, {
-          cloudSettings: activeSettings,
-          linkedAccounts: accounts,
-        });
-        toast.success(t`trizum cloud enabled on this device`);
-
-        if (isSignInSuccessVisibleRef.current) {
-          window.setTimeout(() => {
-            void navigate({ to: "/", replace: true });
-          }, SIGN_IN_SUCCESS_ANIMATION_MS + SIGN_IN_SUCCESS_EXIT_ANIMATION_MS);
-          return;
-        }
-
-        void navigate({ to: "/", replace: true });
-      } catch {
-        if (!isCancelled && showErrorToast) {
-          toast.error(t`Could not load trizum cloud state`);
-        }
-      }
-    }
-  }, [navigate, userId]);
+  }, [userId]);
 
   useEffect(() => {
     if (auth === "success") {
@@ -492,13 +355,7 @@ function CloudSyncSettings() {
       }
 
       const accounts = await fetchLinkedAuthAccounts();
-      setLinkedAccounts(accounts);
-      if (userId) {
-        writeCachedCloudAccountState(userId, {
-          cloudSettings,
-          linkedAccounts: accounts,
-        });
-      }
+      saveLinkedAccounts(accounts);
       toast.success(t`Sign-in method connected`);
     } catch {
       toast.error(t`Could not connect sign-in method`);
@@ -561,8 +418,7 @@ function CloudSyncSettings() {
     try {
       await authClient.signOut();
       clearNativeAuthToken();
-      setCloudSettings(null);
-      setLinkedAccounts([]);
+      clearCloudSyncState();
       await session.refetch();
       toast.success(t`Signed out`);
       void navigate({ to: "/settings", replace: true });
@@ -571,44 +427,6 @@ function CloudSyncSettings() {
     } finally {
       setAuthPendingAction(null);
     }
-  }
-
-  function activateCloudSyncOnDevice(settings: CloudUserSettings | null = cloudSettings) {
-    if (!settings) {
-      toast.message(t`trizum cloud is not set up yet`);
-      return;
-    }
-
-    if (!isValidDocumentId(settings.partyListDocumentId)) {
-      toast.error(t`trizum cloud data is invalid`);
-      return;
-    }
-
-    if (settings.partyListDocumentId === partyList.id) {
-      toast.message(t`This device is already using trizum cloud`);
-      return;
-    }
-
-    localStorage.setItem("partyListId", settings.partyListDocumentId);
-    setCloudSettings(settings);
-    setIsCloudSyncSwitchOpen(false);
-    if (userId) {
-      writeCachedCloudUserSettings(userId, settings);
-      writeCachedCloudAccountState(userId, {
-        cloudSettings: settings,
-        linkedAccounts,
-      });
-    }
-    toast.success(t`trizum cloud enabled on this device`);
-
-    if (isSignInSuccessVisible) {
-      window.setTimeout(() => {
-        void navigate({ to: "/", replace: true });
-      }, SIGN_IN_SUCCESS_ANIMATION_MS + SIGN_IN_SUCCESS_EXIT_ANIMATION_MS);
-      return;
-    }
-
-    void navigate({ to: "/", replace: true });
   }
 
   function openDeleteAccountDialog() {
@@ -633,9 +451,7 @@ function CloudSyncSettings() {
         clearCachedCloudUserSettings(userId);
         clearCachedCloudAccountState(userId);
       }
-      setCloudSettings(null);
-      setLinkedAccounts([]);
-      setIsCloudSyncSwitchOpen(false);
+      clearCloudSyncState();
       setIsDeleteAccountDialogOpen(false);
       setDeleteAccountConfirmation("");
       await session.refetch();
@@ -661,6 +477,17 @@ function CloudSyncSettings() {
     }, DIALOG_EXIT_ANIMATION_MS);
   }
 
+  function onCloudDataActivated(shouldDelay: boolean) {
+    if (shouldDelay) {
+      window.setTimeout(() => {
+        void navigate({ to: "/", replace: true });
+      }, SIGN_IN_SUCCESS_ANIMATION_MS + SIGN_IN_SUCCESS_EXIT_ANIMATION_MS);
+      return;
+    }
+
+    void navigate({ to: "/", replace: true });
+  }
+
   if (!user) {
     return (
       <div className="relative min-h-full">
@@ -673,201 +500,52 @@ function CloudSyncSettings() {
           onOpenChange={closeSignInDialog}
           showHeader={!magicLinkMessage && auth !== "success" && !isSignInSuccessVisible}
         >
-          {auth === "success" || isSignInSuccessVisible ? (
-            <CloudAuthLoadingState />
-          ) : isPasswordResetMode ? (
-            <form className="flex flex-col gap-4" onSubmit={onPasswordResetSubmit}>
-              {authError ? <AuthErrorAlert message={authError} /> : null}
-              <AppTextField
-                errorMessage={authEmailError ?? undefined}
-                isDisabled={isAuthPending}
-                isInvalid={Boolean(authEmailError)}
-                isRequired
-                label={t`Email`}
-                onChange={onAuthEmailChange}
-                type="email"
-                value={authEmail}
-              />
-              {passwordResetMessage ? (
-                <p className="text-sm text-accent-700 dark:text-accent-50">
-                  {passwordResetMessage}
-                </p>
-              ) : null}
-              <Button color="accent" isDisabled={isAuthPending} type="submit">
-                <span className="flex items-center gap-2">
-                  <AuthButtonIcon
-                    icon="lucide.mail"
-                    isPending={authPendingAction === "password-reset"}
-                  />
-                  <Trans>Send password link</Trans>
-                </span>
-              </Button>
-              <Button
-                color="transparent"
-                isDisabled={isAuthPending}
-                onPress={() => {
-                  setIsPasswordResetMode(false);
-                  clearAuthFeedback();
-                }}
-                type="button"
-              >
-                <Trans>Back to sign in</Trans>
-              </Button>
-            </form>
-          ) : magicLinkMessage ? (
-            <MagicLinkSentState
-              email={authEmail}
-              message={magicLinkMessage}
-              onTryAgain={() => {
-                clearAuthFeedback();
-                setIsPasswordLoginMode(false);
-              }}
-            />
-          ) : (
-            <>
-              <div className="flex flex-col gap-3">
-                <Button
-                  color="input-like"
-                  isDisabled={isAuthPending}
-                  onPress={() => {
-                    void onSocialSignIn("apple");
-                  }}
-                >
-                  <span className="flex items-center gap-2">
-                    <AuthButtonIcon icon="brand.apple" isPending={authPendingAction === "apple"} />
-                    <Trans>Continue with Apple</Trans>
-                  </span>
-                </Button>
-                <Button
-                  color="input-like"
-                  isDisabled={isAuthPending}
-                  onPress={() => {
-                    void onSocialSignIn("google");
-                  }}
-                >
-                  <span className="flex items-center gap-2">
-                    <AuthButtonIcon
-                      icon="brand.google"
-                      isPending={authPendingAction === "google"}
-                    />
-                    <Trans>Continue with Google</Trans>
-                  </span>
-                </Button>
-              </div>
-
-              <div className="flex items-center gap-3 text-xs font-medium uppercase text-accent-600 dark:text-accent-300">
-                <span className="h-px flex-1 bg-accent-200 dark:bg-accent-700" />
-                <Trans>or use email</Trans>
-                <span className="h-px flex-1 bg-accent-200 dark:bg-accent-700" />
-              </div>
-
-              {isPasswordLoginMode ? (
-                <form className="flex flex-col gap-4" onSubmit={onPasswordSignInSubmit}>
-                  {authError ? <AuthErrorAlert message={authError} /> : null}
-                  <AppTextField
-                    errorMessage={authEmailError ?? undefined}
-                    isDisabled={isAuthPending}
-                    isInvalid={Boolean(authEmailError)}
-                    isRequired
-                    label={t`Email`}
-                    onChange={onAuthEmailChange}
-                    type="email"
-                    value={authEmail}
-                  />
-                  <AppTextField
-                    errorMessage={authPasswordError ?? undefined}
-                    isDisabled={isAuthPending}
-                    isInvalid={Boolean(authPasswordError)}
-                    isRequired
-                    label={t`Password`}
-                    minLength={8}
-                    onChange={onAuthPasswordChange}
-                    type="password"
-                    value={authPassword}
-                  />
-                  <Button
-                    className="font-semibold"
-                    color="accent"
-                    isDisabled={isAuthPending || !isPasswordSignInEnabled}
-                    type="submit"
-                  >
-                    <span className="flex items-center gap-2">
-                      <AuthButtonIcon
-                        icon="lucide.log-in"
-                        isPending={authPendingAction === "password"}
-                      />
-                      <Trans>Sign in with password</Trans>
-                    </span>
-                  </Button>
-                  <Button
-                    color="input-like"
-                    isDisabled={isAuthPending}
-                    onPress={() => {
-                      setIsPasswordLoginMode(false);
-                      setIsPasswordSignInEnabled(true);
-                      clearAuthFeedback();
-                    }}
-                    type="button"
-                  >
-                    <span className="flex items-center gap-2">
-                      <Icon icon="lucide.mail" width={18} height={18} />
-                      <Trans>Sign in with magic link</Trans>
-                    </span>
-                  </Button>
-                  <Button
-                    className={AUTH_SECONDARY_BUTTON_CLASS_NAME}
-                    color="transparent"
-                    isDisabled={isAuthPending}
-                    onPress={() => {
-                      setIsPasswordResetMode(true);
-                      clearAuthFeedback();
-                    }}
-                    type="button"
-                  >
-                    <Trans>Forgot password?</Trans>
-                  </Button>
-                </form>
-              ) : (
-                <form className="flex flex-col gap-4" onSubmit={onMagicLinkSubmit}>
-                  {authError ? <AuthErrorAlert message={authError} /> : null}
-                  <AppTextField
-                    errorMessage={authEmailError ?? undefined}
-                    isDisabled={isAuthPending}
-                    isInvalid={Boolean(authEmailError)}
-                    isRequired
-                    label={t`Email`}
-                    onChange={onAuthEmailChange}
-                    type="email"
-                    value={authEmail}
-                  />
-                  <Button color="accent" isDisabled={isAuthPending} type="submit">
-                    <span className="flex items-center gap-2">
-                      <AuthButtonIcon
-                        icon="lucide.mail"
-                        isPending={authPendingAction === "magic-link"}
-                      />
-                      <Trans>Email me a sign-in link</Trans>
-                    </span>
-                  </Button>
-                  <Button
-                    color="input-like"
-                    isDisabled={isAuthPending}
-                    onPress={() => {
-                      setIsPasswordLoginMode(true);
-                      setIsPasswordSignInEnabled(false);
-                      clearAuthFeedback();
-                    }}
-                    type="button"
-                  >
-                    <span className="flex items-center gap-2">
-                      <Icon icon="lucide.key-round" width={18} height={18} />
-                      <Trans>Sign in with password</Trans>
-                    </span>
-                  </Button>
-                </form>
-              )}
-            </>
-          )}
+          <CloudSyncSignInForm
+            auth={auth}
+            authEmail={authEmail}
+            authEmailError={authEmailError}
+            authError={authError}
+            authPassword={authPassword}
+            authPasswordError={authPasswordError}
+            authPendingAction={authPendingAction}
+            isAuthPending={isAuthPending}
+            isPasswordLoginMode={isPasswordLoginMode}
+            isPasswordResetMode={isPasswordResetMode}
+            isPasswordSignInEnabled={isPasswordSignInEnabled}
+            isSignInSuccessVisible={isSignInSuccessVisible}
+            magicLinkMessage={magicLinkMessage}
+            onAuthEmailChange={onAuthEmailChange}
+            onAuthPasswordChange={onAuthPasswordChange}
+            onBackToSignIn={() => {
+              setIsPasswordResetMode(false);
+              clearAuthFeedback();
+            }}
+            onForgotPassword={() => {
+              setIsPasswordResetMode(true);
+              clearAuthFeedback();
+            }}
+            onMagicLinkSubmit={onMagicLinkSubmit}
+            onPasswordResetSubmit={onPasswordResetSubmit}
+            onPasswordSignInSubmit={onPasswordSignInSubmit}
+            onSocialSignIn={(provider) => {
+              void onSocialSignIn(provider);
+            }}
+            onTryAnotherEmail={() => {
+              clearAuthFeedback();
+              setIsPasswordLoginMode(false);
+            }}
+            onUseMagicLink={() => {
+              setIsPasswordLoginMode(false);
+              setIsPasswordSignInEnabled(true);
+              clearAuthFeedback();
+            }}
+            onUsePassword={() => {
+              setIsPasswordLoginMode(true);
+              setIsPasswordSignInEnabled(false);
+              clearAuthFeedback();
+            }}
+            passwordResetMessage={passwordResetMessage}
+          />
         </CloudSyncSignInDialog>
       </div>
     );


### PR DESCRIPTION
## Description

Decomposes the cloud sync settings route that was introduced in the reviewed range as a 1,933-line route module. The route is now 659 lines by moving route-local account settings UI, dialogs, sign-in form branches, cloud-account cache helpers, auth result parsing, and account polling/device activation state into focused modules.

This is intended to preserve behavior. First-login cloud settings creation remains in place because that is the intended product policy. The Lingui catalog changes are source-reference updates from moving translated JSX; translations are unchanged.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

No screenshots. This PR is a behavior-preserving route decomposition with no intended UI changes.

## Additional Notes

Validation also included `vp install` and `vp run check --fix`. The branch was merged with current `origin/main` after #209 added React Doctor CI, so the PR diff no longer appears to delete that workflow.

Review notes from the exhaustive pass:

- `settings_.cloud-sync.tsx` is now 659 lines, with sign-in rendering in `CloudSyncSignInForm` and account polling/device activation state in `useCloudSyncAccountState`.
- The large `packages/pwa/api/types.d.ts` update from the reviewed range is generated Cloudflare typing output and intentionally remains tracked as-is.
- Auto-creating cloud user settings on authenticated first load is intentional and remains unchanged.
