### PR TITLE
fix(tooling): adapt Renovate lockfile workflow

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -1,114 +1,72 @@
-name: Fix Renovate Lockfile
+name: Renovate Lockfiles
+
+# Renovate does not use Vite+ to refresh pnpm-lock.yaml. Instead, Renovate
+# updates manifests and this workflow regenerates the lockfile on every
+# Renovate branch push. Renovate ignores this workflow's lockfile commits via
+# gitIgnoredAuthors in renovate.json.
+
+permissions: {}
 
 on:
   push:
     branches:
-      - "renovate/**"
-    paths:
-      - "pnpm-lock.yaml"
+      - renovate/**
 
-permissions:
-  contents: write
-  pull-requests: read
-
+# Queue instead of cancel so a newer Renovate branch push does not stop an
+# in-flight lockfile refresh while it may be about to commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  refresh-lockfile:
-    name: Refresh Lockfile
+  update-lockfile:
+    name: Update Lockfile
+    if: github.event.repository.fork == false && github.event.head_commit.author.email != 'renovate-lockfile@trizum.app'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
           fetch-depth: 0
-          token: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
-
-      - name: Detect Renovate PR
-        id: renovate-pr
-        env:
-          BRANCH_NAME: ${{ github.ref_name }}
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-
-          pr_number=""
-          for attempt in 1 2 3 4 5 6; do
-            pr_number="$(
-              gh api \
-                -X GET "repos/${REPOSITORY}/pulls" \
-                -f state=open \
-                -f head="${REPOSITORY_OWNER}:${BRANCH_NAME}" \
-                --jq '.[0].number // empty'
-            )"
-
-            if [ -n "$pr_number" ]; then
-              break
-            fi
-
-            sleep 10
-          done
-
-          if [ -z "$pr_number" ]; then
-            echo "No open PR found for ${BRANCH_NAME}; skipping lockfile refresh."
-            echo "should_fix=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          author="$(
-            gh pr view "$pr_number" \
-              --repo "$REPOSITORY" \
-              --json author \
-              --jq '.author.login'
-          )"
-
-          case "$author" in
-            app/renovate | renovate | renovate-bot | "renovate[bot]")
-              ;;
-            *)
-              echo "PR #${pr_number} author is ${author}, not Renovate; skipping lockfile refresh."
-              echo "should_fix=false" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
-
-          if ! gh pr view "$pr_number" --repo "$REPOSITORY" --json files --jq '.files[].path' | grep -Fxq "pnpm-lock.yaml"; then
-            echo "PR #${pr_number} does not change pnpm-lock.yaml; skipping lockfile refresh."
-            echo "should_fix=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Renovate PR #${pr_number} changes pnpm-lock.yaml; refreshing with Vite+."
-          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
-          echo "should_fix=true" >> "$GITHUB_OUTPUT"
+          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@v1
-        if: steps.renovate-pr.outputs.should_fix == 'true'
         with:
           node-version-file: ".node-version"
           cache: true
 
-      - name: Refresh pnpm lockfile
-        if: steps.renovate-pr.outputs.should_fix == 'true'
-        run: vp install --lockfile-only
+      - name: Update pnpm lockfile
+        env:
+          # Resolution does not need lifecycle scripts; keep dependency scripts
+          # from running in a workflow that later pushes with a write token.
+          npm_config_ignore_scripts: "true"
+        run: |
+          vp install --lockfile-only --no-frozen-lockfile --ignore-scripts
+
+      - name: Detect lockfile changes
+        id: diff
+        run: |
+          git diff --stat -- pnpm-lock.yaml
+          if git diff --quiet -- pnpm-lock.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit lockfile refresh
-        if: steps.renovate-pr.outputs.should_fix == 'true'
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          BRANCH: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          if git diff --quiet -- pnpm-lock.yaml; then
-            echo "pnpm-lock.yaml is already up to date."
-            exit 0
-          fi
-
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
+          # Identity must stay in sync with gitIgnoredAuthors in renovate.json
+          # so Renovate keeps managing the branch.
+          git config user.name "trizum-renovate-lockfile[bot]"
+          git config user.email "renovate-lockfile@trizum.app"
           git add pnpm-lock.yaml
-          git commit --signoff -m "chore(deps): refresh pnpm lockfile with Vite+"
-          git push
+          git commit -m "chore(deps): refresh pnpm lockfile with Vite+"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${BRANCH}"

--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   update-lockfile:
     name: Update Lockfile
-    if: github.event.repository.fork == false && github.event.head_commit.author.email != 'renovate-lockfile@trizum.app'
+    if: github.event.repository.fork == false && github.event.head_commit.author.email != 'trizum-agent@trizum.app'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,8 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
-          persist-credentials: false
 
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -57,16 +57,13 @@ jobs:
 
       - name: Commit lockfile refresh
         if: steps.diff.outputs.changed == 'true'
-        env:
-          BRANCH: ${{ github.ref_name }}
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           # Identity must stay in sync with gitIgnoredAuthors in renovate.json
           # so Renovate keeps managing the branch.
-          git config user.name "trizum-renovate-lockfile[bot]"
-          git config user.email "renovate-lockfile@trizum.app"
+          git config user.name "trizum-agent[bot]"
+          git config user.email "trizum-agent@trizum.app"
           git add pnpm-lock.yaml
           git commit -m "chore(deps): refresh pnpm lockfile with Vite+"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${BRANCH}"
+          git push

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -16,7 +16,7 @@ The workflow:
 
 - queues runs instead of canceling in progress so a newer Renovate branch push
   does not stop an in-flight lockfile refresh while it may be about to commit,
-- skips commits authored by `renovate-lockfile@trizum.app`,
+- skips commits authored by `trizum-agent@trizum.app`,
 - runs:
 
 ```sh
@@ -25,8 +25,8 @@ vp install --lockfile-only --no-frozen-lockfile --ignore-scripts
 
 - and pushes `pnpm-lock.yaml` back to the same Renovate branch when it changes.
 
-The workflow uses the built-in `GITHUB_TOKEN` with job-scoped `contents: write`
-permission for the follow-up push.
+The workflow uses the built-in `GITHUB_TOKEN` through `actions/checkout` with
+job-scoped `contents: write` permission for the follow-up push.
 
-`renovate.json` lists `renovate-lockfile@trizum.app` in `gitIgnoredAuthors` so
+`renovate.json` lists `trizum-agent@trizum.app` in `gitIgnoredAuthors` so
 Renovate keeps managing branches after the workflow adds its lockfile commit.

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -6,23 +6,27 @@ as local development and CI.
 
 ## Vite+ Lockfile Updates
 
-Renovate's built-in artifact update still creates the initial dependency branch.
-After Renovate pushes a `renovate/**` branch that changes `pnpm-lock.yaml`, the
-[`Fix Renovate Lockfile`](../.github/workflows/renovate-lockfile.yml) workflow
-checks the associated pull request.
+Renovate's native npm artifact updates are disabled because they do not refresh
+`pnpm-lock.yaml` through Vite+. Renovate still creates the initial dependency
+branch, and the
+[`Renovate Lockfiles`](../.github/workflows/renovate-lockfile.yml) workflow
+regenerates the lockfile on every `renovate/**` branch push.
 
-The workflow only proceeds when:
+The workflow:
 
-- the pushed branch matches `renovate/**`,
-- an open pull request exists for that branch,
-- the pull request author is Renovate, including the `app/renovate` GitHub App,
-- and the pull request changes `pnpm-lock.yaml`.
-
-When those checks pass, the workflow runs:
+- queues runs instead of canceling in progress so a newer Renovate branch push
+  does not stop an in-flight lockfile refresh while it may be about to commit,
+- skips commits authored by `renovate-lockfile@trizum.app`,
+- runs:
 
 ```sh
-vp install --lockfile-only
+vp install --lockfile-only --no-frozen-lockfile --ignore-scripts
 ```
 
-If the Vite+ refresh changes `pnpm-lock.yaml`, the workflow commits and pushes a
-follow-up commit to the same Renovate branch.
+- and pushes `pnpm-lock.yaml` back to the same Renovate branch when it changes.
+
+The workflow uses the built-in `GITHUB_TOKEN` with job-scoped `contents: write`
+permission for the follow-up push.
+
+`renovate.json` lists `renovate-lockfile@trizum.app` in `gitIgnoredAuthors` so
+Renovate keeps managing branches after the workflow adds its lockfile commit.

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "gitIgnoredAuthors": ["renovate-lockfile@trizum.app"],
+  "gitIgnoredAuthors": ["trizum-agent@trizum.app"],
   "packageRules": [
     {
       "description": "Skip Renovate's native npm lockfile artifact updates; the Renovate Lockfiles workflow refreshes pnpm-lock.yaml with Vite+.",

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "gitIgnoredAuthors": ["renovate-lockfile@trizum.app"],
   "packageRules": [
+    {
+      "description": "Skip Renovate's native npm lockfile artifact updates; the Renovate Lockfiles workflow refreshes pnpm-lock.yaml with Vite+.",
+      "matchManagers": ["npm"],
+      "skipArtifactsUpdate": true
+    },
     {
       "description": "Keep non-major PWA runtime dependency updates together.",
       "matchManagers": ["npm"],


### PR DESCRIPTION
## Description

Adapts the Renovate lockfile repair workflow to follow the branch-push pattern used by Void Zero's Vite+ repository. Renovate now skips native npm artifact updates, then this workflow refreshes `pnpm-lock.yaml` through Vite+ on every `renovate/**` branch push and commits the result back to the same branch when needed.

This version uses the built-in `GITHUB_TOKEN` through `actions/checkout` with job-scoped `contents: write`, so the workflow can do a normal `git push`. The workflow commit author is the reusable `trizum-agent[bot]` identity, and Renovate ignores that author when deciding whether it still owns the branch.

## Related Issues

Related to #220, #225, #228

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable) - not applicable, workflow/config only
- [x] I've run `vp run lingui:extract` (if I added new strings) - hook ran it; no user-facing strings added
- [x] I've added a changeset (if this is a user-facing change) - not applicable, internal tooling only

## Screenshots

Not applicable.

## Additional Notes

- Based on the Void Zero Vite+ Renovate lockfile workflow: https://github.com/voidzero-dev/vite-plus/actions/runs/27911986141/workflow
- The upstream workflow includes a dedupe step; this PR intentionally omits it because `vp dedupe --check` proposes broad unrelated lockfile rewrites in this repo due to `catalog: latest` entries.
- The lockfile refresh commit author stays in sync with `gitIgnoredAuthors` so Renovate continues managing the branch after the workflow commits.
