### PR TITLE
fix(ci): allow react doctor PR comments

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 concurrency:
   group: react-doctor-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Description

Adds `pull-requests: write` to the React Doctor workflow permissions so the PR summary comment step can read, create, and update the workflow-owned pull request comment.

The failing job in PR #216 had a clean React Doctor scan, but the follow-up comment step failed with `Resource not accessible by integration (HTTP 403)`.

## Related Issues

Related to #216

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; no UI changes.

## Additional Notes

No changeset is included because this is an internal CI workflow fix.
