### PR TITLE
fix(pwa): prevent negative expense editor amounts

### DIFF
--- a/.changeset/clean-expense-amounts.md
+++ b/.changeset/clean-expense-amounts.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Prevent expense editor amount fields from accepting or applying negative values.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -166,7 +166,7 @@ msgstr "Align QR code here"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:443
+#: src/components/ExpenseEditor.tsx:448
 msgid "Amount"
 msgstr "Amount"
 
@@ -174,11 +174,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:761
+#: src/components/ExpenseEditor.tsx:767
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:433
+#: src/components/ExpenseEditor.tsx:438
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -274,7 +274,7 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:350
+#: src/components/ExpenseEditor.tsx:355
 #: src/routes/settings.tsx:430
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -538,7 +538,7 @@ msgstr "Clear search"
 msgid "Close"
 msgstr "Close"
 
-#: src/components/CurrencyField.tsx:80
+#: src/components/CurrencyField.tsx:85
 msgid "Close calculator"
 msgstr "Close calculator"
 
@@ -789,7 +789,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:493
+#: src/components/ExpenseEditor.tsx:499
 msgid "Date"
 msgstr "Date"
 
@@ -1006,7 +1006,7 @@ msgstr "Exact"
 msgid "Expense added"
 msgstr "Expense added"
 
-#: src/components/ExpenseEditor.tsx:162
+#: src/components/ExpenseEditor.tsx:167
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
@@ -1027,7 +1027,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:972
+#: src/components/ExpenseEditor.tsx:979
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1072,7 +1072,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:947
+#: src/components/ExpenseEditor.tsx:954
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -1198,7 +1198,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:849
+#: src/components/ExpenseEditor.tsx:856
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -1287,7 +1287,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:537
+#: src/components/ExpenseEditor.tsx:543
 msgid "Include all"
 msgstr "Include all"
 
@@ -1519,7 +1519,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:341
+#: src/components/ExpenseEditor.tsx:346
 #: src/routes/index/route.tsx:115
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:88
 #: src/routes/party.$partyId/route.tsx:191
@@ -1770,11 +1770,11 @@ msgstr "Only your own debt can be transferred"
 msgid "Open archived parties"
 msgstr "Open archived parties"
 
-#: src/components/CurrencyField.tsx:80
+#: src/components/CurrencyField.tsx:85
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:353
+#: src/components/ExpenseEditor.tsx:358
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1819,7 +1819,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:468
+#: src/components/ExpenseEditor.tsx:474
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -2033,7 +2033,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:867
+#: src/components/ExpenseEditor.tsx:874
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -2110,7 +2110,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1068
+#: src/components/ExpenseEditor.tsx:1075
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2170,7 +2170,7 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:269
+#: src/components/ExpenseEditor.tsx:274
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:111
@@ -2273,7 +2273,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:723
+#: src/components/ExpenseEditor.tsx:729
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -2281,7 +2281,7 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:853
+#: src/components/ExpenseEditor.tsx:860
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
@@ -2435,7 +2435,7 @@ msgstr "Stop trizum cloud on this device"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:269
+#: src/components/ExpenseEditor.tsx:274
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:111
@@ -2482,11 +2482,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:747
+#: src/components/ExpenseEditor.tsx:753
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:748
+#: src/components/ExpenseEditor.tsx:754
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2525,8 +2525,8 @@ msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:992
-#: src/components/ExpenseEditor.tsx:1006
+#: src/components/ExpenseEditor.tsx:999
+#: src/components/ExpenseEditor.tsx:1013
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2625,7 +2625,7 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:409
+#: src/components/ExpenseEditor.tsx:414
 msgid "Title"
 msgstr "Title"
 
