### PR TITLE
Add React Doctor CI

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,26 @@
+name: React Doctor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: millionco/react-doctor@v2


### PR DESCRIPTION
## Description

Adds the official React Doctor GitHub Actions workflow so pull requests run React Doctor and main pushes run the same check.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (describe below)

CI configuration.

## Checklist

- [ ] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [ ] I've run `vp run check`
- [ ] I've run `vp run test` and all tests pass
- [ ] I've run `vp run build`
- [ ] I've added tests for new functionality (if applicable)
- [ ] I've run `vp run lingui:extract` (if I added new strings)
- [ ] I've added a changeset (if this is a user-facing change)

## Screenshots

N/A

## Additional Notes

Validation: workflow content was compared against the requested YAML; no local suite was run for this workflow-only change.
