### PR TITLE
fix(agent-workflows): update lockfile-only Renovate PRs in place

### DIFF
--- a/packages/agent-workflows/src/cli.ts
+++ b/packages/agent-workflows/src/cli.ts
@@ -62,7 +62,11 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
 
   process.stdout.write(`${result.report}\n`);
   if (result.supersedingPullRequest?.prUrl != null) {
-    process.stdout.write(`\nSuperseding PR: ${result.supersedingPullRequest.prUrl}\n`);
+    const label =
+      result.supersedingPullRequest.updatedOriginalPr === true
+        ? "Updated original PR"
+        : "Superseding PR";
+    process.stdout.write(`\n${label}: ${result.supersedingPullRequest.prUrl}\n`);
   }
   if (result.labelAppliedTo != null) {
     process.stdout.write(

--- a/packages/agent-workflows/src/schemas.ts
+++ b/packages/agent-workflows/src/schemas.ts
@@ -169,6 +169,7 @@ export const supersedingPullRequestSchema = z.object({
   localValidationOutput: z.string().optional(),
   prUrl: z.string().optional(),
   summary: z.string(),
+  updatedOriginalPr: z.boolean().optional(),
 });
 export type SupersedingPullRequest = z.infer<typeof supersedingPullRequestSchema>;
 

--- a/packages/agent-workflows/src/workflows/renovate-pr-review.test.ts
+++ b/packages/agent-workflows/src/workflows/renovate-pr-review.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vite-plus/test";
+import { canUpdateOriginalRenovatePr } from "./renovate-pr-review.js";
+
+describe("Renovate PR review workflow", () => {
+  test("allows updating the original PR for lockfile and workspace metadata fixes", () => {
+    expect(canUpdateOriginalRenovatePr(["pnpm-lock.yaml"])).toBe(true);
+    expect(canUpdateOriginalRenovatePr(["pnpm-workspace.yaml"])).toBe(true);
+    expect(canUpdateOriginalRenovatePr(["pnpm-lock.yaml", "pnpm-workspace.yaml"])).toBe(true);
+  });
+
+  test("requires a superseding PR for empty or broader fixes", () => {
+    expect(canUpdateOriginalRenovatePr([])).toBe(false);
+    expect(canUpdateOriginalRenovatePr(["packages/pwa/package.json"])).toBe(false);
+    expect(canUpdateOriginalRenovatePr(["pnpm-lock.yaml", "packages/pwa/package.json"])).toBe(
+      false,
+    );
+  });
+});

--- a/packages/agent-workflows/src/workflows/renovate-pr-review.ts
+++ b/packages/agent-workflows/src/workflows/renovate-pr-review.ts
@@ -68,6 +68,8 @@ interface LocalValidationResult {
   passed: boolean;
 }
 
+const ORIGINAL_PR_DIRECT_UPDATE_FILES = new Set(["pnpm-lock.yaml", "pnpm-workspace.yaml"]);
+
 export const listRenovatePullRequests = createHandler(
   {
     inputValidator: workflowOptionsSchema,
@@ -759,11 +761,49 @@ async function createSupersedingPullRequest(
 
     const fallbackCommitCreated = await commitPendingAgentChanges(worktreeRoot, context);
     const agentCommits = await ensureCoAuthorOnSupersedingCommits(worktreeRoot, originalPrHead);
+    const changedFiles = await listChangedFilesAfter(worktreeRoot, originalPrHead);
     const sandcastleSummary = renderSandcastleSummary(
       sandcastleRun,
       fallbackCommitCreated,
       agentCommits,
     );
+
+    if (canUpdateOriginalRenovatePr(changedFiles)) {
+      await runGitWithOptionalCredentials(
+        ["push", "origin", `HEAD:${context.pr.headRefName}`],
+        worktreeRoot,
+      );
+      await addLabelToIssue(options, context.pr.number, options.readyForHumanReviewLabel);
+      if (options.postReviewComment) {
+        await commentOnPullRequest(
+          options,
+          context.pr.number,
+          renderOriginalPullRequestUpdatedComment(
+            context,
+            report,
+            sandcastleSummary,
+            localValidation,
+          ),
+        );
+      }
+
+      return {
+        branchName: context.pr.headRefName,
+        agentCommits,
+        agentLogPath: sandcastleRun.logFilePath,
+        localValidationOutput: localValidation.output,
+        localValidationPassed: localValidation.passed,
+        prUrl: context.pr.url,
+        summary: truncateText(
+          [
+            "Updated the original Renovate PR because the agent fix only changed lockfile/workspace metadata.",
+            sandcastleSummary,
+          ].join("\n\n"),
+          12_000,
+        ),
+        updatedOriginalPr: true,
+      };
+    }
 
     await runGitWithOptionalCredentials(["push", "-u", "origin", branchName], worktreeRoot);
 
@@ -1038,6 +1078,20 @@ async function listCommitsAfter(worktreeRoot: string, baseCommit: string): Promi
   return splitLines(result.stdout);
 }
 
+async function listChangedFilesAfter(worktreeRoot: string, baseCommit: string): Promise<string[]> {
+  const result = await runCommand("git", ["diff", "--name-only", `${baseCommit}..HEAD`], {
+    cwd: worktreeRoot,
+  });
+  return splitLines(result.stdout);
+}
+
+export function canUpdateOriginalRenovatePr(changedFiles: readonly string[]): boolean {
+  return (
+    changedFiles.length > 0 &&
+    changedFiles.every((file) => ORIGINAL_PR_DIRECT_UPDATE_FILES.has(file))
+  );
+}
+
 async function allCommitsHaveCoAuthor(
   worktreeRoot: string,
   commits: readonly string[],
@@ -1162,6 +1216,38 @@ function renderSupersedingPullRequestBody(
       findings.length === 0 ? "" : findings.map((finding) => `- ${finding}`).join("\n"),
       "",
       "## Local Validation",
+      `- Status: ${localValidation.passed ? "passed" : "failed"}.`,
+      renderValidationCommandBullets(localValidation.output),
+      "- CI on this PR is the source of truth for merge readiness.",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+}
+
+function renderOriginalPullRequestUpdatedComment(
+  context: PullRequestContext,
+  report: string,
+  agentSummary: string,
+  localValidation: LocalValidationResult,
+): string {
+  const reviewSummary = firstParagraph(extractMarkdownSection(report, "Summary"));
+  const findings = extractMarkdownListItems(report, "Findings", 2);
+
+  return redactSecrets(
+    [
+      "## Agent Renovate Review",
+      "",
+      "Updated this Renovate PR because the required fix only touched lockfile/workspace metadata.",
+      "",
+      `**Purpose:** ${renderDependencyUpdateSummary(context)}.`,
+      `**Agent fix:** ${truncateText(firstParagraph(agentSummary), 700)}`,
+      "",
+      "**Review:**",
+      reviewSummary || "See the workflow logs for the full agent review.",
+      findings.length === 0 ? "" : findings.map((finding) => `- ${finding}`).join("\n"),
+      "",
+      "**Local validation:**",
       `- Status: ${localValidation.passed ? "passed" : "failed"}.`,
       renderValidationCommandBullets(localValidation.output),
       "- CI on this PR is the source of truth for merge readiness.",


### PR DESCRIPTION
## Description

When the Renovate agent fixes a blocked PR and the resulting agent diff only touches `pnpm-lock.yaml` and/or `pnpm-workspace.yaml`, push that fix back to the original Renovate branch instead of creating a superseding PR.

Broader fixes still create a superseding PR. The CLI output now distinguishes this in-place path from real superseding PRs.

## Related Issues

Related to #248

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

Local validation passed. `vp run check` still reports the existing PWA warnings unrelated to this change.