### PR TITLE
chore(renovate): enable guarded automerge

### DIFF
--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -37,6 +37,23 @@ its lockfile commit.
 Renovate groups non-major Vite+, Vite, and Vitest updates because the coverage
 providers and test runner use exact peer versions and must move together.
 
+## Automerge
+
+`renovate.json` is the source of truth for automerge eligibility. Keep package,
+version, and update-type matchers there instead of duplicating them in this
+document.
+
+The repo intentionally uses Renovate-managed PR automerge instead of
+platform-native automerge because `main` is not protected with required status
+checks. Renovate's platform-native automerge can merge immediately when the
+platform has no required checks configured. With Renovate-managed automerge,
+Renovate waits until it sees passing branch status checks before merging.
+
+This also keeps the behavior compatible with the lockfile repair workflow:
+Renovate opens the branch, the `Renovate Lockfiles` workflow commits the
+Vite+-generated `pnpm-lock.yaml`, and Renovate can then merge the PR after the
+updated branch passes checks.
+
 ## Agent Review
 
 The

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "platformAutomerge": false,
   "gitIgnoredAuthors": ["259750894+PUNK-02@users.noreply.github.com"],
   "packageRules": [
     {
       "description": "Skip Renovate's native npm lockfile artifact updates; the Renovate Lockfiles workflow refreshes pnpm-lock.yaml with Vite+.",
       "matchManagers": ["npm"],
       "skipArtifactsUpdate": true
+    },
+    {
+      "description": "Automerge non-major dependency updates after status checks pass, excluding 0.x current versions and TypeScript.",
+      "matchUpdateTypes": ["patch", "minor"],
+      "matchPackageNames": ["!typescript"],
+      "matchCurrentVersion": "!/^0\\./",
+      "automerge": true
     },
     {
       "description": "Keep non-major PWA runtime dependency updates together.",


### PR DESCRIPTION
## Description

Configures Renovate to automerge only guarded dependency updates and keeps the exact eligibility policy in `renovate.json`.

This PR also documents the repo-specific rationale for Renovate-managed PR automerge: `main` does not currently have required status checks, so platform-native automerge could merge before checks run. Renovate-managed automerge waits for passing branch status checks and still works with the Vite+ lockfile repair workflow.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [x] Other: dependency automation configuration

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (not applicable: configuration/docs only)
- [x] I've run `vp run lingui:extract` (no user-facing strings; also ran from the commit hook)
- [x] I've added a changeset (not applicable: not a user-facing package change)

## Screenshots

Not applicable.

## Additional Notes

Validation also included `jq empty renovate.json` and `vp dlx --package renovate renovate-config-validator renovate.json`.

`vp run check` still reports existing PWA lint warnings in image interaction and assertion-lint tests; there are no new errors.
