### PR TITLE
fix(agent-workflows): cancel stale renovate reviews

### DIFF
--- a/.github/workflows/renovate-agent-review.yml
+++ b/.github/workflows/renovate-agent-review.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('pr-{0}', inputs.pr) || format('branch-{0}', github.event.workflow_run.head_branch) }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   review:

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -68,6 +68,9 @@ The
 workflow runs after the `CI` workflow completes on a `renovate/**` branch. It
 finds the open non-draft Renovate PR for that branch.
 
+The workflow cancels older in-progress review runs for the same manual PR input
+or Renovate branch so only the newest review continues.
+
 The workflow uses `BOT_GITHUB_TOKEN` for checkout and GitHub CLI write actions,
 configures commits as `lilith[bot]`, restores Codex account auth from Bitwarden
 Secrets Manager, invokes Codex through Sandcastle, and writes the refreshed


### PR DESCRIPTION
## Description

Enables cancellation for in-progress Renovate Agent Review workflow runs that share the existing concurrency group. Manual dispatches are grouped by PR number and workflow-run triggers are grouped by Renovate branch, so a newer review for the same PR or branch now cancels the stale run.

This keeps long-running agent review automation from continuing after newer CI state has superseded it, while preserving the existing PR/branch grouping logic.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this PR changes GitHub Actions behavior and documentation only.

## Additional Notes

- No changeset is included because this is internal CI automation behavior, not a user-facing package change.
- `git diff --check` passed.
- The Renovate Agent Review workflow YAML parses successfully with Ruby/Psych.
