### PR TITLE
fix(agent-workflows): clarify Renovate agent PR bodies

### DIFF
--- a/packages/agent-workflows/src/workflows/renovate-pr-review.test.ts
+++ b/packages/agent-workflows/src/workflows/renovate-pr-review.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vite-plus/test";
-import { canUpdateOriginalRenovatePr } from "./renovate-pr-review.js";
+import type { PullRequestContext } from "../schemas.js";
+import {
+  canUpdateOriginalRenovatePr,
+  renderSupersedingPullRequestBody,
+  type LocalValidationResult,
+} from "./renovate-pr-review.js";
 
 describe("Renovate PR review workflow", () => {
   test("allows updating the original PR for lockfile and workspace metadata fixes", () => {
@@ -14,5 +19,90 @@ describe("Renovate PR review workflow", () => {
     expect(canUpdateOriginalRenovatePr(["pnpm-lock.yaml", "packages/pwa/package.json"])).toBe(
       false,
     );
+  });
+
+  test("explains why superseding PRs exist and reports the failed local command", () => {
+    const context = {
+      affectedAreas: ["mobile", "workspace"],
+      body: "",
+      dependencyMetadata: [],
+      dependencyUpdates: [
+        { file: "pnpm-workspace.yaml", from: "8.0.1", name: "@capacitor/android", to: "8.4.1" },
+        { file: "pnpm-workspace.yaml", from: "8.0.0", name: "@capacitor/app", to: "8.1.0" },
+        { file: "pnpm-workspace.yaml", from: "8.0.1", name: "@capacitor/cli", to: "8.4.1" },
+        { file: "pnpm-workspace.yaml", from: "8.0.1", name: "@capacitor/core", to: "8.4.1" },
+        { file: "pnpm-workspace.yaml", from: "8.0.1", name: "@capacitor/ios", to: "8.4.1" },
+      ],
+      diff: "",
+      failedCheckLogs: [],
+      files: ["pnpm-lock.yaml", "pnpm-workspace.yaml"],
+      pr: {
+        authorLogin: "renovate[bot]",
+        baseRefName: "main",
+        headRefName: "renovate/capacitor",
+        isDraft: false,
+        labels: [],
+        number: 262,
+        status: {
+          conclusion: "pass",
+          failing: [],
+          passing: [],
+          pending: [],
+          skipping: [],
+          summary: "All checks passed.",
+        },
+        title: "chore(deps): update capacitor dependencies",
+        url: "https://github.com/HorusGoul/trizum/pull/262",
+      },
+      usageMatches: [],
+    } satisfies PullRequestContext;
+    const report = [
+      "### Summary",
+      "The catalog and lockfile update is coherent, but tracked Capacitor native files still reference removed pnpm package paths.",
+      "",
+      "### Findings",
+      "- [blocker] iOS Podfile and Podfile.lock still pin old Capacitor package paths: Refresh iOS with cap sync ios and pod install, then commit Podfile plus Podfile.lock.",
+    ].join("\n");
+    const localValidation = {
+      commands: [
+        { command: "vp install --frozen-lockfile --ignore-scripts --prefer-offline", exitCode: 0 },
+        { command: "vp run check", exitCode: 0 },
+        { command: "vp run test", exitCode: 0 },
+        { command: "vp run build", exitCode: 1 },
+      ],
+      failedCommand: "vp run build",
+      failedExitCode: 1,
+      failureSummary:
+        "Could not find 'bundler' (2.7.2) required by packages/mobile/ios/App/Gemfile.lock.",
+      output: "",
+      passed: false,
+    } satisfies LocalValidationResult;
+    const body = renderSupersedingPullRequestBody(
+      context,
+      report,
+      "Completed and committed `49b8ab2 chore(deps): complete Renovate PR #262`.",
+      localValidation,
+      [
+        "packages/mobile/android/capacitor.settings.gradle",
+        "packages/mobile/ios/App/Podfile",
+        "packages/mobile/ios/App/Podfile.lock",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+      ],
+    );
+
+    expect(body).toContain("## Why This PR Exists");
+    expect(body).toContain(
+      "tracked Capacitor native files still reference removed pnpm package paths",
+    );
+    expect(body).toContain("iOS Podfile and Podfile.lock still pin old Capacitor package paths");
+    expect(body).toContain("## What Changed");
+    expect(body).toContain("- Dependency update: @capacitor/android 8.0.1 -> 8.4.1");
+    expect(body).toContain("and 1 more");
+    expect(body).toContain("- Agent fix: Applied the agent-generated fix");
+    expect(body).toContain("`packages/mobile/ios/App/Podfile.lock`");
+    expect(body).toContain("- [fail] `vp run build` (exit 1)");
+    expect(body).toContain("- Failed command: `vp run build` (exit 1).");
+    expect(body).toContain("Could not find 'bundler' (2.7.2)");
   });
 });

--- a/packages/agent-workflows/src/workflows/renovate-pr-review.ts
+++ b/packages/agent-workflows/src/workflows/renovate-pr-review.ts
@@ -33,6 +33,7 @@ import {
   runCommand,
   splitLines,
   truncateText,
+  type CommandResult,
 } from "../adapters/exec.js";
 import {
   runSandcastleCodexFix,
@@ -63,7 +64,16 @@ const MAX_DEPENDENCY_METADATA = 12;
 const BOT_COMMIT_CO_AUTHOR = "Horus Lugo <horusgoul@gmail.com>";
 const BOT_COMMIT_CO_AUTHOR_TRAILER = `Co-authored-by: ${BOT_COMMIT_CO_AUTHOR}`;
 
-interface LocalValidationResult {
+export interface LocalValidationCommandResult {
+  command: string;
+  exitCode: number;
+}
+
+export interface LocalValidationResult {
+  commands: LocalValidationCommandResult[];
+  failedCommand?: string;
+  failedExitCode?: number;
+  failureSummary?: string;
   output: string;
   passed: boolean;
 }
@@ -755,6 +765,7 @@ async function createSupersedingPullRequest(
     const localValidation = options.runLocalValidation
       ? await runLocalValidation(worktreeRoot)
       : {
+          commands: [],
           output: "Local validation skipped by workflow option.",
           passed: true,
         };
@@ -783,6 +794,7 @@ async function createSupersedingPullRequest(
             report,
             sandcastleSummary,
             localValidation,
+            changedFiles,
           ),
         );
       }
@@ -813,6 +825,7 @@ async function createSupersedingPullRequest(
       report,
       sandcastleSummary,
       localValidation,
+      changedFiles,
     );
     await writeFile(bodyPath, body, "utf8");
     const createResult = await gh(
@@ -918,6 +931,10 @@ async function runLocalValidation(worktreeRoot: string): Promise<LocalValidation
     GIT_TERMINAL_PROMPT: "0",
   };
   const output: string[] = [];
+  const commandResults: LocalValidationCommandResult[] = [];
+  let failedCommand: string | undefined;
+  let failedExitCode: number | undefined;
+  let failureSummary: string | undefined;
   let passed = true;
 
   try {
@@ -939,8 +956,15 @@ async function runLocalValidation(worktreeRoot: string): Promise<LocalValidation
           .filter(Boolean)
           .join("\n"),
       );
+      commandResults.push({
+        command: result.command,
+        exitCode: result.exitCode,
+      });
       if (result.exitCode !== 0) {
         passed = false;
+        failedCommand = result.command;
+        failedExitCode = result.exitCode;
+        failureSummary = summarizeCommandFailure(result);
         break;
       }
     }
@@ -949,9 +973,37 @@ async function runLocalValidation(worktreeRoot: string): Promise<LocalValidation
   }
 
   return {
+    commands: commandResults,
+    ...(failedCommand == null ? {} : { failedCommand }),
+    ...(failedExitCode == null ? {} : { failedExitCode }),
+    ...(failureSummary == null ? {} : { failureSummary }),
     output: output.join("\n\n"),
     passed,
   };
+}
+
+function summarizeCommandFailure(result: CommandResult): string {
+  const combinedOutput = stripAnsiCodes(redactSecrets([result.stderr, result.stdout].join("\n")));
+  const lines = splitLines(combinedOutput)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+  const errorLines = lines.filter((line) =>
+    /error|failed|could not|not found|missing|exception/i.test(line),
+  );
+  const summaryLines = (errorLines.length === 0 ? lines.slice(-12) : errorLines.slice(-12)).map(
+    (line) => truncateText(line, 500),
+  );
+
+  if (summaryLines.length === 0) {
+    return `Command exited with status ${result.exitCode} without producing output.`;
+  }
+
+  return truncateText(summaryLines.join("\n"), 1_400);
+}
+
+function stripAnsiCodes(value: string): string {
+  const escape = String.fromCharCode(27);
+  return value.replace(new RegExp(`${escape}\\[[0-?]*[ -/]*[@-~]`, "g"), "");
 }
 
 async function hideCodexAuthCache(): Promise<{ restore: () => Promise<void> }> {
@@ -1194,11 +1246,12 @@ function renderReviewComment(decision: ReviewDecision): string {
   );
 }
 
