### PR TITLE
fix(ci): deploy pwa previews for conflicted prs

### DIFF
--- a/.github/workflows/pwa-preview.yml
+++ b/.github/workflows/pwa-preview.yml
@@ -1,7 +1,7 @@
 name: PWA Preview
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -11,7 +11,6 @@ permissions:
   contents: read
   deployments: write
   issues: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -21,17 +20,21 @@ jobs:
   preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
+    # `pull_request` workflows are suppressed while a PR has merge conflicts.
+    # `pull_request_target` still runs, so keep previews available, but only
+    # build and deploy same-repository PR code.
     if: github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: ".node-version"
-          cache: true
+          cache: false
 
       - name: Build PWA
         run: vp run --filter @trizum/pwa build

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -49,8 +49,8 @@ connected repository builds.
 
 - Production deploys run after a changeset release updates the PWA version or
   changelog on `main`.
-- Pull requests get Cloudflare preview deployments from the
-  `PWA Preview` workflow, and the workflow updates a PR comment with the latest
-  preview URL.
+- Same-repository pull requests get Cloudflare preview deployments from the
+  `PWA Preview` workflow, including PRs with merge conflicts, and the workflow
+  updates a PR comment with the latest preview URL.
 - The workflows require `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`
   repository secrets.


### PR DESCRIPTION
## Description

Switches the PWA preview workflow to `pull_request_target` so same-repository PRs still generate Cloudflare previews when they have merge conflicts. The workflow still checks out the PR head SHA for the preview build.

Security hardening for the privileged trigger:

- Keeps the job limited to same-repository PRs.
- Disables persisted checkout credentials in the PR worktree.
- Disables Vite+ dependency caching for this workflow.
- Removes the unused `pull-requests: write` permission.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable. This is a GitHub Actions workflow change.

## Additional Notes

`pull_request_target` is intentionally limited to same-repository PRs here. Fork PRs remain skipped by the job-level guard.