### PR TITLE
fix(tooling): skip setup install for Renovate lockfiles

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: true
+          # Renovate's initial branch can contain a stale pnpm-lock.yaml. Do
+          # not let setup-vp run the default frozen install before this
+          # workflow repairs the lockfile below.
+          run-install: false
 
       - name: Update pnpm lockfile
         env:

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -17,6 +17,8 @@ The workflow:
 - queues runs instead of canceling in progress so a newer Renovate branch push
   does not stop an in-flight lockfile refresh while it may be about to commit,
 - skips commits authored by `trizum-agent@trizum.app`,
+- disables setup-vp's automatic install because Renovate's initial lockfile can
+  be out of sync with the updated manifests,
 - runs:
 
 ```sh


### PR DESCRIPTION
## Description

Fixes the Renovate lockfile repair workflow added in #230. The failing run stopped inside `voidzero-dev/setup-vp@v1` before our repair step ran because setup-vp defaults to `run-install: true`, which runs a frozen `vp install` in CI.

On Renovate branches, the initial `pnpm-lock.yaml` can be stale relative to the updated manifest. This PR disables setup-vp's automatic install so the workflow reaches its explicit non-frozen lockfile repair command first:

```sh
vp install --lockfile-only --no-frozen-lockfile --ignore-scripts
```

## Related Issues

Related to #220, #230

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable) - not applicable, workflow config only
- [x] I've run `vp run lingui:extract` (if I added new strings) - hook ran it; no user-facing strings added
- [x] I've added a changeset (if this is a user-facing change) - not applicable, internal tooling only

## Screenshots

Not applicable.

## Additional Notes

- Failing workflow: https://github.com/HorusGoul/trizum/actions/runs/28329045417/job/83923941477?pr=220
- Failure was `ERR_PNPM_OUTDATED_LOCKFILE` before the `Update pnpm lockfile` step, with `@babel/core` at `7.29.0` in the lockfile and `7.29.6` in `packages/pwa/package.json`.
- Verified in a temporary worktree of `origin/renovate/npm-babel-core-vulnerability` that the explicit lockfile-only command succeeds and updates `pnpm-lock.yaml`.
