### PR TITLE
fix(agent-workflows): reuse Renovate superseding PRs

### DIFF
--- a/packages/agent-workflows/src/workflows/renovate-pr-review.test.ts
+++ b/packages/agent-workflows/src/workflows/renovate-pr-review.test.ts
@@ -3,7 +3,9 @@ import type { PullRequestContext } from "../schemas.js";
 import {
   canUpdateOriginalRenovatePr,
   renderSupersedingPullRequestBody,
+  selectExistingSupersedingPullRequest,
   type LocalValidationResult,
+  type SupersedingPullRequestCandidate,
 } from "./renovate-pr-review.js";
 
 describe("Renovate PR review workflow", () => {
@@ -19,6 +21,48 @@ describe("Renovate PR review workflow", () => {
     expect(canUpdateOriginalRenovatePr(["pnpm-lock.yaml", "packages/pwa/package.json"])).toBe(
       false,
     );
+  });
+
+  test("selects an existing superseding PR instead of creating a duplicate", () => {
+    const candidates = [
+      {
+        baseRefName: "main",
+        body: "Supersedes #237.\n\n## Summary\nDuplicate created later.",
+        headRefName: "agent/renovate-pr-237-later",
+        number: 267,
+        title: "chore(deps): update dependency ruby to v3.4.9",
+        url: "https://github.com/HorusGoul/trizum/pull/267",
+      },
+      {
+        baseRefName: "main",
+        body: "Supersedes #237.\n\n## Summary\nFirst superseding PR.",
+        headRefName: "agent/renovate-pr-237-first",
+        number: 263,
+        title: "chore(deps): update dependency ruby to v3.4.9",
+        url: "https://github.com/HorusGoul/trizum/pull/263",
+      },
+      {
+        baseRefName: "release",
+        body: "Supersedes #237.",
+        headRefName: "agent/renovate-pr-237-release",
+        number: 260,
+        title: "chore(deps): update dependency ruby to v3.4.9",
+        url: "https://github.com/HorusGoul/trizum/pull/260",
+      },
+      {
+        baseRefName: "main",
+        body: "Supersedes #23.",
+        headRefName: "agent/renovate-pr-23",
+        number: 261,
+        title: "chore(deps): update dependency ruby",
+        url: "https://github.com/HorusGoul/trizum/pull/261",
+      },
+    ] satisfies SupersedingPullRequestCandidate[];
+
+    expect(selectExistingSupersedingPullRequest(candidates, 237, "main")).toMatchObject({
+      number: 263,
+      url: "https://github.com/HorusGoul/trizum/pull/263",
+    });
   });
 
   test("explains why superseding PRs exist and reports the failed local command", () => {

--- a/packages/agent-workflows/src/workflows/renovate-pr-review.ts
+++ b/packages/agent-workflows/src/workflows/renovate-pr-review.ts
@@ -78,6 +78,15 @@ export interface LocalValidationResult {
   passed: boolean;
 }
 
+export interface SupersedingPullRequestCandidate {
+  baseRefName: string;
+  body: string;
+  headRefName: string;
+  number: number;
+  title: string;
+  url: string;
+}
+
 const ORIGINAL_PR_DIRECT_UPDATE_FILES = new Set(["pnpm-lock.yaml", "pnpm-workspace.yaml"]);
 
 export const listRenovatePullRequests = createHandler(
@@ -724,12 +733,84 @@ async function commentOnPullRequest(
   );
 }
 
+async function findExistingSupersedingPullRequest(
+  options: WorkflowOptions,
+  context: PullRequestContext,
+): Promise<SupersedingPullRequestCandidate | undefined> {
+  const candidates = await ghJson<SupersedingPullRequestCandidate[]>(
+    options,
+    "pr",
+    "list",
+    "--state",
+    "open",
+    "--limit",
+    "100",
+    "--json",
+    "baseRefName,body,headRefName,number,title,url",
+  );
+
+  return selectExistingSupersedingPullRequest(
+    candidates,
+    context.pr.number,
+    context.pr.baseRefName,
+  );
+}
+
+export function selectExistingSupersedingPullRequest(
+  candidates: readonly SupersedingPullRequestCandidate[],
+  originalPrNumber: number,
+  baseRefName: string,
+): SupersedingPullRequestCandidate | undefined {
+  const matches = candidates.filter(
+    (candidate) =>
+      candidate.number !== originalPrNumber &&
+      candidate.baseRefName === baseRefName &&
+      hasSupersedesMarker(candidate.body, originalPrNumber),
+  );
+
+  return matches.sort((left, right) => left.number - right.number)[0];
+}
+
+function hasSupersedesMarker(body: string, originalPrNumber: number): boolean {
+  const marker = `Supersedes #${originalPrNumber}`;
+  return splitLines(body).some((line) => {
+    const normalizedLine = line.trim().replace(/\.$/, "");
+    return normalizedLine === marker;
+  });
+}
+
+function renderExistingSupersedingPullRequestSummary(
+  context: PullRequestContext,
+  existingPullRequest: SupersedingPullRequestCandidate,
+): string {
+  return [
+    `Reused existing superseding PR #${existingPullRequest.number} for Renovate PR #${context.pr.number}.`,
+    `Existing PR: ${existingPullRequest.url}`,
+    "Skipped creating another agent branch for the same original PR.",
+  ].join("\n");
+}
+
 async function createSupersedingPullRequest(
   options: WorkflowOptions,
   context: PullRequestContext,
   report: string,
 ): Promise<SupersedingPullRequest> {
   await ensureReadyLabel(options);
+
+  const existingSupersedingPullRequest = await findExistingSupersedingPullRequest(options, context);
+  if (existingSupersedingPullRequest != null) {
+    await addLabelToIssue(
+      options,
+      existingSupersedingPullRequest.number,
+      options.readyForHumanReviewLabel,
+    );
+
+    return {
+      branchName: existingSupersedingPullRequest.headRefName,
+      prUrl: existingSupersedingPullRequest.url,
+      summary: renderExistingSupersedingPullRequestSummary(context, existingSupersedingPullRequest),
+    };
+  }
 
   const branchName = `agent/renovate-pr-${context.pr.number}-${Date.now()}`;
   let worktreeRoot: string | undefined;


### PR DESCRIPTION
## Description

Prevents the Renovate agent workflow from creating multiple superseding PRs for the same original Renovate PR. Before running Sandcastle and creating a new branch, the workflow now looks for an open PR on the same base with the generated `Supersedes #<original>` marker, reuses the oldest match, and keeps the ready-for-human-review label applied.

## Related Issues

Related to #263
Related to #267

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

No changeset: this is internal automation behavior.

`vp run check` passes with existing PWA lint warnings unrelated to this PR.