-function renderSupersedingPullRequestBody(
+export function renderSupersedingPullRequestBody(
   context: PullRequestContext,
   report: string,
   agentSummary: string,
   localValidation: LocalValidationResult,
+  changedFiles: readonly string[],
 ): string {
   const reviewSummary = firstParagraph(extractMarkdownSection(report, "Summary"));
   const findings = extractMarkdownListItems(report, "Findings", 2);
@@ -1207,17 +1260,21 @@ function renderSupersedingPullRequestBody(
     [
       `Supersedes #${context.pr.number}.`,
       "",
-      "## Summary",
-      `- Purpose: ${renderDependencyUpdateSummary(context)}.`,
-      `- Agent fix: ${truncateText(firstParagraph(agentSummary), 700)}`,
+      "## Why This PR Exists",
+      truncateText(reviewSummary, 900) || "See the workflow logs for the full agent review.",
+      renderFindingBullets(findings),
       "",
-      "## Review",
-      reviewSummary || "See the workflow logs for the full agent review.",
-      findings.length === 0 ? "" : findings.map((finding) => `- ${finding}`).join("\n"),
+      "## What Changed",
+      `- Dependency update: ${renderDependencyUpdateSummary(context)}.`,
+      `- Agent fix: ${renderAgentFixSummary(agentSummary)}`,
+      "",
+      "Changed files:",
+      renderChangedFiles(changedFiles),
       "",
       "## Local Validation",
       `- Status: ${localValidation.passed ? "passed" : "failed"}.`,
-      renderValidationCommandBullets(localValidation.output),
+      renderValidationCommandBullets(localValidation),
+      renderValidationFailure(localValidation),
       "- CI on this PR is the source of truth for merge readiness.",
     ]
       .filter(Boolean)
@@ -1230,6 +1287,7 @@ function renderOriginalPullRequestUpdatedComment(
   report: string,
   agentSummary: string,
   localValidation: LocalValidationResult,
+  changedFiles: readonly string[],
 ): string {
   const reviewSummary = firstParagraph(extractMarkdownSection(report, "Summary"));
   const findings = extractMarkdownListItems(report, "Findings", 2);
@@ -1240,16 +1298,21 @@ function renderOriginalPullRequestUpdatedComment(
       "",
       "Updated this Renovate PR because the required fix only touched lockfile/workspace metadata.",
       "",
-      `**Purpose:** ${renderDependencyUpdateSummary(context)}.`,
-      `**Agent fix:** ${truncateText(firstParagraph(agentSummary), 700)}`,
+      "**Why this update was needed:**",
+      truncateText(reviewSummary, 700) || "See the workflow logs for the full agent review.",
+      renderFindingBullets(findings),
       "",
-      "**Review:**",
-      reviewSummary || "See the workflow logs for the full agent review.",
-      findings.length === 0 ? "" : findings.map((finding) => `- ${finding}`).join("\n"),
+      "**What changed:**",
+      `- Dependency update: ${renderDependencyUpdateSummary(context)}.`,
+      `- Agent fix: ${renderAgentFixSummary(agentSummary)}`,
+      "",
+      "Changed files:",
+      renderChangedFiles(changedFiles),
       "",
       "**Local validation:**",
       `- Status: ${localValidation.passed ? "passed" : "failed"}.`,
-      renderValidationCommandBullets(localValidation.output),
+      renderValidationCommandBullets(localValidation),
+      renderValidationFailure(localValidation),
       "- CI on this PR is the source of truth for merge readiness.",
     ]
       .filter(Boolean)
@@ -1262,23 +1325,92 @@ function renderDependencyUpdateSummary(context: PullRequestContext): string {
     return context.pr.title;
   }
 
-  return context.dependencyUpdates
+  const renderedUpdates = context.dependencyUpdates
     .slice(0, 4)
     .map((update) => `${update.name} ${update.from ?? "unknown"} -> ${update.to ?? "unknown"}`)
     .join(", ");
+
+  if (context.dependencyUpdates.length <= 4) {
+    return renderedUpdates;
+  }
+
+  return `${renderedUpdates}, and ${context.dependencyUpdates.length - 4} more`;
 }
 
-function renderValidationCommandBullets(output: string): string {
-  const commands = splitLines(output)
-    .filter((line) => line.startsWith("$ "))
-    .map((line) => line.slice(2))
-    .slice(0, 6);
+function renderAgentFixSummary(agentSummary: string): string {
+  const summary = firstParagraph(agentSummary);
+  if (
+    !summary ||
+    /^completed and committed\b/i.test(summary) ||
+    /^sandcastle codex run completed\b/i.test(summary)
+  ) {
+    return "Applied the agent-generated fix for the review findings.";
+  }
 
-  if (commands.length === 0) {
+  return truncateText(summary, 500);
+}
+
+function renderChangedFiles(changedFiles: readonly string[]): string {
+  if (changedFiles.length === 0) {
+    return "- No changed files were reported.";
+  }
+
+  const visibleFiles = changedFiles.slice(0, 8).map((file) => `- \`${file}\``);
+  if (changedFiles.length <= visibleFiles.length) {
+    return visibleFiles.join("\n");
+  }
+
+  return [...visibleFiles, `- ${changedFiles.length - visibleFiles.length} more file(s).`].join(
+    "\n",
+  );
+}
+
+function renderFindingBullets(findings: readonly string[]): string {
+  if (findings.length === 0) {
+    return "";
+  }
+
+  return findings.map((finding) => `- ${truncateText(finding, 450)}`).join("\n");
+}
+
+function renderValidationCommandBullets(localValidation: LocalValidationResult): string {
+  if (localValidation.commands.length === 0) {
     return "- No local validation commands were reported.";
   }
 
-  return commands.map((command) => `- \`${command}\``).join("\n");
+  return localValidation.commands
+    .map((command) => {
+      const status = command.exitCode === 0 ? "pass" : "fail";
+      const exitCode = command.exitCode === 0 ? "" : ` (exit ${command.exitCode})`;
+      return `- [${status}] \`${command.command}\`${exitCode}`;
+    })
+    .join("\n");
+}
+
+function renderValidationFailure(localValidation: LocalValidationResult): string {
+  if (localValidation.passed) {
+    return "";
+  }
+
+  const failedCommand = localValidation.failedCommand ?? "unknown command";
+  const exitCode =
+    localValidation.failedExitCode == null ? "" : ` (exit ${localValidation.failedExitCode})`;
+  const failureSummary = localValidation.failureSummary?.trim();
+
+  return [
+    `- Failed command: \`${failedCommand}\`${exitCode}.`,
+    failureSummary == null || failureSummary.length === 0
+      ? ""
+      : ["- Failure output:", "```text", sanitizeMarkdownCodeBlock(failureSummary), "```"].join(
+          "\n",
+        ),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function sanitizeMarkdownCodeBlock(value: string): string {
+  return value.replace(/```/g, "'''");
 }
 
 function extractMarkdownSection(markdown: string, heading: string): string {


### PR DESCRIPTION
## Description

Clarifies generated Renovate agent follow-up PRs so reviewers can see why the PR exists, what the agent changed, and which local validation command failed when validation does not pass.

## Related Issues

Related to #266

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

`vp run check` passes with existing PWA lint warnings unrelated to this PR.
