### PR TITLE
fix(pwa): skip inline party balance recalculation

### DIFF
--- a/.changeset/skip-party-inline-balance-recalc.md
+++ b/.changeset/skip-party-inline-balance-recalc.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Skip immediate party balance recalculation when adding, updating, or removing expenses.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -324,15 +324,15 @@ msgstr "Bahamian Dollar"
 msgid "Bahraini Dinar"
 msgstr "Bahraini Dinar"
 
-#: src/routes/party.$partyId/route.tsx:177
+#: src/routes/party.$partyId/route.tsx:186
 msgid "Balance, Highest First"
 msgstr "Balance, Highest First"
 
-#: src/routes/party.$partyId/route.tsx:161
+#: src/routes/party.$partyId/route.tsx:170
 msgid "Balance, Lowest First"
 msgstr "Balance, Lowest First"
 
-#: src/routes/party.$partyId/route.tsx:309
+#: src/routes/party.$partyId/route.tsx:318
 msgid "Balances"
 msgstr "Balances"
 
@@ -1018,7 +1018,7 @@ msgstr "Expense Split Mode"
 msgid "Expense updated"
 msgstr "Expense updated"
 
-#: src/routes/party.$partyId/route.tsx:303
+#: src/routes/party.$partyId/route.tsx:312
 msgid "Expenses"
 msgstr "Expenses"
 
@@ -1422,7 +1422,7 @@ msgstr "Last used"
 msgid "Last year"
 msgstr "Last year"
 
-#: src/routes/party.$partyId/route.tsx:287
+#: src/routes/party.$partyId/route.tsx:296
 msgid "Leave party"
 msgstr "Leave party"
 
@@ -1522,7 +1522,7 @@ msgstr "Me"
 #: src/components/ExpenseEditor.tsx:341
 #: src/routes/index/route.tsx:115
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:88
-#: src/routes/party.$partyId/route.tsx:191
+#: src/routes/party.$partyId/route.tsx:200
 msgid "Menu"
 msgstr "Menu"
 
@@ -1595,7 +1595,7 @@ msgstr "Myanma Kyat"
 
 #: src/routes/new/-components/NewPartyDetailsFields.tsx:32
 #: src/routes/party_.$partyId.settings/-components/PartySettingsDetailsFields.tsx:28
-#: src/routes/party.$partyId/route.tsx:145
+#: src/routes/party.$partyId/route.tsx:154
 msgid "Name"
 msgstr "Name"
 
@@ -1758,7 +1758,7 @@ msgstr "Older parties stay tucked away, not gone"
 msgid "Omani Rial"
 msgstr "Omani Rial"
 
-#: src/routes/party.$partyId/route.tsx:232
+#: src/routes/party.$partyId/route.tsx:241
 msgid "Only show your expenses"
 msgstr "Only show your expenses"
 
@@ -1981,7 +1981,7 @@ msgstr "People that owe you money"
 msgid "Permanently delete your trizum cloud account"
 msgstr "Permanently delete your trizum cloud account"
 
-#: src/routes/party.$partyId/route.tsx:228
+#: src/routes/party.$partyId/route.tsx:237
 msgid "Personal mode"
 msgstr "Personal mode"
 
@@ -2201,7 +2201,7 @@ msgstr "Search emoji..."
 msgid "Security"
 msgstr "Security"
 
-#: src/routes/party.$partyId/route.tsx:255
+#: src/routes/party.$partyId/route.tsx:264
 msgid "See spending totals and rankings"
 msgstr "See spending totals and rankings"
 
@@ -2238,7 +2238,7 @@ msgid "Set up your username, avatar, and preferences"
 msgstr "Set up your username, avatar, and preferences"
 
 #: src/routes/index/route.tsx:126
-#: src/routes/party.$partyId/route.tsx:280
+#: src/routes/party.$partyId/route.tsx:289
 #: src/routes/settings.tsx:263
 msgid "Settings"
 msgstr "Settings"
@@ -2257,7 +2257,7 @@ msgstr "Seychellois Rupee"
 
 #: src/routes/party_.$partyId.share.tsx:55
 #: src/routes/party_.$partyId.share.tsx:90
-#: src/routes/party.$partyId/route.tsx:268
+#: src/routes/party.$partyId/route.tsx:277
 msgid "Share party"
 msgstr "Share party"
 
@@ -2378,7 +2378,7 @@ msgstr "Somali Shilling"
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
-#: src/routes/party.$partyId/route.tsx:137
+#: src/routes/party.$partyId/route.tsx:146
 msgid "Sort balances"
 msgstr "Sort balances"
 
