### PR TITLE
fix(renovate): isolate manual non-major updates

### DIFF
--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -34,11 +34,15 @@ follow-up push.
 `gitIgnoredAuthors` so Renovate keeps managing branches after the workflow adds
 its lockfile commit.
 
-Renovate groups patch and minor dependency updates into one PR to keep update
-volume manageable. Most major updates stay independent, but tightly coupled
-dependency families still have major grouping rules so packages that need to
-move together are reviewed together. `react` and `react-dom` updates are
-disabled because the app uses experimental builds that are managed manually.
+Renovate groups automergeable patch and minor dependency updates into one PR to
+keep update volume manageable. TypeScript and current 0.x patch/minor updates
+are grouped separately for manual review so they do not block automerge for
+unrelated dependencies.
+
+Most major updates stay independent, but tightly coupled dependency families
+still have major grouping rules so packages that need to move together are
+reviewed together. `react` and `react-dom` updates are disabled because the app
+uses experimental builds that are managed manually.
 
 ## Automerge
 

--- a/renovate.json
+++ b/renovate.json
@@ -19,10 +19,26 @@
       "automerge": true
     },
     {
-      "description": "Keep patch and minor dependency updates together to reduce Renovate PR volume.",
+      "description": "Keep automergeable patch and minor dependency updates together to reduce Renovate PR volume.",
       "matchUpdateTypes": ["patch", "minor"],
+      "matchPackageNames": ["!typescript"],
+      "matchCurrentVersion": "!/^0\\./",
       "groupName": "non-major dependencies",
       "groupSlug": "non-major-dependencies"
+    },
+    {
+      "description": "Keep TypeScript patch and minor updates in a manual-review non-major group.",
+      "matchUpdateTypes": ["patch", "minor"],
+      "matchPackageNames": ["typescript"],
+      "groupName": "manual non-major dependencies",
+      "groupSlug": "manual-non-major-dependencies"
+    },
+    {
+      "description": "Keep current 0.x patch and minor updates in a manual-review non-major group.",
+      "matchUpdateTypes": ["patch", "minor"],
+      "matchCurrentVersion": "/^0\\./",
+      "groupName": "manual non-major dependencies",
+      "groupSlug": "manual-non-major-dependencies"
     },
     {
       "description": "Do not update experimental React runtime packages; they are managed manually.",


### PR DESCRIPTION
## Description

Adjusts the Renovate grouping from #295 so the broad `non-major dependencies` group only contains updates that match the automerge rule: patch/minor updates excluding TypeScript and packages currently on `0.x`.

TypeScript and current-0.x patch/minor updates now share a separate `manual non-major dependencies` group. This keeps manual-review updates from preventing unrelated automergeable dependency updates from merging.

## Related Issues

Related to #295

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [x] Other (Renovate configuration)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

N/A, no UI changes.

## Additional Notes

Validation run:

- `jq empty renovate.json`
- `git diff --check`
- `corepack pnpm@11.0.0 dlx --package renovate renovate-config-validator renovate.json`
- `vp run check`
- `vp run test`
- `vp run build`

`vp run check` passed with existing unrelated warnings in PWA files.