@@ -2824,14 +2824,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:892
+#: src/components/ExpenseEditor.tsx:899
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1001
-#: src/components/ExpenseEditor.tsx:1018
+#: src/components/ExpenseEditor.tsx:1008
+#: src/components/ExpenseEditor.tsx:1025
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2844,7 +2844,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:932
+#: src/components/ExpenseEditor.tsx:939
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2929,7 +2929,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1053
+#: src/components/ExpenseEditor.tsx:1060
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -158,7 +158,7 @@ msgstr "Alinea el código QR aquí"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:443
+#: src/components/ExpenseEditor.tsx:448
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -166,11 +166,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:761
+#: src/components/ExpenseEditor.tsx:767
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:433
+#: src/components/ExpenseEditor.tsx:438
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -262,7 +262,7 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:350
+#: src/components/ExpenseEditor.tsx:355
 #: src/routes/settings.tsx:430
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -514,7 +514,7 @@ msgstr "Borrar búsqueda"
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/components/CurrencyField.tsx:80
+#: src/components/CurrencyField.tsx:85
 msgid "Close calculator"
 msgstr "Cerrar calculadora"
 
@@ -761,7 +761,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:493
+#: src/components/ExpenseEditor.tsx:499
 msgid "Date"
 msgstr "Fecha"
 
@@ -970,7 +970,7 @@ msgstr "Por ahora todo está archivado. Puedes reabrir cualquier grupo desde la 
 msgid "Expense added"
 msgstr "Gasto añadido"
 
-#: src/components/ExpenseEditor.tsx:162
+#: src/components/ExpenseEditor.tsx:167
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
@@ -987,7 +987,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:972
+#: src/components/ExpenseEditor.tsx:979
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1028,7 +1028,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:947
+#: src/components/ExpenseEditor.tsx:954
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -1150,7 +1150,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:849
+#: src/components/ExpenseEditor.tsx:856
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -1239,7 +1239,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:537
+#: src/components/ExpenseEditor.tsx:543
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1467,7 +1467,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:341
+#: src/components/ExpenseEditor.tsx:346
 #: src/routes/index/route.tsx:115
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:88
 #: src/routes/party.$partyId/route.tsx:191
@@ -1714,11 +1714,11 @@ msgstr "Solo puedes transferir tus propias deudas"
 msgid "Open archived parties"
 msgstr "Abrir grupos archivados"
 
-#: src/components/CurrencyField.tsx:80
+#: src/components/CurrencyField.tsx:85
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:353
+#: src/components/ExpenseEditor.tsx:358
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1759,7 +1759,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:468
+#: src/components/ExpenseEditor.tsx:474
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -1965,7 +1965,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:867
+#: src/components/ExpenseEditor.tsx:874
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -2038,7 +2038,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1068
+#: src/components/ExpenseEditor.tsx:1075
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2098,7 +2098,7 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:269
+#: src/components/ExpenseEditor.tsx:274
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:111
@@ -2201,7 +2201,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:723
+#: src/components/ExpenseEditor.tsx:729
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -2209,7 +2209,7 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:853
+#: src/components/ExpenseEditor.tsx:860
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
@@ -2359,7 +2359,7 @@ msgstr "Detener trizum cloud en este dispositivo"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:269
+#: src/components/ExpenseEditor.tsx:274
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:111
@@ -2406,11 +2406,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:747
+#: src/components/ExpenseEditor.tsx:753
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:748
+#: src/components/ExpenseEditor.tsx:754
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2449,8 +2449,8 @@ msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:992
-#: src/components/ExpenseEditor.tsx:1006
+#: src/components/ExpenseEditor.tsx:999
+#: src/components/ExpenseEditor.tsx:1013
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2549,7 +2549,7 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:409
+#: src/components/ExpenseEditor.tsx:414
 msgid "Title"
 msgstr "Título"
 
@@ -2736,14 +2736,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:892
+#: src/components/ExpenseEditor.tsx:899
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1001
-#: src/components/ExpenseEditor.tsx:1018
+#: src/components/ExpenseEditor.tsx:1008
+#: src/components/ExpenseEditor.tsx:1025
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2751,7 +2751,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:932
+#: src/components/ExpenseEditor.tsx:939
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2832,7 +2832,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1053
+#: src/components/ExpenseEditor.tsx:1060
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/src/components/CurrencyField.tsx
+++ b/packages/pwa/src/components/CurrencyField.tsx
@@ -1,5 +1,6 @@
 import { t } from "@lingui/core/macro";
