### PR TITLE
fix(pwa): prevent party route indexing

### DIFF
--- a/.changeset/fresh-party-robots.md
+++ b/.changeset/fresh-party-robots.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Prevent crawlers from indexing party routes by sending a noindex robots header for `/party/*` responses.

--- a/packages/pwa/public/_headers
+++ b/packages/pwa/public/_headers
@@ -1,2 +1,5 @@
 /*
   Document-Policy: js-profiling
+
+/party/*
+  X-Robots-Tag: noindex, nofollow


### PR DESCRIPTION
## Description

Adds a Cloudflare `_headers` rule for `/party/*` routes so responses include `X-Robots-Tag: noindex, nofollow`. This tells crawlers that fetch shared party URLs not to index or follow those pages.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; no UI changes.

## Additional Notes

Added a patch changeset for `@trizum/pwa`. Because `@trizum/pwa` and `@trizum/mobile` are configured as a fixed Changesets group, `vp exec changeset status --since main` reports both packages for a patch bump.
