### PR TITLE
fix(tooling): use bot token for Renovate checkout

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - uses: voidzero-dev/setup-vp@v1
         with:

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -27,8 +27,8 @@ vp install --lockfile-only --no-frozen-lockfile --ignore-scripts
 
 - and pushes `pnpm-lock.yaml` back to the same Renovate branch when it changes.
 
-The workflow uses the built-in `GITHUB_TOKEN` through `actions/checkout` with
-job-scoped `contents: write` permission for the follow-up push.
+The workflow uses `BOT_GITHUB_TOKEN` through `actions/checkout` for the
+follow-up push.
 
 `renovate.json` lists `trizum-agent@trizum.app` in `gitIgnoredAuthors` so
 Renovate keeps managing branches after the workflow adds its lockfile commit.


### PR DESCRIPTION
## Description

Configures the Renovate lockfile workflow checkout step to use `secrets.BOT_GITHUB_TOKEN`. The workflow still performs a normal `git push`; `actions/checkout` persists the bot token credentials for that push.

The Renovate docs are updated to match the checkout-backed bot token behavior.

## Related Issues

Related to #220, #230, #231

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable) - not applicable, workflow config only
- [x] I've run `vp run lingui:extract` (if I added new strings) - hook ran it; no user-facing strings added
- [x] I've added a changeset (if this is a user-facing change) - not applicable, internal tooling only

## Screenshots

Not applicable.

## Additional Notes

- Keeps `run-install: false` from #231 so setup-vp does not fail on Renovate's initially stale lockfile before the repair step.
- The lockfile refresh commit identity remains `trizum-agent[bot]`, matching `gitIgnoredAuthors`.