@@ -2423,7 +2423,7 @@ msgstr "Start date"
 msgid "Start tracking expenses with your group"
 msgstr "Start tracking expenses with your group"
 
-#: src/routes/party.$partyId/route.tsx:251
+#: src/routes/party.$partyId/route.tsx:260
 msgid "Stats"
 msgstr "Stats"
 
@@ -2534,7 +2534,7 @@ msgstr "Take photo"
 msgid "Tanzanian Shilling"
 msgstr "Tanzanian Shilling"
 
-#: src/routes/party.$partyId/route.tsx:214
+#: src/routes/party.$partyId/route.tsx:223
 msgid "Tap to change"
 msgstr "Tap to change"
 
@@ -2942,7 +2942,7 @@ msgstr "View Third-Party Licenses"
 msgid "Viewing as {0}"
 msgstr "Viewing as {0}"
 
-#: src/routes/party.$partyId/route.tsx:210
+#: src/routes/party.$partyId/route.tsx:219
 msgid "Viewing as {participantName}"
 msgstr "Viewing as {participantName}"
 
@@ -3023,7 +3023,7 @@ msgstr "You can add photos to your expenses for better tracking."
 msgid "You can only transfer debt from actions where you are the one who owes the money."
 msgstr "You can only transfer debt from actions where you are the one who owes the money."
 
-#: src/routes/party.$partyId/route.tsx:102
+#: src/routes/party.$partyId/route.tsx:111
 msgid "You left the party!"
 msgstr "You left the party!"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -312,15 +312,15 @@ msgstr "Dólar Bahameño"
 msgid "Bahraini Dinar"
 msgstr "Dinar Bareiní"
 
-#: src/routes/party.$partyId/route.tsx:177
+#: src/routes/party.$partyId/route.tsx:186
 msgid "Balance, Highest First"
 msgstr "Balance, Mayor Primero"
 
-#: src/routes/party.$partyId/route.tsx:161
+#: src/routes/party.$partyId/route.tsx:170
 msgid "Balance, Lowest First"
 msgstr "Balance, Menor Primero"
 
-#: src/routes/party.$partyId/route.tsx:309
+#: src/routes/party.$partyId/route.tsx:318
 msgid "Balances"
 msgstr "Balance"
 
@@ -978,7 +978,7 @@ msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revis
 msgid "Expense updated"
 msgstr "Gasto actualizado"
 
-#: src/routes/party.$partyId/route.tsx:303
+#: src/routes/party.$partyId/route.tsx:312
 msgid "Expenses"
 msgstr "Gastos"
 
@@ -1370,7 +1370,7 @@ msgstr "Último uso"
 msgid "Last year"
 msgstr "Año pasado"
 
-#: src/routes/party.$partyId/route.tsx:287
+#: src/routes/party.$partyId/route.tsx:296
 msgid "Leave party"
 msgstr "Dejar el grupo"
 
@@ -1470,7 +1470,7 @@ msgstr "Yo"
 #: src/components/ExpenseEditor.tsx:341
 #: src/routes/index/route.tsx:115
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:88
-#: src/routes/party.$partyId/route.tsx:191
+#: src/routes/party.$partyId/route.tsx:200
 msgid "Menu"
 msgstr "Menú"
 
@@ -1543,7 +1543,7 @@ msgstr "Kyat Birmano"
 
 #: src/routes/new/-components/NewPartyDetailsFields.tsx:32
 #: src/routes/party_.$partyId.settings/-components/PartySettingsDetailsFields.tsx:28
-#: src/routes/party.$partyId/route.tsx:145
+#: src/routes/party.$partyId/route.tsx:154
 msgid "Name"
 msgstr "Nombre"
 
@@ -1702,7 +1702,7 @@ msgstr "Los grupos antiguos quedan apartados, no desaparecen"
 msgid "Omani Rial"
 msgstr "Rial Omaní"
 
-#: src/routes/party.$partyId/route.tsx:232
+#: src/routes/party.$partyId/route.tsx:241
 msgid "Only show your expenses"
 msgstr "Mostrar solo tus gastos"
 
@@ -1913,7 +1913,7 @@ msgstr "Personas que te deben dinero"
 msgid "Permanently delete your trizum cloud account"
 msgstr "Eliminar permanentemente tu cuenta de trizum cloud"
 
-#: src/routes/party.$partyId/route.tsx:228
+#: src/routes/party.$partyId/route.tsx:237
 msgid "Personal mode"
 msgstr "Modo personal"
 
@@ -2129,7 +2129,7 @@ msgstr "Buscar emoji..."
 msgid "Security"
 msgstr "Seguridad"
 
