### PR TITLE
fix(tooling): allow Renovate app lockfile repairs

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -67,11 +67,15 @@ jobs:
               --jq '.author.login'
           )"
 
-          if [ "$author" != "renovate[bot]" ] && [ "$author" != "renovate-bot" ] && [ "$author" != "renovate" ]; then
-            echo "PR #${pr_number} author is ${author}, not Renovate; skipping lockfile refresh."
-            echo "should_fix=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          case "$author" in
+            app/renovate | renovate | renovate-bot | "renovate[bot]")
+              ;;
+            *)
+              echo "PR #${pr_number} author is ${author}, not Renovate; skipping lockfile refresh."
+              echo "should_fix=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
 
           if ! gh pr view "$pr_number" --repo "$REPOSITORY" --json files --jq '.files[].path' | grep -Fxq "pnpm-lock.yaml"; then
             echo "PR #${pr_number} does not change pnpm-lock.yaml; skipping lockfile refresh."

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -15,7 +15,7 @@ The workflow only proceeds when:
 
 - the pushed branch matches `renovate/**`,
 - an open pull request exists for that branch,
-- the pull request author is Renovate,
+- the pull request author is Renovate, including the `app/renovate` GitHub App,
 - and the pull request changes `pnpm-lock.yaml`.
 
 When those checks pass, the workflow runs:


### PR DESCRIPTION
## Description

Fix the Renovate lockfile repair workflow so it accepts Renovate PRs authored by the GitHub App identity `app/renovate`.

The failed run for PR #220 skipped before running `vp install --lockfile-only` because the workflow only allowed `renovate[bot]`, `renovate-bot`, and `renovate`. GitHub reported that PR's author as `app/renovate`, so this changes the author gate to allow that observed Renovate identity while continuing to reject non-Renovate authors.

## Related Issues

Related to #220
Related to #225

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable; shell-case simulation used for the workflow gate)
- [x] I've run `vp run lingui:extract` (if I added new strings; also run by commit hook)
- [x] I've added a changeset (if this is a user-facing change; not applicable)

## Screenshots

Not applicable; no UI changes.

## Additional Notes

Observed failure: https://github.com/HorusGoul/trizum/actions/runs/28327881427/job/83920904813?pr=220

Additional validation:

- Ruby YAML parse for `.github/workflows/renovate-lockfile.yml`
- Shell `case` simulation confirmed `app/renovate` and `renovate[bot]` are allowed while another author is denied
