### PR TITLE
fix(tooling): use Lilith identity for automation commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,11 @@ jobs:
           commit: --signoff
           add: --all
           message: "style: apply automatic fixes"
-          committer_name: GitHub Actions
-          committer_email: actions@github.com
+          author_name: lilith[bot]
+          author_email: 259750894+PUNK-02@users.noreply.github.com
+          committer_name: lilith[bot]
+          committer_email: 259750894+PUNK-02@users.noreply.github.com
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Check if autofix and extract messages were successful
         if: ${{ steps.autofix.outcome != 'success' || steps.extract-messages.outcome != 'success' }}

--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   update-lockfile:
     name: Update Lockfile
-    if: github.event.repository.fork == false && github.event.head_commit.author.email != 'trizum-agent@trizum.app'
+    if: github.event.repository.fork == false && github.event.head_commit.author.email != '259750894+PUNK-02@users.noreply.github.com'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -67,8 +67,8 @@ jobs:
 
           # Identity must stay in sync with gitIgnoredAuthors in renovate.json
           # so Renovate keeps managing the branch.
-          git config user.name "trizum-agent[bot]"
-          git config user.email "trizum-agent@trizum.app"
+          git config user.name "lilith[bot]"
+          git config user.email "259750894+PUNK-02@users.noreply.github.com"
           git add pnpm-lock.yaml
           git commit -m "chore(deps): refresh pnpm lockfile with Vite+"
           git push

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -16,7 +16,7 @@ The workflow:
 
 - queues runs instead of canceling in progress so a newer Renovate branch push
   does not stop an in-flight lockfile refresh while it may be about to commit,
-- skips commits authored by `trizum-agent@trizum.app`,
+- skips commits authored by `259750894+PUNK-02@users.noreply.github.com`,
 - disables setup-vp's automatic install because Renovate's initial lockfile can
   be out of sync with the updated manifests,
 - runs:
@@ -30,5 +30,6 @@ vp install --lockfile-only --no-frozen-lockfile --ignore-scripts
 The workflow uses `BOT_GITHUB_TOKEN` through `actions/checkout` for the
 follow-up push.
 
-`renovate.json` lists `trizum-agent@trizum.app` in `gitIgnoredAuthors` so
-Renovate keeps managing branches after the workflow adds its lockfile commit.
+`renovate.json` lists `259750894+PUNK-02@users.noreply.github.com` in
+`gitIgnoredAuthors` so Renovate keeps managing branches after the workflow adds
+its lockfile commit.

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "gitIgnoredAuthors": ["trizum-agent@trizum.app"],
+  "gitIgnoredAuthors": ["259750894+PUNK-02@users.noreply.github.com"],
   "packageRules": [
     {
       "description": "Skip Renovate's native npm lockfile artifact updates; the Renovate Lockfiles workflow refreshes pnpm-lock.yaml with Vite+.",


### PR DESCRIPTION
## Description

Updates automated commit attribution to use Lilith's managed PUNK-02 agent account for both Renovate lockfile repairs and PR autofix commits.

Renovate lockfile repairs now commit as:

- Name: `lilith[bot]`
- Email: `259750894+PUNK-02@users.noreply.github.com`

The PR autofix job now uses the same author and committer identity, and passes `secrets.BOT_GITHUB_TOKEN` to `EndBug/add-and-commit` while checkout also persists the bot token for the push.

`renovate.json` and the Renovate workflow self-skip condition use the same email so Renovate continues to manage branches after the lockfile workflow adds a refresh commit.

## Related Issues

Related to #220, #230, #231, #234

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable) - not applicable, workflow config only
- [x] I've run `vp run lingui:extract` (if I added new strings) - hook ran it; no user-facing strings added
- [x] I've added a changeset (if this is a user-facing change) - not applicable, internal tooling only

## Screenshots

Not applicable.

## Additional Notes

- GitHub account metadata for PUNK-02 has no public email, so this uses the account-associated GitHub noreply email format based on user id `259750894`.
- Renovate checkout and CI autofix checkout both use `BOT_GITHUB_TOKEN`.