-#: src/routes/party.$partyId/route.tsx:255
+#: src/routes/party.$partyId/route.tsx:264
 msgid "See spending totals and rankings"
 msgstr "Ver totales y clasificación de gasto"
 
@@ -2166,7 +2166,7 @@ msgid "Set up your username, avatar, and preferences"
 msgstr "Configura tu nombre de usuario, avatar y preferencias"
 
 #: src/routes/index/route.tsx:126
-#: src/routes/party.$partyId/route.tsx:280
+#: src/routes/party.$partyId/route.tsx:289
 #: src/routes/settings.tsx:263
 msgid "Settings"
 msgstr "Configuración"
@@ -2185,7 +2185,7 @@ msgstr "Rupia de Seychelles"
 
 #: src/routes/party_.$partyId.share.tsx:55
 #: src/routes/party_.$partyId.share.tsx:90
-#: src/routes/party.$partyId/route.tsx:268
+#: src/routes/party.$partyId/route.tsx:277
 msgid "Share party"
 msgstr "Compartir grupo"
 
@@ -2302,7 +2302,7 @@ msgstr "Chelín Somalí"
 msgid "Something went wrong"
 msgstr "Algo salió mal"
 
-#: src/routes/party.$partyId/route.tsx:137
+#: src/routes/party.$partyId/route.tsx:146
 msgid "Sort balances"
 msgstr "Ordenar balances"
 
@@ -2347,7 +2347,7 @@ msgstr "Fecha de inicio"
 msgid "Start tracking expenses with your group"
 msgstr "Comienza a registrar gastos con tu grupo"
 
-#: src/routes/party.$partyId/route.tsx:251
+#: src/routes/party.$partyId/route.tsx:260
 msgid "Stats"
 msgstr "Estadísticas"
 
@@ -2458,7 +2458,7 @@ msgstr "Hacer foto"
 msgid "Tanzanian Shilling"
 msgstr "Chelín Tanzano"
 
-#: src/routes/party.$partyId/route.tsx:214
+#: src/routes/party.$partyId/route.tsx:223
 msgid "Tap to change"
 msgstr "Toca para cambiar"
 
@@ -2845,7 +2845,7 @@ msgstr "Ver Licencias de Terceros"
 msgid "Viewing as {0}"
 msgstr "Viendo como {0}"
 
-#: src/routes/party.$partyId/route.tsx:210
+#: src/routes/party.$partyId/route.tsx:219
 msgid "Viewing as {participantName}"
 msgstr "Viendo como {participantName}"
 
@@ -2922,7 +2922,7 @@ msgstr "Puedes añadir fotos a tus gastos para un mejor seguimiento."
 msgid "You can only transfer debt from actions where you are the one who owes the money."
 msgstr "Solo puedes transferir deudas de acciones en las que tú eres quien debe el dinero."
 
-#: src/routes/party.$partyId/route.tsx:102
+#: src/routes/party.$partyId/route.tsx:111
 msgid "You left the party!"
 msgstr "¡Has dejado el grupo!"
 

--- a/packages/pwa/src/hooks/useParty.ts
+++ b/packages/pwa/src/hooks/useParty.ts
@@ -215,11 +215,6 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
     lastChunkHandle.change((doc) => {
       insertAt(doc.expenses, 0, expenseWithHash);
     });
-    lastChunk = lastChunkHandle.doc();
-
-    if (!lastChunk) {
-      throw new Error("Chunk not found, this should not happen");
-    }
 
     handle.change((party) => {
       let existingLastChunkRef = party.chunkRefs.find(
@@ -230,24 +225,6 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
         existingLastChunkRef = lastChunkRef;
         insertAt(party.chunkRefs, 0, existingLastChunkRef);
       }
-    });
-
-    const lastChunkBalancesHandle = await repo.find<PartyExpenseChunkBalances>(
-      lastChunkRef.balancesId,
-    );
-    const lastChunkBalances = lastChunkBalancesHandle.doc();
-
-    if (!lastChunkBalances) {
-      throw new Error("Chunk balances not found, this should not happen");
-    }
-
-    const balancesByParticipant = calculateBalancesByParticipant(
-      lastChunk.expenses,
-      party.participants,
-    );
-
-    lastChunkBalancesHandle.change((doc) => {
-      patchMutate(doc.balances, diff(clone(doc.balances), clone(balancesByParticipant)));
     });
 
     return expenseWithHash;
@@ -269,7 +246,7 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
     }
 
     const chunkHandle = await repo.find<PartyExpenseChunk>(chunkRef.chunkId);
