### PR TITLE
fix(ci): allow concurrent Renovate agent reviews

### DIFF
--- a/.github/workflows/renovate-agent-review.yml
+++ b/.github/workflows/renovate-agent-review.yml
@@ -16,7 +16,7 @@ on:
       - completed
 
 concurrency:
-  group: ${{ github.workflow }}-codex-auth
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('pr-{0}', inputs.pr) || format('branch-{0}', github.event.workflow_run.head_branch) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Description

Allow Renovate agent review workflow runs for different Renovate PRs to execute concurrently by scoping the concurrency group to the dispatch PR number or workflow_run head branch.

Duplicate runs for the same PR or Renovate branch still share a group and remain serialized.

## Related Issues

Related to #245

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

This is workflow-only. Local `actionlint` is not installed in this environment, so validation used the repo Vite+ gates and `git diff --check`.