### PR TITLE
fix(pwa): restore deploy preview worker handler

### DIFF
--- a/.changeset/tidy-cloudflare-previews.md
+++ b/.changeset/tidy-cloudflare-previews.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Fix Cloudflare Worker deploy preview builds by preserving the Worker handler export and using the browser-safe `debug` entry during upload validation.

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -131,6 +131,15 @@ export default defineConfig(({ mode }) => {
       sourcemap: true,
       minify: true,
     },
+    resolve: {
+      alias: [
+        {
+          // Cloudflare Worker validation does not expose CommonJS require.
+          find: /^debug$/,
+          replacement: "debug/src/browser.js",
+        },
+      ],
+    },
     test: {
       exclude: [...configDefaults.exclude, "e2e/**"],
       include: ["api/**/*.test.ts", "src/**/*.test.ts"],

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { getConfig as getLinguiConfig } from "@lingui/conf";
 import type { Plugin } from "vite-plus";
-import { configDefaults, defineConfig } from "vite-plus";
+import { configDefaults, defineConfig, perEnvironmentPlugin } from "vite-plus";
 import react from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
@@ -146,7 +146,7 @@ export default defineConfig(({ mode }) => {
         presets: [reactCompilerPreset],
       }),
       wasm() as Plugin,
-      topLevelAwait(),
+      clientTopLevelAwaitPlugin(),
       lingui({
         cwd: packageRoot,
         configPath: linguiConfigPath,
@@ -274,6 +274,12 @@ function appendSourceMappingURLPlugin(): Plugin {
       }
     },
   };
+}
+
+function clientTopLevelAwaitPlugin(): Plugin {
+  return perEnvironmentPlugin("trizum-client-top-level-await", (environment) =>
+    environment.config.consumer === "client" ? topLevelAwait() : false,
+  );
 }
 
 function sentrySourcemapsPlugin(): Plugin {


### PR DESCRIPTION
## Description

Fixes the PWA Deploy Preview job for pull requests.

The first failure was caused by `vite-plugin-top-level-await` running in both the client and Cloudflare Worker environments. That rewrote the Worker entry into an async `__tla` export shape, so `wrangler versions upload` uploaded assets but Cloudflare rejected the Worker script as having no registered event handlers.

After restoring the direct Worker default export, Cloudflare validation reached the bundle and exposed a second issue: the Worker build resolved `debug` through its Node CommonJS entry, which calls `require("util")`. The Worker upload validation environment does not expose CommonJS `require`, so the build now aliases the bare `debug` package to its browser entry.

## Related Issues

Related to #212

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [ ] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable. This is a deployment build configuration fix with no UI changes.

## Additional Notes

Additional validation:
- `vp exec changeset status`
- `vp exec wrangler versions upload --dry-run --outdir .wrangler/dry-run-preview-fixed-2`
- Worker bundle inspection confirms `Calling \`require\``, `require("util")`, `debug/src/node`, and `__tla` are absent from `packages/pwa/dist/trizum/index.js`.

Changeset: `.changeset/tidy-cloudflare-previews.md`.