-    let chunk = chunkHandle.doc();
+    const chunk = chunkHandle.doc();
 
     if (!chunk) {
       throw new Error("Chunk not found, this should not happen");
@@ -286,28 +263,6 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
 
       delete expenseEntry.__editCopy;
       delete expenseEntry.__editCopyLastUpdatedAt;
-    });
-
-    chunk = chunkHandle.doc();
-
-    if (!chunk) {
-      throw new Error("Chunk not found, this should not happen");
-    }
-
-    const lastChunkBalancesHandle = await repo.find<PartyExpenseChunkBalances>(chunkRef.balancesId);
-    const lastChunkBalances = lastChunkBalancesHandle.doc();
-
-    if (!lastChunkBalances) {
-      throw new Error("Chunk balances not found, this should not happen");
-    }
-
-    const balancesByParticipant = calculateBalancesByParticipant(
-      chunk.expenses,
-      party.participants,
-    );
-
-    lastChunkBalancesHandle.change((doc) => {
-      patchMutate(doc.balances, diff(clone(doc.balances), clone(balancesByParticipant)));
     });
   }
 
@@ -327,7 +282,7 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
     }
 
     const chunkHandle = await repo.find<PartyExpenseChunk>(chunkRef.chunkId);
-    let chunk = chunkHandle.doc();
+    const chunk = chunkHandle.doc();
 
     if (!chunk) {
       throw new Error("Chunk not found, this should not happen");
@@ -342,29 +297,6 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
 
       deleteAt(doc.expenses, expenseIndex);
     });
-
-    chunk = chunkHandle.doc();
-
-    if (!chunk) {
-      throw new Error("Chunk not found, this should not happen");
-    }
-
-    const lastChunkBalancesHandle = await repo.find<PartyExpenseChunkBalances>(chunkRef.balancesId);
-    const lastChunkBalances = lastChunkBalancesHandle.doc();
-
-    if (!lastChunkBalances) {
-      throw new Error("Chunk balances not found, this should not happen");
-    }
-
-    const balancesByParticipant = calculateBalancesByParticipant(
-      chunk.expenses,
-      party.participants,
-    );
-
-    lastChunkBalancesHandle.change((doc) => {
-      patchMutate(doc.balances, diff(clone(doc.balances), clone(balancesByParticipant)));
-    });
-    lastChunkBalancesHandle.doc();
 
     return true;
   }

--- a/packages/pwa/src/routes/party.$partyId/route.tsx
+++ b/packages/pwa/src/routes/party.$partyId/route.tsx
@@ -67,24 +67,33 @@ function PartyById() {
     });
   }
 
-  const didRecalculateBalances = useRef(false);
+  const lastRecalculatedBalancesPartyIdRef = useRef<string | null>(null);
   const { setLastOpenedPartyId } = usePartyList();
   const lastRecordedPartyIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (selectedTab !== "balances" || didRecalculateBalances.current) {
+    if (selectedTab !== "balances") {
+      lastRecalculatedBalancesPartyIdRef.current = null;
+      return;
+    }
+
+    if (lastRecalculatedBalancesPartyIdRef.current === partyId) {
       return;
     }
 
     const idleCallback = requestIdleCallback(() => {
-      didRecalculateBalances.current = true;
-      recalculateBalances().catch(() => null);
+      lastRecalculatedBalancesPartyIdRef.current = partyId;
+      recalculateBalances().catch(() => {
+        if (lastRecalculatedBalancesPartyIdRef.current === partyId) {
+          lastRecalculatedBalancesPartyIdRef.current = null;
+        }
+      });
     });
 
     return () => {
       cancelIdleCallback(idleCallback);
     };
-  }, [selectedTab, recalculateBalances]);
+  }, [partyId, selectedTab, recalculateBalances]);
 
   useEffect(() => {
     if (!partyId || lastRecordedPartyIdRef.current === partyId) {


### PR DESCRIPTION
## Description

Removes the immediate chunk balance recalculation from party expense add, update, and remove operations. These operations now only mutate the expense chunk, leaving balance updates to the balances-tab recalculation path.

The balances tab now tracks recalculation per opened party instead of once per route instance, so same-route navigation from one party's balances to another party's balances refreshes the correct balance documents.

This avoids the production failure path around in-place balance document updates while keeping balances fresh when users open the balances view.

## Related Issues

No linked issue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; no UI changes.

## Additional Notes

- A patch changeset is included for `@trizum/pwa`.
- Updated the branch with `origin/main`.
- Targeted E2E passed: `vp run --filter @trizum/pwa test:e2e -- e2e/debt-transfer.spec.ts`.