-import { AppCurrencyField } from "#src/ui/fields/TextField.js";
+import { AppCurrencyField } from "#src/ui/fields/AppCurrencyField.js";
+import { clampCurrencyFieldValue } from "#src/ui/fields/currencyFieldValues.js";
 import React, { use, useRef } from "react";
 import { CurrencyContext } from "./CurrencyContext";
 import { useCalculatorMode } from "#src/hooks/useCalculatorMode.ts";
@@ -48,11 +49,15 @@ function CurrencyFieldWithCalculator({
   ];
   const fieldContainerRef = useRef<HTMLDivElement>(null);
   const [state, actions] = useCalculatorMode({
-    value: props.value ?? 0,
-    onChange: (value) => props.onChange?.(value),
+    value: clampCurrencyFieldValue(props.value ?? 0, props.minValue),
+    onChange: (value) => props.onChange?.(clampCurrencyFieldValue(value, props.minValue)),
     fieldContainerRef,
     currency: props.currency,
   });
+  const previewValue =
+    state.previewValue === null
+      ? null
+      : clampCurrencyFieldValue(state.previewValue, props.minValue);
 
   function handleFocus(event: React.FocusEvent<HTMLInputElement>) {
     props.onFocus?.(event);
@@ -97,7 +102,7 @@ function CurrencyFieldWithCalculator({
           onDismiss={actions.deactivate}
           fieldContainerRef={fieldContainerRef}
           presenceElementId={presenceElementId}
-          previewValue={state.previewValue}
+          previewValue={previewValue}
           currency={props.currency}
         />
       )}

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -45,6 +45,11 @@ import {
 import { getLogger } from "#src/lib/log.ts";
 import { MediaGalleryContext } from "./MediaGalleryContext";
 import type { AppFormApi } from "#src/lib/reactFormTypes.ts";
+import {
+  convertExpenseEditorAmountToUnits,
+  expenseEditorAmountMinValue,
+  normalizeExpenseEditorAmount,
+} from "#src/lib/expenseEditorAmounts.ts";
 
 export interface ExpenseEditorFormValues {
   name: string;
@@ -443,12 +448,13 @@ function ExpenseDetailsFields({
             label={t`Amount`}
             value={field.state.value}
             onChange={(value) => {
-              field.handleChange(value || 0);
+              field.handleChange(normalizeExpenseEditorAmount(value));
             }}
             onBlur={createFieldFocusHandlers(field).onBlur}
             errorMessage={field.state.meta.errors?.join(", ")}
             isInvalid={field.state.meta.isTouched && field.state.meta.errors?.length > 0}
             className="col-span-2"
+            minValue={expenseEditorAmountMinValue}
             onFocus={(event) => {
               const input = event.target as HTMLInputElement;
               input.select();
@@ -660,7 +666,7 @@ function ParticipantItem({
     };
     newShares[participant.id] = {
       type: "exact",
-      value: convertToUnits(value || 0),
+      value: convertExpenseEditorAmountToUnits(value),
     };
     updateShares(newShares);
   }
@@ -791,10 +797,11 @@ function ParticipantSplitAmountField({
       calculator
       autoOpenCalculator={autoOpenCalculator}
       calculatorButtonClassName="absolute bottom-0.5 -left-8 h-6 w-6"
-      value={participantAmount / 100}
+      value={normalizeExpenseEditorAmount(participantAmount / 100)}
       onChange={onChange}
       className="w-20"
       inputClassName="h-7 px-0 text-right border-t-0 border-x-0 rounded-none border-b"
+      minValue={expenseEditorAmountMinValue}
       onFocus={(event) => {
         // Select all text
         const input = event.target as HTMLInputElement;
@@ -810,7 +817,7 @@ function calculateParticipantUnitAmounts(
   amount: number,
   shares: Record<ExpenseUser, { type: "divide" | "exact"; value: number }>,
 ) {
-  const amountInUnits = convertToUnits(amount);
+  const amountInUnits = convertExpenseEditorAmountToUnits(amount);
 
   return getExpenseUnitShares({
     shares,
@@ -833,7 +840,7 @@ function SharesWarning({ amount, shares }: SharesWarningProps) {
 
   const unitAmounts = calculateParticipantUnitAmounts(amount, shares);
   const totalUnitAmount = Object.values(unitAmounts).reduce((sum, amount) => sum + amount, 0);
-  const showWarning = totalUnitAmount - convertToUnits(amount) !== 0;
+  const showWarning = totalUnitAmount - convertExpenseEditorAmountToUnits(amount) !== 0;
   const currency = party.currency;
   const totalAmount = totalUnitAmount / 100;
   const expenseAmount = amount;

--- a/packages/pwa/src/lib/expenseEditorAmounts.test.ts
+++ b/packages/pwa/src/lib/expenseEditorAmounts.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vite-plus/test";
+import {
+  convertExpenseEditorAmountToUnits,
+  normalizeExpenseEditorAmount,
+} from "./expenseEditorAmounts";
+
+describe("normalizeExpenseEditorAmount", () => {
+  test("preserves positive amount field values", () => {
+    expect(normalizeExpenseEditorAmount(12.34)).toBe(12.34);
+  });
+
+  test("normalizes negative amount field values to zero", () => {
+    expect(normalizeExpenseEditorAmount(-12.34)).toBe(0);
+  });
+
+  test("normalizes non-finite amount field values to zero", () => {
+    expect(normalizeExpenseEditorAmount(Number.NaN)).toBe(0);
+  });
+});
+
+describe("convertExpenseEditorAmountToUnits", () => {
+  test("converts positive amounts to currency units", () => {
+    expect(convertExpenseEditorAmountToUnits(12.34)).toBe(1234);
+  });
+
+  test("never converts negative amounts to negative units", () => {
+    expect(convertExpenseEditorAmountToUnits(-12.34)).toBe(0);
+  });
+});

--- a/packages/pwa/src/lib/expenseEditorAmounts.ts
+++ b/packages/pwa/src/lib/expenseEditorAmounts.ts
@@ -1,0 +1,15 @@
+import { convertToUnits } from "#src/lib/expenses.js";
+
+export const expenseEditorAmountMinValue = 0;
+
+export function normalizeExpenseEditorAmount(value: number) {
+  if (!Number.isFinite(value)) {
+    return expenseEditorAmountMinValue;
+  }
+
+  return Math.max(value, expenseEditorAmountMinValue);
+}
+
+export function convertExpenseEditorAmountToUnits(value: number) {
+  return convertToUnits(normalizeExpenseEditorAmount(value));
+}

--- a/packages/pwa/src/ui/fields/AppCurrencyField.test.ts
+++ b/packages/pwa/src/ui/fields/AppCurrencyField.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vite-plus/test";
+import { clampCurrencyFieldValue, sanitizeCurrencyFieldInput } from "./currencyFieldValues";
+
+describe("sanitizeCurrencyFieldInput", () => {
+  test("strips minus signs from typed currency values", () => {
+    expect(sanitizeCurrencyFieldInput("-12.34", 2)).toBe("12.34");
+  });
+
+  test("normalizes comma decimals and limits precision", () => {
+    expect(sanitizeCurrencyFieldInput("12,345", 2)).toBe("12.34");
+  });
+
+  test("removes non-numeric characters", () => {
+    expect(sanitizeCurrencyFieldInput("$1a2b.30", 2)).toBe("12.30");
+  });
+});
+
+describe("clampCurrencyFieldValue", () => {
+  test("keeps values above the minimum", () => {
+    expect(clampCurrencyFieldValue(12.34, 0)).toBe(12.34);
+  });
+
+  test("clamps values below the minimum", () => {
+    expect(clampCurrencyFieldValue(-12.34, 0)).toBe(0);
+  });
+
+  test("keeps negative values when no minimum is provided", () => {
+    expect(clampCurrencyFieldValue(-12.34, undefined)).toBe(-12.34);
+  });
+});

--- a/packages/pwa/src/ui/fields/AppCurrencyField.tsx
+++ b/packages/pwa/src/ui/fields/AppCurrencyField.tsx
@@ -8,6 +8,7 @@ import {
 import { cn, type ClassName } from "../utils";
 import { FieldError, Label } from "./Field";
 import { getCurrencyDecimalPrecision } from "./currencyPrecision.js";
+import { clampCurrencyFieldValue, sanitizeCurrencyFieldInput } from "./currencyFieldValues.js";
 import { Input, TextField } from "./TextFieldPrimitives.js";
 
 interface AppCurrencyFieldProps extends Omit<AriaTextFieldProps, "value" | "onChange"> {
@@ -18,6 +19,21 @@ interface AppCurrencyFieldProps extends Omit<AriaTextFieldProps, "value" | "onCh
   onChange?: (value: number) => void;
   inputClassName?: ClassName;
   currency?: string;
+  minValue?: number;
+}
+
+function getSanitizedSelectionPosition(
+  value: string,
+  selectionPosition: number,
+  decimalPrecision: number,
+) {
+  const sanitizedValue = sanitizeCurrencyFieldInput(value, decimalPrecision);
+  const sanitizedPrefix = sanitizeCurrencyFieldInput(
+    value.substring(0, selectionPosition),
+    decimalPrecision,
+  );
+
+  return Math.min(sanitizedPrefix.length, sanitizedValue.length);
 }
 
 export function AppCurrencyField({
@@ -29,14 +45,18 @@ export function AppCurrencyField({
   onChange,
   inputClassName,
   currency,
+  minValue,
   ...props
 }: AppCurrencyFieldProps) {
-  const [internalValue, setInternalValue] = React.useState(() => value?.toString() || "");
+  const [internalValue, setInternalValue] = React.useState(() =>
+    value === undefined ? "" : clampCurrencyFieldValue(value, minValue).toString(),
+  );
 
   const parsedInternalValue = parseFloat(internalValue || "0");
-  const parsedValue = parseFloat(value?.toString() || "0");
+  const parsedValue =
+    value === undefined ? parsedInternalValue : clampCurrencyFieldValue(value, minValue);
 
-  if (parsedInternalValue !== parsedValue) {
+  if (value !== undefined && parsedInternalValue !== parsedValue) {
     setInternalValue(parsedValue.toString());
   }
 
@@ -52,51 +72,32 @@ export function AppCurrencyField({
         const initialValue = event.currentTarget.value;
         const selectionStart = event.currentTarget.selectionStart || 0;
         const selectionEnd = event.currentTarget.selectionEnd || 0;
+        const sanitizedValue = sanitizeCurrencyFieldInput(initialValue, decimalPrecision);
 
-        let newValue = initialValue.replace(/,/g, ".");
-        newValue = newValue.replace(/[^0-9.]/g, "");
-
-        const lastDotIndex = newValue.lastIndexOf(".");
-        let withoutDots = "";
-        let removedBeforeCursor = 0;
-
-        for (let i = 0; i < newValue.length; i++) {
-          if (newValue[i] === ".") {
-            if (i === lastDotIndex) {
-              withoutDots += ".";
-            } else if (i < selectionStart) {
-              removedBeforeCursor++;
-            }
-          } else {
-            withoutDots += newValue[i];
-          }
-        }
-
-        if (lastDotIndex !== -1) {
-          const decimalPart = withoutDots.substring(lastDotIndex + 1);
-          if (decimalPart.length > decimalPrecision) {
-            withoutDots = withoutDots.substring(0, lastDotIndex + 1 + decimalPrecision);
-          }
-        }
-
-        event.currentTarget.value = withoutDots;
-
-        const newSelectionStart = Math.max(0, selectionStart - removedBeforeCursor);
-        const newSelectionEnd = Math.max(0, selectionEnd - removedBeforeCursor);
-
-        event.currentTarget.selectionStart = Math.min(newSelectionStart, withoutDots.length);
-        event.currentTarget.selectionEnd = Math.min(newSelectionEnd, withoutDots.length);
+        event.currentTarget.value = sanitizedValue;
+        event.currentTarget.selectionStart = getSanitizedSelectionPosition(
+          initialValue,
+          selectionStart,
+          decimalPrecision,
+        );
+        event.currentTarget.selectionEnd = getSanitizedSelectionPosition(
+          initialValue,
+          selectionEnd,
+          decimalPrecision,
+        );
       }}
       onChange={(value) => {
-        setInternalValue(value);
+        const sanitizedValue = sanitizeCurrencyFieldInput(value, decimalPrecision);
 
-        const trimmedValue = value.trim();
+        setInternalValue(sanitizedValue);
+
+        const trimmedValue = sanitizedValue.trim();
         if (trimmedValue === "" || trimmedValue === ".") {
-          onChange?.(0);
+          onChange?.(clampCurrencyFieldValue(0, minValue));
         } else {
           const parsed = parseFloat(trimmedValue);
           if (!isNaN(parsed)) {
-            onChange?.(parsed);
+            onChange?.(clampCurrencyFieldValue(parsed, minValue));
           }
         }
       }}

--- a/packages/pwa/src/ui/fields/currencyFieldValues.ts
+++ b/packages/pwa/src/ui/fields/currencyFieldValues.ts
@@ -1,0 +1,34 @@
+export function clampCurrencyFieldValue(value: number, minValue: number | undefined) {
+  if (!Number.isFinite(value)) {
+    return minValue ?? 0;
+  }
+
+  return minValue === undefined ? value : Math.max(value, minValue);
+}
+
+export function sanitizeCurrencyFieldInput(value: string, decimalPrecision: number) {
+  const normalizedValue = value.replace(/,/g, ".");
+  const numericValue = normalizedValue.replace(/[^0-9.]/g, "");
+  const lastDotIndex = numericValue.lastIndexOf(".");
+  let sanitizedValue = "";
+
+  for (let index = 0; index < numericValue.length; index++) {
+    const character = numericValue[index];
+
+    if (character !== "." || index === lastDotIndex) {
+      sanitizedValue += character;
+    }
+  }
+
+  const decimalSeparatorIndex = sanitizedValue.lastIndexOf(".");
+
+  if (decimalSeparatorIndex !== -1) {
+    const decimalPart = sanitizedValue.substring(decimalSeparatorIndex + 1);
+
+    if (decimalPart.length > decimalPrecision) {
+      sanitizedValue = sanitizedValue.substring(0, decimalSeparatorIndex + 1 + decimalPrecision);
+    }
+  }
+
+  return sanitizedValue;
+}


### PR DESCRIPTION
## Description

Prevent expense editor amount fields from accepting or applying negative values.

- Sanitizes currency text input consistently in `onInput` and `onChange`, so typed or pasted minus signs cannot produce negative field values.
- Adds opt-in minimum value support to currency fields and applies a zero minimum to the expense editor total amount and participant exact amount fields.
- Clamps calculator-applied values and previews for those non-negative expense amount fields.
- Adds focused tests for currency input sanitization and expense editor amount normalization.
- Includes a patch changeset for `@trizum/pwa`.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not included; this is input behavior without a visual design change.

## Additional Notes

- `vp run lingui:extract` updated existing catalog source references only; no new user-facing strings were added.
- `vp exec react-doctor --verbose --scope changed` reported no changed-scope issues. The remote score API was unreachable, so no numeric score was available.
