### PR TITLE
chore(deps): update hono dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7527,10 +7527,6 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.10.6:
-    resolution: {integrity: sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==}
-    engines: {node: '>=16.9.0'}
-
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
@@ -15143,7 +15139,7 @@ snapshots:
       emojibase-regex: 17.0.0
       exifr: 7.1.3
       heic-to: 1.4.2
-      hono: 4.10.6
+      hono: 4.12.27
       jose: 6.2.3
       mathjs: 15.1.0
       motion: 12.38.0(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
@@ -17469,8 +17465,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.10.6: {}
 
   hono@4.12.27: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,11 +83,11 @@ catalogs:
       specifier: 5.2.8
       version: 5.2.8
     '@hono/node-server':
-      specifier: 1.19.6
-      version: 1.19.6
+      specifier: 1.19.14
+      version: 1.19.14
     '@hono/node-ws':
-      specifier: 1.2.0
-      version: 1.2.0
+      specifier: 1.3.1
+      version: 1.3.1
     '@horus.dev/tw-dynamic-themes':
       specifier: 0.0.3
       version: 0.0.3
@@ -239,8 +239,8 @@ catalogs:
       specifier: 1.4.2
       version: 1.4.2
     hono:
-      specifier: 4.10.6
-      version: 4.10.6
+      specifier: 4.12.27
+      version: 4.12.27
     jose:
       specifier: 6.2.3
       version: 6.2.3
@@ -674,7 +674,7 @@ importers:
         version: 1.4.2
       hono:
         specifier: 'catalog:'
-        version: 4.10.6
+        version: 4.12.27
       jose:
         specifier: 'catalog:'
         version: 6.2.3
@@ -865,10 +865,10 @@ importers:
         version: 2.5.6
       '@hono/node-server':
         specifier: 'catalog:'
-        version: 1.19.6(hono@4.10.6)
+        version: 1.19.14(hono@4.12.27)
       '@hono/node-ws':
         specifier: 'catalog:'
-        version: 1.2.0(@hono/node-server@1.19.6(hono@4.10.6))(hono@4.10.6)
+        version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.27))(hono@4.12.27)
       '@kubiks/otel-drizzle':
         specifier: 'catalog:'
         version: 2.1.0(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2))
@@ -898,7 +898,7 @@ importers:
         version: 0.45.2(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2)
       hono:
         specifier: 'catalog:'
-        version: 4.10.6
+        version: 4.12.27
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -2501,17 +2501,17 @@ packages:
   '@formatjs/intl-localematcher@0.5.4':
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
 
-  '@hono/node-server@1.19.6':
-    resolution: {integrity: sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
 
-  '@hono/node-ws@1.2.0':
-    resolution: {integrity: sha512-OBPQ8OSHBw29mj00wT/xGYtB6HY54j0fNSdVZ7gZM3TUeq0So11GXaWtFf1xWxQNfumKIsj0wRuLKWfVsO5GgQ==}
+  '@hono/node-ws@1.3.1':
+    resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      '@hono/node-server': ^1.11.1
+      '@hono/node-server': ^1.19.11
       hono: ^4.6.0
 
   '@horus.dev/tw-dynamic-themes@0.0.3':
@@ -7531,6 +7531,10 @@ packages:
     resolution: {integrity: sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -11953,14 +11957,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@hono/node-server@1.19.6(hono@4.10.6)':
+  '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
-      hono: 4.10.6
+      hono: 4.12.27
 
-  '@hono/node-ws@1.2.0(@hono/node-server@1.19.6(hono@4.10.6))(hono@4.10.6)':
+  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.27))(hono@4.12.27)':
     dependencies:
-      '@hono/node-server': 1.19.6(hono@4.10.6)
-      hono: 4.10.6
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      hono: 4.12.27
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -15487,9 +15491,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.2)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.4)(typescript@5.9.2)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.10.2)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.0.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.10.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.4)(typescript@5.9.2)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(vite@8.0.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@types/node@24.10.2)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -17467,6 +17471,8 @@ snapshots:
       react-is: 16.13.1
 
   hono@4.10.6: {}
+
+  hono@4.12.27: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,8 +38,8 @@ catalog:
   "@cloudflare/vite-plugin": 1.29.0
   "@fontsource-variable/fira-code": 5.2.7
   "@fontsource-variable/inter": 5.2.8
-  "@hono/node-server": 1.19.6
-  "@hono/node-ws": 1.2.0
+  "@hono/node-server": 1.19.14
+  "@hono/node-ws": 1.3.1
   "@horus.dev/tw-dynamic-themes": 0.0.3
   "@internationalized/date": 3.10.0
   "@kubiks/otel-drizzle": 2.1.0
@@ -92,7 +92,7 @@ catalog:
   eslint-plugin-lingui: 0.11.0
   exifr: 7.1.3
   heic-to: 1.4.2
-  hono: 4.10.6
+  hono: 4.12.27
   jose: 6.2.3
   lucide-static: 1.8.0
   mathjs: 15.1.0


### PR DESCRIPTION
Supersedes #227.
## Summary
- Purpose: @hono/node-server 1.19.6 -> 1.19.14, @hono/node-ws 1.2.0 -> 1.3.1, hono 4.10.6 -> 4.12.27.
- Agent fix: Completed and committed the superseding fix.
## Review
Reviewed chore(deps): update hono dependencies (#227); affected areas: server, workspace; updates: @hono/node-server 1.19.6 -> 1.19.14, @hono/node-ws 1.2.0 -> 1.3.1, hono 4.10.6 -> 4.12.27.
The PR updates the Hono catalog entries and includes a refreshed pnpm lockfile, and the reported CI checks are green. However, the lockfile still keeps the injected @trizum/pwa snapshot on hono 4.10.6, so the old Hono version remains in the installed graph despite the catalog/importer update to 4.12.27.
- [blocker] Lockfile still resolves injected PWA snapshot to hono 4.10.6 (pnpm-lock.yaml): In the PR lockfile, the packages/pwa importer is updated to hono 4.12.27, but the injected @trizum/pwa file snapshot used by packages/mobile still lists hono: 4.10.6 and leaves a hono@4.10.6 snapshot. Because pnpm-workspace.yaml enables injectWorkspacePackages, the dependency update is incomplete and the old Hono release remains installable in the mobile/PWA dependency graph. Refresh the lockfile so no hono: 4.10.6 or hono@4.10.6 entries remain unless another package intentionally pins that version.
- [warning] @hono/node-ws is deprecated upstream (packages/server/src/main.ts): The @hono/node-ws 1.3.1 release/README marks the package deprecated in favor of @hono/node-server v2 built-in WebSocket support. Current server code still imports createNodeWebSocket from @hono/node-ws. This does not appear to break the current PR API-wise, but it should be tracked as a follow-up migration rather than treated as a long-term dependency path.
## Local Validation
- Status: failed.
- `vp install --frozen-lockfile --ignore-scripts --prefer-offline`
- `vp run check`
- `vp check`
- `vp run test`
- CI on this PR is the source of truth for merge readiness.