### PR TITLE
feat(pwa): add expense rule blocks

### DIFF
--- a/.changeset/receipt-expense-rules.md
+++ b/.changeset/receipt-expense-rules.md
@@ -1,0 +1,9 @@
+---
+"@trizum/pwa": minor
+---
+
+Add configurable expense rule blocks to party settings.
+
+Parties can configure a receipt requirement rule using expense properties, operators, and values, and the expense editor now requires an explicit override acknowledgement before saving a matching expense without a receipt.
+
+Fixes #294.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -103,6 +103,14 @@ msgstr "ADB Unit of Account"
 msgid "Add"
 msgstr "Add"
 
+#: src/components/ExpenseEditor.tsx:583
+msgid "Add a receipt or acknowledge the override before saving."
+msgstr "Add a receipt or acknowledge the override before saving."
+
+#: src/components/ExpenseEditor.tsx:180
+msgid "Add a receipt or acknowledge the receipt rule override before saving."
+msgstr "Add a receipt or acknowledge the receipt rule override before saving."
+
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:81
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:89
 msgid "Add an expense"
@@ -111,6 +119,10 @@ msgstr "Add an expense"
 #: src/components/CloudSyncAccountSettings.tsx:43
 msgid "Add Apple as a sign-in method"
 msgstr "Add Apple as a sign-in method"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:200
+msgid "Add condition"
+msgstr "Add condition"
 
 #: src/components/PartyStatsView.tsx:850
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
@@ -133,6 +145,10 @@ msgstr "Add participant"
 #: src/routes/settings_.cloud-sync.tsx:904
 msgid "Add password sign-in"
 msgstr "Add password sign-in"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:213
+msgid "Add receipt rule"
+msgstr "Add receipt rule"
 
 #: src/routes/index/-components/ProfileSetupCard.tsx:29
 msgid "Add your name so others know who you are and how to pay you"
@@ -166,7 +182,8 @@ msgstr "Align QR code here"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:451
+#: src/components/ExpenseEditor.tsx:478
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:43
 msgid "Amount"
 msgstr "Amount"
 
@@ -174,11 +191,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:769
+#: src/components/ExpenseEditor.tsx:852
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:441
+#: src/components/ExpenseEditor.tsx:468
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -274,7 +291,7 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:358
+#: src/components/ExpenseEditor.tsx:385
 #: src/routes/settings.tsx:430
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -395,6 +412,10 @@ msgstr "Brunei Dollar"
 #: src/routes/support/route.tsx:67
 msgid "Bug Reports"
 msgstr "Bug Reports"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:133
+msgid "Build rules from expense fields, conditions, and values. Matching expenses can still be saved with an acknowledged override."
+msgstr "Build rules from expense fields, conditions, and values. Matching expenses can still be saved with an acknowledged override."
 
 #: src/routes/about.tsx:90
 msgid "Built With"
@@ -582,6 +603,10 @@ msgstr "Compare how much everyone has paid across different timeframes. Settleme
 msgid "Complete your profile"
 msgstr "Complete your profile"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:292
+msgid "Condition"
+msgstr "Condition"
+
 #: src/routes/index/-components/EmptyState.tsx:43
 msgid "Configure Profile"
 msgstr "Configure Profile"
@@ -654,6 +679,10 @@ msgstr "Connections"
 #: src/routes/support/route.tsx:45
 msgid "Contact Us"
 msgstr "Contact Us"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:62
+msgid "contains"
+msgstr "contains"
 
 #: src/components/CloudSyncSignInForm.tsx:143
 msgid "Continue with Apple"
@@ -789,7 +818,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:501
+#: src/components/ExpenseEditor.tsx:528
 msgid "Date"
 msgstr "Date"
 
@@ -864,6 +893,10 @@ msgstr "Divide"
 #: src/routes/new/route.tsx:226
 msgid "Djiboutian Franc"
 msgstr "Djiboutian Franc"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:63
+msgid "does not contain"
+msgstr "does not contain"
 
 #: src/routes/new/route.tsx:227
 msgid "Dominican Peso"
@@ -1006,9 +1039,17 @@ msgstr "Exact"
 msgid "Expense added"
 msgstr "Expense added"
 
-#: src/components/ExpenseEditor.tsx:162
+#: src/components/ExpenseEditor.tsx:168
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:274
+msgid "Expense property"
+msgstr "Expense property"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:129
+msgid "Expense rules"
+msgstr "Expense rules"
 
 #: src/components/ExpenseEditor.tsx:257
 msgid "Expense Split Mode"
@@ -1027,7 +1068,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:980
+#: src/components/ExpenseEditor.tsx:1063
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1072,7 +1113,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:955
+#: src/components/ExpenseEditor.tsx:1038
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -1198,7 +1239,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:857
+#: src/components/ExpenseEditor.tsx:940
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -1251,6 +1292,10 @@ msgstr "How to pay?"
 msgid "Hungarian Forint"
 msgstr "Hungarian Forint"
 
+#: src/components/ExpenseEditor.tsx:594
+msgid "I acknowledge this expense does not include a receipt."
+msgstr "I acknowledge this expense does not include a receipt."
+
 #: src/routes/new/route.tsx:246
 msgid "Icelandic Króna"
 msgstr "Icelandic Króna"
@@ -1287,7 +1332,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:545
+#: src/components/ExpenseEditor.tsx:628
 msgid "Include all"
 msgstr "Include all"
 
@@ -1329,9 +1374,41 @@ msgstr "Iranian Rial"
 msgid "Iraqi Dinar"
 msgstr "Iraqi Dinar"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:64
+msgid "is empty"
+msgstr "is empty"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:56
+msgid "is equal to"
+msgstr "is equal to"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:58
+msgid "is greater than"
+msgstr "is greater than"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:59
+msgid "is greater than or equal to"
+msgstr "is greater than or equal to"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:60
+msgid "is less than"
+msgstr "is less than"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:61
+msgid "is less than or equal to"
+msgstr "is less than or equal to"
+
 #: src/routes/support/route.tsx:94
 msgid "Is my data secure?"
 msgstr "Is my data secure?"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:65
+msgid "is not empty"
+msgstr "is not empty"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:57
+msgid "is not equal to"
+msgstr "is not equal to"
 
 #: src/routes/new/route.tsx:189
 msgid "Israeli Shekel"
@@ -1519,7 +1596,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:349
+#: src/components/ExpenseEditor.tsx:376
 #: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:88
 #: src/routes/party.$partyId/route.tsx:174
@@ -1672,6 +1749,10 @@ msgstr "No camera found on this device"
 msgid "No cloud settings saved yet"
 msgstr "No cloud settings saved yet"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:172
+msgid "No conditions. This rule applies to every expense."
+msgstr "No conditions. This rule applies to every expense."
+
 #: src/routes/new/route.tsx:337
 msgid "No currency"
 msgstr "No currency"
@@ -1774,7 +1855,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:361
+#: src/components/ExpenseEditor.tsx:388
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1819,7 +1900,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:476
+#: src/components/ExpenseEditor.tsx:503
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -1911,7 +1992,7 @@ msgstr "Party restored to home"
 msgid "Party Settings"
 msgstr "Party Settings"
 
-#: src/routes/party_.$partyId.settings/route.tsx:55
+#: src/routes/party_.$partyId.settings/route.tsx:62
 msgid "Party settings saved!"
 msgstr "Party settings saved!"
 
@@ -2033,7 +2114,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:875
+#: src/components/ExpenseEditor.tsx:958
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -2093,6 +2174,14 @@ msgstr "Real-Time Sync"
 msgid "Receipt Attachments"
 msgstr "Receipt Attachments"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:51
+msgid "Receipt count"
+msgstr "Receipt count"
+
+#: src/components/ExpenseEditor.tsx:575
+msgid "Receipt rule"
+msgstr "Receipt rule"
+
 #: src/routes/party_.$partyId.transfer-debt/-components/DestinationParticipantCard.tsx:32
 msgid "Recommended match"
 msgstr "Recommended match"
@@ -2110,9 +2199,17 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1072
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:318
+msgid "Remove condition"
+msgstr "Remove condition"
+
+#: src/components/ExpenseEditor.tsx:1155
 msgid "Remove photo"
 msgstr "Remove photo"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:157
+msgid "Remove receipt rule"
+msgstr "Remove receipt rule"
 
 #: src/routes/about/route.tsx:94
 msgid "Report an Issue"
@@ -2121,6 +2218,14 @@ msgstr "Report an Issue"
 #: src/routes/support/route.tsx:61
 msgid "Report Issues"
 msgstr "Report Issues"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:147
+msgid "Require receipt"
+msgstr "Require receipt"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:216
+msgid "Require receipts when expense conditions match."
+msgstr "Require receipts when expense conditions match."
 
 #: src/routes/reset-password.tsx:70
 msgid "Reset password"
@@ -2179,10 +2284,10 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:277
+#: src/components/ExpenseEditor.tsx:297
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
-#: src/routes/party_.$partyId.settings/route.tsx:111
+#: src/routes/party_.$partyId.settings/route.tsx:119
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
 #: src/routes/settings.tsx:232
@@ -2282,7 +2387,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:731
+#: src/components/ExpenseEditor.tsx:814
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -2290,7 +2395,7 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:861
+#: src/components/ExpenseEditor.tsx:944
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
@@ -2448,10 +2553,10 @@ msgstr "Stop trizum cloud on this device"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:277
+#: src/components/ExpenseEditor.tsx:297
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
-#: src/routes/party_.$partyId.settings/route.tsx:111
+#: src/routes/party_.$partyId.settings/route.tsx:119
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
 #: src/routes/settings.tsx:232
@@ -2495,11 +2600,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:755
+#: src/components/ExpenseEditor.tsx:838
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:756
+#: src/components/ExpenseEditor.tsx:839
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2538,8 +2643,8 @@ msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:1000
-#: src/components/ExpenseEditor.tsx:1014
+#: src/components/ExpenseEditor.tsx:1083
+#: src/components/ExpenseEditor.tsx:1097
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2605,6 +2710,10 @@ msgstr "This device is already using trizum cloud"
 msgid "This device is synced"
 msgstr "This device is synced"
 
+#: src/components/ExpenseEditor.tsx:579
+msgid "This expense matches a rule that requires a receipt."
+msgstr "This expense matches a rule that requires a receipt."
+
 #: src/hooks/useMediaFileActions.ts:30
 msgid "This HEIC or HEIF image could not be processed. Try another photo or export it as JPEG or PNG."
 msgstr "This HEIC or HEIF image could not be processed. Try another photo or export it as JPEG or PNG."
@@ -2638,7 +2747,8 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:417
+#: src/components/ExpenseEditor.tsx:444
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:47
 msgid "Title"
 msgstr "Title"
 
@@ -2837,14 +2947,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:900
+#: src/components/ExpenseEditor.tsx:983
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1009
-#: src/components/ExpenseEditor.tsx:1026
+#: src/components/ExpenseEditor.tsx:1092
+#: src/components/ExpenseEditor.tsx:1109
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2857,7 +2967,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:940
+#: src/components/ExpenseEditor.tsx:1023
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2918,6 +3028,12 @@ msgstr "Username, phone, language, launch behavior, and accent color"
 msgid "Uzbekistan Som"
 msgstr "Uzbekistan Som"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:347
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:363
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:381
+msgid "Value"
+msgstr "Value"
+
 #: src/routes/new/route.tsx:319
 msgid "Vanuatu Vatu"
 msgstr "Vanuatu Vatu"
@@ -2942,7 +3058,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1061
+#: src/components/ExpenseEditor.tsx:1144
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"
@@ -2995,6 +3111,14 @@ msgstr "What is this party about?"
 #: src/routes/settings.tsx:359
 msgid "What's your preferred way to be addressed?"
 msgstr "What's your preferred way to be addressed?"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:167
+msgid "When"
+msgstr "When"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:151
+msgid "When all conditions match, the expense should include a receipt."
+msgstr "When all conditions match, the expense should include a receipt."
 
 #: src/routes/party_.$partyId.who.tsx:98
 msgid "Who are you?"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -99,6 +99,14 @@ msgstr "Unidad de Cuenta del BAsD"
 msgid "Add"
 msgstr "Sumar"
 
+#: src/components/ExpenseEditor.tsx:583
+msgid "Add a receipt or acknowledge the override before saving."
+msgstr "Añade un recibo o confirma la excepción antes de guardar."
+
+#: src/components/ExpenseEditor.tsx:180
+msgid "Add a receipt or acknowledge the receipt rule override before saving."
+msgstr "Añade un recibo o confirma la excepción de la regla de recibos antes de guardar."
+
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:81
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:89
 msgid "Add an expense"
@@ -107,6 +115,10 @@ msgstr "Añadir un gasto"
 #: src/components/CloudSyncAccountSettings.tsx:43
 msgid "Add Apple as a sign-in method"
 msgstr "Añadir Apple como método de inicio de sesión"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:200
+msgid "Add condition"
+msgstr "Añadir condición"
 
 #: src/components/PartyStatsView.tsx:850
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
@@ -129,6 +141,10 @@ msgstr "Añadir participante"
 #: src/routes/settings_.cloud-sync.tsx:904
 msgid "Add password sign-in"
 msgstr "Añadir inicio de sesión con contraseña"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:213
+msgid "Add receipt rule"
+msgstr "Añadir regla de recibo"
 
 #: src/routes/index/-components/ProfileSetupCard.tsx:29
 msgid "Add your name so others know who you are and how to pay you"
@@ -158,7 +174,8 @@ msgstr "Alinea el código QR aquí"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:451
+#: src/components/ExpenseEditor.tsx:478
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:43
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -166,11 +183,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:769
+#: src/components/ExpenseEditor.tsx:852
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:441
+#: src/components/ExpenseEditor.tsx:468
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -262,7 +279,7 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:358
+#: src/components/ExpenseEditor.tsx:385
 #: src/routes/settings.tsx:430
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -383,6 +400,10 @@ msgstr "Dólar de Brunéi"
 #: src/routes/support/route.tsx:67
 msgid "Bug Reports"
 msgstr "Reportar errores"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:133
+msgid "Build rules from expense fields, conditions, and values. Matching expenses can still be saved with an acknowledged override."
+msgstr "Crea reglas a partir de campos, condiciones y valores del gasto. Los gastos que coincidan aún se pueden guardar confirmando una excepción."
 
 #: src/routes/new/route.tsx:180
 msgid "Bulgarian Lev"
@@ -558,6 +579,10 @@ msgstr "Compara cuánto ha pagado cada persona en distintos períodos. Las trans
 msgid "Complete your profile"
 msgstr "Completa tu perfil"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:292
+msgid "Condition"
+msgstr "Condición"
+
 #: src/routes/index/-components/EmptyState.tsx:43
 msgid "Configure Profile"
 msgstr "Configurar perfil"
@@ -630,6 +655,10 @@ msgstr "Conexiones"
 #: src/routes/support/route.tsx:45
 msgid "Contact Us"
 msgstr "Contacto"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:62
+msgid "contains"
+msgstr "contiene"
 
 #: src/components/CloudSyncSignInForm.tsx:143
 msgid "Continue with Apple"
@@ -761,7 +790,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:501
+#: src/components/ExpenseEditor.tsx:528
 msgid "Date"
 msgstr "Fecha"
 
@@ -836,6 +865,10 @@ msgstr "Dividir"
 #: src/routes/new/route.tsx:226
 msgid "Djiboutian Franc"
 msgstr "Franco Yibutiano"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:63
+msgid "does not contain"
+msgstr "no contiene"
 
 #: src/routes/new/route.tsx:227
 msgid "Dominican Peso"
@@ -970,9 +1003,17 @@ msgstr "Por ahora todo está archivado. Puedes reabrir cualquier grupo desde la 
 msgid "Expense added"
 msgstr "Gasto añadido"
 
-#: src/components/ExpenseEditor.tsx:162
+#: src/components/ExpenseEditor.tsx:168
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:274
+msgid "Expense property"
+msgstr "Propiedad del gasto"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:129
+msgid "Expense rules"
+msgstr "Reglas de gastos"
 
 #: src/routes/party_.$partyId.expense.$expenseId_.edit.tsx:156
 msgid "Expense updated"
@@ -987,7 +1028,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:980
+#: src/components/ExpenseEditor.tsx:1063
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1028,7 +1069,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:955
+#: src/components/ExpenseEditor.tsx:1038
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -1150,7 +1191,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:857
+#: src/components/ExpenseEditor.tsx:940
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -1199,6 +1240,10 @@ msgstr "¿Cómo pagar?"
 msgid "Hungarian Forint"
 msgstr "Forinto Húngaro"
 
+#: src/components/ExpenseEditor.tsx:594
+msgid "I acknowledge this expense does not include a receipt."
+msgstr "Confirmo que este gasto no incluye un recibo."
+
 #: src/routes/new/route.tsx:246
 msgid "Icelandic Króna"
 msgstr "Corona Islandesa"
@@ -1239,7 +1284,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:545
+#: src/components/ExpenseEditor.tsx:628
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1281,9 +1326,41 @@ msgstr "Rial Iraní"
 msgid "Iraqi Dinar"
 msgstr "Dinar Iraquí"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:64
+msgid "is empty"
+msgstr "está vacío"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:56
+msgid "is equal to"
+msgstr "es igual a"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:58
+msgid "is greater than"
+msgstr "es mayor que"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:59
+msgid "is greater than or equal to"
+msgstr "es mayor o igual que"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:60
+msgid "is less than"
+msgstr "es menor que"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:61
+msgid "is less than or equal to"
+msgstr "es menor o igual que"
+
 #: src/routes/support/route.tsx:94
 msgid "Is my data secure?"
 msgstr "¿Mis datos están seguros?"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:65
+msgid "is not empty"
+msgstr "no está vacío"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:57
+msgid "is not equal to"
+msgstr "no es igual a"
 
 #: src/routes/new/route.tsx:189
 msgid "Israeli Shekel"
@@ -1467,7 +1544,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:349
+#: src/components/ExpenseEditor.tsx:376
 #: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:88
 #: src/routes/party.$partyId/route.tsx:174
@@ -1620,6 +1697,10 @@ msgstr "No se encontró cámara en este dispositivo"
 msgid "No cloud settings saved yet"
 msgstr "Todavía no hay configuración guardada en la nube"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:172
+msgid "No conditions. This rule applies to every expense."
+msgstr "Sin condiciones. Esta regla se aplica a todos los gastos."
+
 #: src/routes/new/route.tsx:337
 msgid "No currency"
 msgstr "Sin moneda"
@@ -1718,7 +1799,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:361
+#: src/components/ExpenseEditor.tsx:388
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1759,7 +1840,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:476
+#: src/components/ExpenseEditor.tsx:503
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -1843,7 +1924,7 @@ msgstr "Grupo restaurado al inicio"
 msgid "Party Settings"
 msgstr "Configuración del Grupo"
 
-#: src/routes/party_.$partyId.settings/route.tsx:55
+#: src/routes/party_.$partyId.settings/route.tsx:62
 msgid "Party settings saved!"
 msgstr "¡Configuración del grupo guardada!"
 
@@ -1965,7 +2046,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:875
+#: src/components/ExpenseEditor.tsx:958
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -2021,6 +2102,14 @@ msgstr "Listo en otro dispositivo"
 msgid "Real-Time Sync"
 msgstr "Sincronización en Tiempo Real"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:51
+msgid "Receipt count"
+msgstr "Número de recibos"
+
+#: src/components/ExpenseEditor.tsx:575
+msgid "Receipt rule"
+msgstr "Regla de recibo"
+
 #: src/routes/party_.$partyId.transfer-debt/-components/DestinationParticipantCard.tsx:32
 msgid "Recommended match"
 msgstr "Coincidencia recomendada"
@@ -2038,9 +2127,17 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1072
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:318
+msgid "Remove condition"
+msgstr "Eliminar condición"
+
+#: src/components/ExpenseEditor.tsx:1155
 msgid "Remove photo"
 msgstr "Eliminar foto"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:157
+msgid "Remove receipt rule"
+msgstr "Eliminar regla de recibo"
 
 #: src/routes/about/route.tsx:94
 msgid "Report an Issue"
@@ -2049,6 +2146,14 @@ msgstr "Reportar un Problema"
 #: src/routes/support/route.tsx:61
 msgid "Report Issues"
 msgstr "Reportar problemas"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:147
+msgid "Require receipt"
+msgstr "Requerir recibo"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:216
+msgid "Require receipts when expense conditions match."
+msgstr "Requerir recibos cuando coincidan las condiciones del gasto."
 
 #: src/routes/reset-password.tsx:70
 msgid "Reset password"
@@ -2107,10 +2212,10 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:277
+#: src/components/ExpenseEditor.tsx:297
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
-#: src/routes/party_.$partyId.settings/route.tsx:111
+#: src/routes/party_.$partyId.settings/route.tsx:119
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
 #: src/routes/settings.tsx:232
@@ -2210,7 +2315,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:731
+#: src/components/ExpenseEditor.tsx:814
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -2218,7 +2323,7 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:861
+#: src/components/ExpenseEditor.tsx:944
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
@@ -2372,10 +2477,10 @@ msgstr "Detener trizum cloud en este dispositivo"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:277
+#: src/components/ExpenseEditor.tsx:297
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
-#: src/routes/party_.$partyId.settings/route.tsx:111
+#: src/routes/party_.$partyId.settings/route.tsx:119
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
 #: src/routes/settings.tsx:232
@@ -2419,11 +2524,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:755
+#: src/components/ExpenseEditor.tsx:838
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:756
+#: src/components/ExpenseEditor.tsx:839
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2462,8 +2567,8 @@ msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:1000
-#: src/components/ExpenseEditor.tsx:1014
+#: src/components/ExpenseEditor.tsx:1083
+#: src/components/ExpenseEditor.tsx:1097
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2529,6 +2634,10 @@ msgstr "Este dispositivo ya usa trizum cloud"
 msgid "This device is synced"
 msgstr "Este dispositivo está sincronizado"
 
+#: src/components/ExpenseEditor.tsx:579
+msgid "This expense matches a rule that requires a receipt."
+msgstr "Este gasto coincide con una regla que requiere un recibo."
+
 #: src/hooks/useMediaFileActions.ts:30
 msgid "This HEIC or HEIF image could not be processed. Try another photo or export it as JPEG or PNG."
 msgstr "Esta imagen HEIC o HEIF no se pudo procesar. Prueba con otra foto o expórtala como JPEG o PNG."
@@ -2562,7 +2671,8 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:417
+#: src/components/ExpenseEditor.tsx:444
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:47
 msgid "Title"
 msgstr "Título"
 
@@ -2749,14 +2859,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:900
+#: src/components/ExpenseEditor.tsx:983
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1009
-#: src/components/ExpenseEditor.tsx:1026
+#: src/components/ExpenseEditor.tsx:1092
+#: src/components/ExpenseEditor.tsx:1109
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2764,7 +2874,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:940
+#: src/components/ExpenseEditor.tsx:1023
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2821,6 +2931,12 @@ msgstr "Nombre de usuario, teléfono, idioma, comportamiento de inicio y color d
 msgid "Uzbekistan Som"
 msgstr "Som Uzbeko"
 
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:347
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:363
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:381
+msgid "Value"
+msgstr "Valor"
+
 #: src/routes/new/route.tsx:319
 msgid "Vanuatu Vatu"
 msgstr "Vatu de Vanuatu"
@@ -2845,7 +2961,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1061
+#: src/components/ExpenseEditor.tsx:1144
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"
@@ -2894,6 +3010,14 @@ msgstr "¿De qué trata este grupo?"
 #: src/routes/settings.tsx:359
 msgid "What's your preferred way to be addressed?"
 msgstr "¿Cuál es tu forma preferida de que te llamen?"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:167
+msgid "When"
+msgstr "Cuando"
+
+#: src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx:151
+msgid "When all conditions match, the expense should include a receipt."
+msgstr "Cuando coincidan todas las condiciones, el gasto debe incluir un recibo."
 
 #: src/routes/party_.$partyId.who.tsx:98
 msgid "Who are you?"

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -15,7 +15,11 @@ import Dinero from "dinero.js";
 import { useExpenseParticipants } from "#src/hooks/useExpenseParticipants.ts";
 import { useCurrentParty } from "#src/hooks/useParty.ts";
 import { Checkbox } from "#src/ui/Checkbox.tsx";
-import type { PartyParticipant } from "#src/models/party.ts";
+import {
+  getExpenseReceiptRuleViolation,
+  type Party,
+  type PartyParticipant,
+} from "#src/models/party.ts";
 import { AppSelect, SelectItem } from "#src/ui/Select.tsx";
 import { Tooltip, TooltipTrigger } from "#src/ui/Tooltip.tsx";
 import { AppDatePicker } from "#src/ui/DatePicker.tsx";
@@ -53,6 +57,7 @@ export interface ExpenseEditorFormValues {
   paidBy: ExpenseUser;
   shares: Record<ExpenseUser, { type: "divide" | "exact"; value: number }>;
   photos: MediaFile["id"][];
+  receiptRuleOverrideAcknowledged: boolean;
 }
 
 export interface ExpenseEditorRef {
@@ -93,6 +98,7 @@ export function ExpenseEditor({
   onViewPhoto,
 }: ExpenseEditorProps) {
   const { i18n } = useLingui();
+  const { party } = useCurrentParty();
   const { partyList, setAutoOpenCalculator } = usePartyList();
   const autoOpenCalculator = partyList.autoOpenCalculator ?? false;
   const saveInFlightRef = useRef(false);
@@ -163,6 +169,18 @@ export function ExpenseEditor({
         return;
       }
 
+      const receiptRuleViolation = getExpenseReceiptRuleViolation({
+        amount: totalAmount.getAmount(),
+        photoCount: value.photos.length,
+        rules: party.expenseRules,
+        title: value.name,
+      });
+
+      if (receiptRuleViolation && !value.receiptRuleOverrideAcknowledged) {
+        toast.error(t`Add a receipt or acknowledge the receipt rule override before saving.`);
+        return;
+      }
+
       saveInFlightRef.current = true;
 
       try {
@@ -194,6 +212,8 @@ export function ExpenseEditor({
 
   const shares = useStore(form.store, (state) => state.values.shares);
   const amount = useStore(form.store, (state) => state.values.amount);
+  const name = useStore(form.store, (state) => state.values.name);
+  const photos = useStore(form.store, (state) => state.values.photos);
 
   const isReceivingUpdatesRef = useRef(false);
   const focusedFieldRef = useRef<keyof ExpenseEditorFormValues | null>(null);
@@ -307,6 +327,13 @@ export function ExpenseEditor({
           onViewPhoto={onViewPhoto}
           participants={participants}
           shouldAutoFocus={autoFocus}
+        />
+        <ReceiptRuleOverrideField
+          amount={amount}
+          form={form}
+          photos={photos}
+          rules={party.expenseRules}
+          title={name}
         />
         <ExpenseParticipantsSection
           amount={amount}
@@ -514,6 +541,62 @@ function ExpenseDetailsFields({
         )}
       </form.Field>
     </div>
+  );
+}
+
+function ReceiptRuleOverrideField({
+  amount,
+  form,
+  photos,
+  rules,
+  title,
+}: {
+  amount: number;
+  form: ExpenseEditorFormApi;
+  photos: MediaFile["id"][];
+  rules: Party["expenseRules"];
+  title: string;
+}) {
+  const violation = getExpenseReceiptRuleViolation({
+    amount: convertToUnits(amount),
+    photoCount: photos.length,
+    rules,
+    title,
+  });
+
+  if (!violation) {
+    return null;
+  }
+
+  return (
+    <Alert className="mt-4" variant="default">
+      <Icon icon="lucide.receipt-text" />
+
+      <AlertTitle>{t`Receipt rule`}</AlertTitle>
+
+      <AlertDescription>
+        <p>
+          <Trans>This expense matches a rule that requires a receipt.</Trans>
+        </p>
+
+        <p>
+          <Trans>Add a receipt or acknowledge the override before saving.</Trans>
+        </p>
+
+        <form.Field name="receiptRuleOverrideAcknowledged">
+          {(field) => (
+            <Checkbox
+              className="mt-1"
+              isSelected={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={field.handleChange}
+            >
+              <Trans>I acknowledge this expense does not include a receipt.</Trans>
+            </Checkbox>
+          )}
+        </form.Field>
+      </AlertDescription>
+    </Alert>
   );
 }
 

--- a/packages/pwa/src/hooks/useParty.ts
+++ b/packages/pwa/src/hooks/useParty.ts
@@ -13,6 +13,7 @@ import type {
   PartyExpenseChunkRef,
   PartyParticipant,
 } from "#src/models/party.js";
+import { normalizePartyExpenseRules } from "#src/models/party.js";
 import { useRepo } from "#src/lib/automerge/useRepo.ts";
 import type { DocHandle, Repo, DocumentId } from "@automerge/automerge-repo/slim";
 import { deleteAt, insertAt, isValidDocumentId } from "@automerge/automerge-repo/slim";
@@ -111,11 +112,14 @@ export function getPartyHelpers(repo: Repo, handle: DocHandle<Party>) {
     void recalculateBalances();
   }
 
-  function updateSettings(values: Pick<Party, "name" | "symbol" | "description" | "participants">) {
+  function updateSettings(
+    values: Pick<Party, "name" | "symbol" | "description" | "participants" | "expenseRules">,
+  ) {
     handle.change((doc) => {
       doc.name = values.name;
       doc.symbol = values.symbol;
       doc.description = values.description;
+      doc.expenseRules = normalizePartyExpenseRules(values.expenseRules);
       doc.participants = values.participants;
     });
   }

--- a/packages/pwa/src/models/party.test.ts
+++ b/packages/pwa/src/models/party.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "vite-plus/test";
+import {
+  createDefaultExpenseRule,
+  getDefaultPartyExpenseRules,
+  getExpenseReceiptRuleViolation,
+  normalizePartyExpenseRules,
+} from "./party";
+
+describe("normalizePartyExpenseRules", () => {
+  test("defaults missing rules to an empty rule list", () => {
+    expect(normalizePartyExpenseRules(undefined)).toStrictEqual(getDefaultPartyExpenseRules());
+  });
+
+  test("normalizes generic rule condition values", () => {
+    expect(
+      normalizePartyExpenseRules({
+        rules: [
+          {
+            action: "requireReceipt",
+            conditions: [
+              {
+                property: "amount",
+                operator: "greaterThan",
+                value: 5000.6,
+              },
+            ],
+          },
+        ],
+      }),
+    ).toStrictEqual({
+      rules: [
+        {
+          action: "requireReceipt",
+          conditions: [
+            {
+              id: expect.any(String),
+              property: "amount",
+              operator: "greaterThan",
+              value: 5001,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("converts legacy above-amount receipt rules into generic amount conditions", () => {
+    expect(
+      normalizePartyExpenseRules({
+        receiptRequirement: {
+          type: "aboveAmount",
+          amount: 10_000,
+        },
+      }),
+    ).toStrictEqual({
+      rules: [
+        {
+          action: "requireReceipt",
+          conditions: [
+            {
+              id: expect.any(String),
+              property: "amount",
+              operator: "greaterThan",
+              value: 10_000,
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("getExpenseReceiptRuleViolation", () => {
+  test("does not require receipts when rules are missing", () => {
+    expect(
+      getExpenseReceiptRuleViolation({
+        amount: 10_000,
+        photoCount: 0,
+        title: "Lunch",
+      }),
+    ).toBeNull();
+  });
+
+  test("requires a receipt when a receipt rule has no conditions", () => {
+    const rule = createDefaultExpenseRule();
+
+    expect(
+      getExpenseReceiptRuleViolation({
+        amount: 1,
+        photoCount: 0,
+        title: "Lunch",
+        rules: {
+          rules: [rule],
+        },
+      }),
+    ).toStrictEqual({
+      rule,
+    });
+  });
+
+  test("does not report a violation when a receipt is present", () => {
+    expect(
+      getExpenseReceiptRuleViolation({
+        amount: 10_000,
+        photoCount: 1,
+        title: "Lunch",
+        rules: {
+          rules: [createDefaultExpenseRule()],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("requires a receipt only when amount condition matches", () => {
+    const rules = {
+      rules: [
+        {
+          action: "requireReceipt",
+          conditions: [
+            {
+              id: "amount-condition",
+              property: "amount",
+              operator: "greaterThan",
+              value: 10_000,
+            },
+          ],
+        },
+      ],
+    } as const;
+
+    expect(
+      getExpenseReceiptRuleViolation({
+        amount: 10_000,
+        photoCount: 0,
+        title: "Lunch",
+        rules,
+      }),
+    ).toBeNull();
+
+    expect(
+      getExpenseReceiptRuleViolation({
+        amount: 10_001,
+        photoCount: 0,
+        title: "Lunch",
+        rules,
+      }),
+    ).toStrictEqual({
+      rule: rules.rules[0],
+    });
+  });
+
+  test("supports text conditions on the expense title", () => {
+    const rules = {
+      rules: [
+        {
+          action: "requireReceipt",
+          conditions: [
+            {
+              id: "title-condition",
+              property: "title",
+              operator: "contains",
+              value: "hotel",
+            },
+          ],
+        },
+      ],
+    } as const;
+
+    expect(
+      getExpenseReceiptRuleViolation({
+        amount: 10_000,
+        photoCount: 0,
+        title: "Lunch",
+        rules,
+      }),
+    ).toBeNull();
+
+    expect(
+      getExpenseReceiptRuleViolation({
+        amount: 10_000,
+        photoCount: 0,
+        title: "Hotel deposit",
+        rules,
+      }),
+    ).toStrictEqual({
+      rule: rules.rules[0],
+    });
+  });
+});

--- a/packages/pwa/src/models/party.ts
+++ b/packages/pwa/src/models/party.ts
@@ -4,6 +4,59 @@ import type { BalancesByParticipant, Expense } from "./expense";
 import type { Currency } from "dinero.js";
 import type { MediaFile } from "./media";
 
+export const EXPENSE_RULE_PROPERTIES = ["amount", "title", "receiptCount"] as const;
+export const EXPENSE_RULE_OPERATORS = [
+  "equals",
+  "notEquals",
+  "greaterThan",
+  "greaterThanOrEqual",
+  "lessThan",
+  "lessThanOrEqual",
+  "contains",
+  "doesNotContain",
+  "isEmpty",
+  "isNotEmpty",
+] as const;
+export const NUMERIC_EXPENSE_RULE_OPERATORS = [
+  "equals",
+  "notEquals",
+  "greaterThan",
+  "greaterThanOrEqual",
+  "lessThan",
+  "lessThanOrEqual",
+] as const;
+export const TEXT_EXPENSE_RULE_OPERATORS = [
+  "equals",
+  "notEquals",
+  "contains",
+  "doesNotContain",
+  "isEmpty",
+  "isNotEmpty",
+] as const;
+
+export type ExpenseRuleProperty = (typeof EXPENSE_RULE_PROPERTIES)[number];
+export type ExpenseRuleOperator = (typeof EXPENSE_RULE_OPERATORS)[number];
+export type ExpenseRuleAction = "requireReceipt";
+export type ExpenseRuleConditionValue = string | number | boolean | null;
+
+export interface ExpenseRuleCondition {
+  id: string;
+  property: ExpenseRuleProperty;
+  operator: ExpenseRuleOperator;
+  value: ExpenseRuleConditionValue;
+}
+
+export interface PartyExpenseRule {
+  action: ExpenseRuleAction;
+  conditions: ExpenseRuleCondition[];
+}
+
+export interface PartyExpenseRules {
+  rules: PartyExpenseRule[];
+}
+
+export const DEFAULT_RECEIPT_REQUIREMENT_AMOUNT = 10_000;
+
 export interface Party {
   id: DocumentId;
   type: "party";
@@ -11,6 +64,7 @@ export interface Party {
   symbol?: string;
   description: string;
   currency: Currency;
+  expenseRules?: PartyExpenseRules;
   participants: Record<ExpenseUser, PartyParticipant>;
   chunkRefs: PartyExpenseChunkRef[];
 }
@@ -49,4 +103,297 @@ export interface PartyExpenseChunkBalances {
   type: "expenseChunkBalances";
   balances: BalancesByParticipant;
   partyId: Party["id"];
+}
+
+export function getDefaultPartyExpenseRules(): PartyExpenseRules {
+  return {
+    rules: [],
+  };
+}
+
+export function getExpenseRuleOperatorsForProperty(
+  property: ExpenseRuleProperty,
+): readonly ExpenseRuleOperator[] {
+  switch (property) {
+    case "amount":
+    case "receiptCount":
+      return NUMERIC_EXPENSE_RULE_OPERATORS;
+    case "title":
+      return TEXT_EXPENSE_RULE_OPERATORS;
+  }
+}
+
+export function getDefaultExpenseRuleOperator(property: ExpenseRuleProperty): ExpenseRuleOperator {
+  switch (property) {
+    case "amount":
+    case "receiptCount":
+      return "greaterThan";
+    case "title":
+      return "contains";
+  }
+}
+
+export function doesExpenseRuleOperatorNeedValue(operator: ExpenseRuleOperator) {
+  return operator !== "isEmpty" && operator !== "isNotEmpty";
+}
+
+export function createDefaultExpenseRuleCondition(
+  property: ExpenseRuleProperty = "amount",
+): ExpenseRuleCondition {
+  return {
+    id: createExpenseRuleConditionId(),
+    property,
+    operator: getDefaultExpenseRuleOperator(property),
+    value: property === "title" ? "" : DEFAULT_RECEIPT_REQUIREMENT_AMOUNT,
+  };
+}
+
+export function createDefaultExpenseRule(): PartyExpenseRule {
+  return {
+    action: "requireReceipt",
+    conditions: [],
+  };
+}
+
+export function normalizePartyExpenseRules(expenseRules?: unknown): PartyExpenseRules {
+  const rawExpenseRules = expenseRules as
+    | { rules?: unknown; receiptRequirement?: unknown }
+    | null
+    | undefined;
+
+  if (!rawExpenseRules) {
+    return getDefaultPartyExpenseRules();
+  }
+
+  const legacyReceiptRequirement = rawExpenseRules.receiptRequirement as
+    | { type?: unknown; amount?: unknown }
+    | null
+    | undefined;
+
+  if (legacyReceiptRequirement) {
+    switch (legacyReceiptRequirement.type) {
+      case "always":
+        return {
+          rules: [createDefaultExpenseRule()],
+        };
+      case "aboveAmount":
+        return {
+          rules: [
+            {
+              action: "requireReceipt",
+              conditions: [
+                normalizeExpenseRuleCondition({
+                  property: "amount",
+                  operator: "greaterThan",
+                  value: legacyReceiptRequirement.amount,
+                }),
+              ],
+            },
+          ],
+        };
+      default:
+        return getDefaultPartyExpenseRules();
+    }
+  }
+
+  if (!Array.isArray(rawExpenseRules.rules)) {
+    return getDefaultPartyExpenseRules();
+  }
+
+  return {
+    rules: rawExpenseRules.rules
+      .map(normalizePartyExpenseRule)
+      .filter((rule): rule is PartyExpenseRule => Boolean(rule)),
+  };
+}
+
+function normalizePartyExpenseRule(rawRule: unknown): PartyExpenseRule | null {
+  const rule = rawRule as { action?: unknown; conditions?: unknown };
+
+  if (rule.action !== "requireReceipt") {
+    return null;
+  }
+
+  return {
+    action: "requireReceipt",
+    conditions: Array.isArray(rule.conditions)
+      ? rule.conditions.map((condition, index) => normalizeExpenseRuleCondition(condition, index))
+      : [],
+  };
+}
+
+export function normalizeExpenseRuleCondition(
+  rawCondition: unknown,
+  fallbackIndex?: number,
+): ExpenseRuleCondition {
+  const condition = rawCondition as {
+    id?: unknown;
+    property?: unknown;
+    operator?: unknown;
+    value?: unknown;
+  };
+  const property = isExpenseRuleProperty(condition.property) ? condition.property : "amount";
+  const allowedOperators = getExpenseRuleOperatorsForProperty(property);
+  const defaultOperator = getDefaultExpenseRuleOperator(property);
+  const operator = isStringInArray(condition.operator, allowedOperators)
+    ? condition.operator
+    : defaultOperator;
+
+  return {
+    id:
+      typeof condition.id === "string" ? condition.id : createExpenseRuleConditionId(fallbackIndex),
+    property,
+    operator,
+    value: normalizeExpenseRuleConditionValue({
+      operator,
+      property,
+      value: condition.value,
+    }),
+  };
+}
+
+function createExpenseRuleConditionId(fallbackIndex?: number) {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `condition-${fallbackIndex ?? Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function normalizeExpenseRuleConditionValue({
+  operator,
+  property,
+  value,
+}: {
+  operator: ExpenseRuleOperator;
+  property: ExpenseRuleProperty;
+  value: unknown;
+}): ExpenseRuleConditionValue {
+  if (!doesExpenseRuleOperatorNeedValue(operator)) {
+    return null;
+  }
+
+  switch (property) {
+    case "amount":
+    case "receiptCount": {
+      const numericValue = typeof value === "number" ? value : Number(value);
+      return Number.isFinite(numericValue) ? Math.max(0, Math.round(numericValue)) : 0;
+    }
+    case "title":
+      return typeof value === "string" ? value : "";
+  }
+}
+
+function isExpenseRuleProperty(value: unknown): value is ExpenseRuleProperty {
+  return isStringInArray(value, EXPENSE_RULE_PROPERTIES);
+}
+
+function isStringInArray<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+export interface ExpenseRuleEvaluationInput {
+  amount: number;
+  photoCount: number;
+  title: string;
+}
+
+export interface ExpenseReceiptRuleViolation {
+  rule: PartyExpenseRule;
+}
+
+export function getExpenseReceiptRuleViolation({
+  amount,
+  photoCount,
+  rules,
+  title,
+}: {
+  amount: number;
+  photoCount: number;
+  rules?: unknown;
+  title: string;
+}): ExpenseReceiptRuleViolation | null {
+  if (photoCount > 0) {
+    return null;
+  }
+
+  const matchingRule = normalizePartyExpenseRules(rules).rules.find((rule) => {
+    return (
+      rule.action === "requireReceipt" &&
+      doesExpenseRuleApply(rule, {
+        amount,
+        photoCount,
+        title,
+      })
+    );
+  });
+
+  return matchingRule ? { rule: matchingRule } : null;
+}
+
+export function doesExpenseRuleApply(rule: PartyExpenseRule, expense: ExpenseRuleEvaluationInput) {
+  return rule.conditions.every((condition) => doesExpenseRuleConditionApply(condition, expense));
+}
+
+function doesExpenseRuleConditionApply(
+  condition: ExpenseRuleCondition,
+  expense: ExpenseRuleEvaluationInput,
+) {
+  const normalizedCondition = normalizeExpenseRuleCondition(condition);
+  const actualValue = getExpenseRulePropertyValue(normalizedCondition.property, expense);
+  const conditionValue = normalizedCondition.value;
+
+  switch (normalizedCondition.operator) {
+    case "equals":
+      return compareConditionValues(actualValue, conditionValue) === 0;
+    case "notEquals":
+      return compareConditionValues(actualValue, conditionValue) !== 0;
+    case "greaterThan":
+      return compareConditionValues(actualValue, conditionValue) > 0;
+    case "greaterThanOrEqual":
+      return compareConditionValues(actualValue, conditionValue) >= 0;
+    case "lessThan":
+      return compareConditionValues(actualValue, conditionValue) < 0;
+    case "lessThanOrEqual":
+      return compareConditionValues(actualValue, conditionValue) <= 0;
+    case "contains":
+      return String(actualValue)
+        .toLocaleLowerCase()
+        .includes(String(conditionValue).toLocaleLowerCase());
+    case "doesNotContain":
+      return !String(actualValue)
+        .toLocaleLowerCase()
+        .includes(String(conditionValue).toLocaleLowerCase());
+    case "isEmpty":
+      return String(actualValue).trim() === "";
+    case "isNotEmpty":
+      return String(actualValue).trim() !== "";
+  }
+}
+
+function getExpenseRulePropertyValue(
+  property: ExpenseRuleProperty,
+  expense: ExpenseRuleEvaluationInput,
+) {
+  switch (property) {
+    case "amount":
+      return expense.amount;
+    case "title":
+      return expense.title;
+    case "receiptCount":
+      return expense.photoCount;
+  }
+}
+
+function compareConditionValues(
+  actualValue: ExpenseRuleConditionValue,
+  conditionValue: ExpenseRuleConditionValue,
+) {
+  if (typeof actualValue === "number" || typeof conditionValue === "number") {
+    return Number(actualValue) - Number(conditionValue);
+  }
+
+  return String(actualValue)
+    .toLocaleLowerCase()
+    .localeCompare(String(conditionValue).toLocaleLowerCase());
 }

--- a/packages/pwa/src/routes/party_.$partyId.add.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.add.tsx
@@ -118,6 +118,7 @@ function AddExpense() {
           shares: {},
           paidAt,
           photos: [],
+          receiptRuleOverrideAcknowledged: false,
         }}
         goBackFallbackOptions={{ to: "/party/$partyId" }}
         onViewPhoto={openGallery}

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit.tsx
@@ -291,6 +291,7 @@ function getFormValues(expense: Expense): ExpenseEditorFormValues {
       photos: expense.__editCopy.photos,
       amount: getExpenseTotalAmount(expense.__editCopy) / 100,
       paidBy: Object.keys(expense.__editCopy.paidBy)[0],
+      receiptRuleOverrideAcknowledged: false,
     };
   }
 
@@ -301,6 +302,7 @@ function getFormValues(expense: Expense): ExpenseEditorFormValues {
     paidBy: Object.keys(expense.paidBy)[0],
     shares: expense.shares,
     photos: expense.photos,
+    receiptRuleOverrideAcknowledged: false,
   };
 }
 

--- a/packages/pwa/src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.settings/-components/PartyExpenseRulesField.tsx
@@ -1,0 +1,394 @@
+import type { MessageDescriptor } from "@lingui/core";
+import { msg, t } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { Trans } from "@lingui/react/macro";
+import { convertToUnits } from "#src/lib/expenses.ts";
+import {
+  createDefaultExpenseRule,
+  createDefaultExpenseRuleCondition,
+  doesExpenseRuleOperatorNeedValue,
+  getExpenseRuleOperatorsForProperty,
+  normalizeExpenseRuleCondition,
+  normalizePartyExpenseRules,
+  type ExpenseRuleCondition,
+  type ExpenseRuleOperator,
+  type ExpenseRuleProperty,
+  type Party,
+  type PartyExpenseRule,
+  type PartyExpenseRules,
+} from "#src/models/party.ts";
+import { Button } from "#src/ui/Button.tsx";
+import { Icon } from "#src/ui/Icon.tsx";
+import { IconButton } from "#src/ui/IconButton.tsx";
+import { AppSelect, SelectItem } from "#src/ui/Select.tsx";
+import { AppCurrencyField, AppNumberField, AppTextField } from "#src/ui/fields/TextField.js";
+
+interface PartyExpenseRulesFieldProps {
+  currency: Party["currency"];
+  errorMessage?: string;
+  isInvalid?: boolean;
+  onBlur: () => void;
+  onChange: (value: PartyExpenseRules) => void;
+  value: PartyExpenseRules;
+}
+
+type MessageOption<T extends string> = {
+  id: T;
+  label: MessageDescriptor;
+};
+
+const EXPENSE_PROPERTY_OPTIONS = [
+  {
+    id: "amount",
+    label: msg`Amount`,
+  },
+  {
+    id: "title",
+    label: msg`Title`,
+  },
+  {
+    id: "receiptCount",
+    label: msg`Receipt count`,
+  },
+] satisfies MessageOption<ExpenseRuleProperty>[];
+
+const EXPENSE_OPERATOR_LABELS = {
+  equals: msg`is equal to`,
+  notEquals: msg`is not equal to`,
+  greaterThan: msg`is greater than`,
+  greaterThanOrEqual: msg`is greater than or equal to`,
+  lessThan: msg`is less than`,
+  lessThanOrEqual: msg`is less than or equal to`,
+  contains: msg`contains`,
+  doesNotContain: msg`does not contain`,
+  isEmpty: msg`is empty`,
+  isNotEmpty: msg`is not empty`,
+} satisfies Record<ExpenseRuleOperator, MessageDescriptor>;
+
+export function PartyExpenseRulesField({
+  currency,
+  errorMessage,
+  isInvalid,
+  onBlur,
+  onChange,
+  value,
+}: PartyExpenseRulesFieldProps) {
+  const { _ } = useLingui();
+  const expenseRules = normalizePartyExpenseRules(value);
+  const receiptRuleIndex = expenseRules.rules.findIndex((rule) => rule.action === "requireReceipt");
+  const receiptRule = receiptRuleIndex >= 0 ? expenseRules.rules[receiptRuleIndex] : null;
+
+  function setRules(rules: PartyExpenseRule[]) {
+    onChange(normalizePartyExpenseRules({ rules }));
+  }
+
+  function setReceiptRule(nextRule: PartyExpenseRule | null) {
+    const nextRules = expenseRules.rules.slice();
+
+    if (receiptRuleIndex >= 0) {
+      if (nextRule) {
+        nextRules[receiptRuleIndex] = nextRule;
+      } else {
+        nextRules.splice(receiptRuleIndex, 1);
+      }
+    } else if (nextRule) {
+      nextRules.push(nextRule);
+    }
+
+    setRules(nextRules);
+  }
+
+  function updateCondition(index: number, condition: ExpenseRuleCondition) {
+    if (!receiptRule) {
+      return;
+    }
+
+    const conditions = receiptRule.conditions.slice();
+    conditions[index] = normalizeExpenseRuleCondition(condition);
+
+    setReceiptRule({
+      ...receiptRule,
+      conditions,
+    });
+  }
+
+  function removeCondition(index: number) {
+    if (!receiptRule) {
+      return;
+    }
+
+    setReceiptRule({
+      ...receiptRule,
+      conditions: receiptRule.conditions.filter((_, conditionIndex) => conditionIndex !== index),
+    });
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-medium">
+        <Trans>Expense rules</Trans>
+      </h2>
+
+      <p className="mt-2">
+        <Trans>
+          Build rules from expense fields, conditions, and values. Matching expenses can still be
+          saved with an acknowledged override.
+        </Trans>
+      </p>
+
+      <div className="mt-4 flex flex-col gap-4">
+        {receiptRule ? (
+          <div className="rounded-lg border border-accent-500 bg-white p-4 dark:border-accent-700 dark:bg-accent-900">
+            <div className="flex items-start gap-3">
+              <Icon icon="lucide.receipt-text" className="mt-0.5 size-5 flex-shrink-0" />
+
+              <div className="min-w-0 flex-1">
+                <h3 className="font-medium">
+                  <Trans>Require receipt</Trans>
+                </h3>
+
+                <p className="mt-1 text-sm text-accent-700 dark:text-accent-50">
+                  <Trans>When all conditions match, the expense should include a receipt.</Trans>
+                </p>
+              </div>
+
+              <IconButton
+                icon="lucide.trash-2"
+                aria-label={t`Remove receipt rule`}
+                color="transparent"
+                className="h-8 w-8 flex-shrink-0"
+                iconClassName="size-4"
+                onPress={() => setReceiptRule(null)}
+              />
+            </div>
+
+            <div className="mt-4">
+              <h4 className="text-sm font-medium">
+                <Trans>When</Trans>
+              </h4>
+
+              {receiptRule.conditions.length === 0 ? (
+                <p className="mt-2 text-sm text-accent-700 dark:text-accent-50">
+                  <Trans>No conditions. This rule applies to every expense.</Trans>
+                </p>
+              ) : null}
+
+              <div className="mt-3 flex flex-col gap-3">
+                {receiptRule.conditions.map((condition, index) => (
+                  <ExpenseRuleConditionRow
+                    key={condition.id}
+                    condition={condition}
+                    currency={currency}
+                    onBlur={onBlur}
+                    onChange={(nextCondition) => updateCondition(index, nextCondition)}
+                    onRemove={() => removeCondition(index)}
+                  />
+                ))}
+              </div>
+
+              <Button
+                color="input-like"
+                className="mt-4 w-auto px-4"
+                onPress={() => {
+                  setReceiptRule({
+                    ...receiptRule,
+                    conditions: [...receiptRule.conditions, createDefaultExpenseRuleCondition()],
+                  });
+                }}
+              >
+                <Icon icon="lucide.plus" className="mr-2 size-4" />
+                <Trans>Add condition</Trans>
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button
+            color="input-like"
+            className="h-auto min-h-16 justify-start rounded-lg px-4 py-4"
+            onPress={() => setReceiptRule(createDefaultExpenseRule())}
+          >
+            <Icon icon="lucide.plus" className="mr-3 size-5" />
+            <span className="flex flex-col items-start text-left">
+              <span className="font-medium">
+                <Trans>Add receipt rule</Trans>
+              </span>
+              <span className="mt-1 text-sm text-accent-700 dark:text-accent-50">
+                <Trans>Require receipts when expense conditions match.</Trans>
+              </span>
+            </span>
+          </Button>
+        )}
+
+        {isInvalid && errorMessage ? (
+          <p className="text-sm font-medium text-danger-500">{errorMessage}</p>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function ExpenseRuleConditionRow({
+  condition,
+  currency,
+  onBlur,
+  onChange,
+  onRemove,
+}: {
+  condition: ExpenseRuleCondition;
+  currency: Party["currency"];
+  onBlur: () => void;
+  onChange: (condition: ExpenseRuleCondition) => void;
+  onRemove: () => void;
+}) {
+  const { _ } = useLingui();
+  const operatorOptions = getExpenseRuleOperatorsForProperty(condition.property).map(
+    (operator) => ({
+      id: operator,
+      label: EXPENSE_OPERATOR_LABELS[operator],
+    }),
+  );
+
+  function updateProperty(property: ExpenseRuleProperty) {
+    onChange({
+      ...createDefaultExpenseRuleCondition(property),
+      id: condition.id,
+    });
+  }
+
+  function updateOperator(operator: ExpenseRuleOperator) {
+    const defaultCondition = createDefaultExpenseRuleCondition(condition.property);
+    onChange(
+      normalizeExpenseRuleCondition({
+        ...condition,
+        operator,
+        value: doesExpenseRuleOperatorNeedValue(operator)
+          ? (condition.value ?? defaultCondition.value)
+          : null,
+      }),
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-[1fr_1fr_auto] items-end gap-2 md:grid-cols-[1fr_1fr_1fr_auto]">
+      <AppSelect<MessageOption<ExpenseRuleProperty>>
+        aria-label={t`Expense property`}
+        items={EXPENSE_PROPERTY_OPTIONS}
+        selectedKey={condition.property}
+        onBlur={onBlur}
+        onSelectionChange={(key) => {
+          if (key) {
+            updateProperty(String(key) as ExpenseRuleProperty);
+          }
+        }}
+      >
+        {(option) => (
+          <SelectItem key={option.id} value={option} textValue={_(option.label)}>
+            {_(option.label)}
+          </SelectItem>
+        )}
+      </AppSelect>
+
+      <AppSelect<MessageOption<ExpenseRuleOperator>>
+        aria-label={t`Condition`}
+        items={operatorOptions}
+        selectedKey={condition.operator}
+        onBlur={onBlur}
+        onSelectionChange={(key) => {
+          if (key) {
+            updateOperator(String(key) as ExpenseRuleOperator);
+          }
+        }}
+      >
+        {(option) => (
+          <SelectItem key={option.id} value={option} textValue={_(option.label)}>
+            {_(option.label)}
+          </SelectItem>
+        )}
+      </AppSelect>
+
+      <ConditionValueField
+        condition={condition}
+        currency={currency}
+        onBlur={onBlur}
+        onChange={onChange}
+      />
+
+      <IconButton
+        icon="lucide.x"
+        aria-label={t`Remove condition`}
+        color="input-like"
+        className="h-10 w-10"
+        iconClassName="size-4"
+        onPress={onRemove}
+      />
+    </div>
+  );
+}
+
+function ConditionValueField({
+  condition,
+  currency,
+  onBlur,
+  onChange,
+}: {
+  condition: ExpenseRuleCondition;
+  currency: Party["currency"];
+  onBlur: () => void;
+  onChange: (condition: ExpenseRuleCondition) => void;
+}) {
+  if (!doesExpenseRuleOperatorNeedValue(condition.operator)) {
+    return <div className="hidden md:block" />;
+  }
+
+  switch (condition.property) {
+    case "amount":
+      return (
+        <AppCurrencyField
+          aria-label={t`Value`}
+          value={Number(condition.value) / 100}
+          onBlur={onBlur}
+          onChange={(amount) => {
+            onChange({
+              ...condition,
+              value: Math.max(0, convertToUnits(amount)),
+            });
+          }}
+          currency={currency}
+          className="col-span-2 md:col-span-1"
+        />
+      );
+    case "receiptCount":
+      return (
+        <AppNumberField
+          aria-label={t`Value`}
+          value={Number(condition.value)}
+          minValue={0}
+          step={1}
+          inputMode="numeric"
+          onBlur={onBlur}
+          onChange={(count) => {
+            onChange({
+              ...condition,
+              value: Math.max(0, Math.round(count)),
+            });
+          }}
+          className="col-span-2 md:col-span-1"
+        />
+      );
+    case "title":
+      return (
+        <AppTextField
+          aria-label={t`Value`}
+          value={String(condition.value)}
+          onBlur={onBlur}
+          onChange={(text) => {
+            onChange({
+              ...condition,
+              value: text,
+            });
+          }}
+          className="col-span-2 md:col-span-1"
+        />
+      );
+  }
+}

--- a/packages/pwa/src/routes/party_.$partyId.settings/-components/types.ts
+++ b/packages/pwa/src/routes/party_.$partyId.settings/-components/types.ts
@@ -1,9 +1,10 @@
-import type { PartyParticipant } from "#src/models/party.js";
+import type { PartyExpenseRules, PartyParticipant } from "#src/models/party.js";
 
 export interface PartySettingsFormValues {
   name: string;
   symbol: string;
   description: string;
+  expenseRules: PartyExpenseRules;
   participants: (PartyParticipant | (PartyParticipant & { __isNew: true }))[];
 }
 

--- a/packages/pwa/src/routes/party_.$partyId.settings/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.settings/route.tsx
@@ -1,7 +1,12 @@
 import { t } from "@lingui/core/macro";
 import { useParty } from "#src/hooks/useParty.js";
 import { guardParticipatingInParty } from "#src/lib/guards.js";
-import { DEFAULT_PARTY_SYMBOL, type Party, type PartyParticipant } from "#src/models/party.js";
+import {
+  DEFAULT_PARTY_SYMBOL,
+  normalizePartyExpenseRules,
+  type Party,
+  type PartyParticipant,
+} from "#src/models/party.js";
 import { IconButton } from "#src/ui/IconButton.js";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute } from "@tanstack/react-router";
@@ -9,6 +14,7 @@ import { PartyPendingComponent } from "#src/components/PartyPendingComponent.tsx
 import { Suspense, useId } from "react";
 import { toast } from "sonner";
 import { PartyParticipantsField } from "./-components/PartyParticipantsField.js";
+import { PartyExpenseRulesField } from "./-components/PartyExpenseRulesField.js";
 import { PartySettingsDetailsFields } from "./-components/PartySettingsDetailsFields.js";
 import { PartySettingsHeader } from "./-components/PartySettingsHeader.js";
 import type {
@@ -49,6 +55,7 @@ function PartySettings() {
       name: values.name,
       symbol: values.symbol,
       description: values.description,
+      expenseRules: values.expenseRules,
       participants,
     });
 
@@ -60,6 +67,7 @@ function PartySettings() {
       name: party.name,
       symbol: party.symbol || DEFAULT_PARTY_SYMBOL,
       description: party.description,
+      expenseRules: normalizePartyExpenseRules(party.expenseRules),
       participants: Object.values(party.participants),
     } as PartySettingsFormValues,
     onSubmit: ({ value }) => {
@@ -128,6 +136,18 @@ function PartySettings() {
         className="container mt-4 flex flex-col gap-6 px-4"
       >
         <PartySettingsDetailsFields form={form} />
+        <form.Field name="expenseRules">
+          {(field) => (
+            <PartyExpenseRulesField
+              currency={party.currency}
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
+              errorMessage={field.state.meta.errors?.join(", ")}
+              isInvalid={field.state.meta.isTouched && field.state.meta.errors?.length > 0}
+            />
+          )}
+        </form.Field>
         <PartyParticipantsField
           addNewParticipant={addNewParticipant}
           addParticipantForm={addParticipantForm}


### PR DESCRIPTION
## Description

Adds a generic expense-rule block model for party settings. The first supported action is requiring receipts, with condition blocks built from expense properties, operators, and values.

The expense editor evaluates matching receipt rules against title, amount, and receipt count, and requires an explicit override acknowledgement before saving without a receipt.

## Related Issues

Related to #294

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [x] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not included. This is a draft PR; the changed UI is the party settings rule builder and the expense-editor receipt override alert.

## Additional Notes

`vp run build` completed with existing tolerated Automerge WASM, chunk-size, and plugin-timing warnings. Sentry sourcemap upload was skipped because `SENTRY_AUTH_TOKEN` is not set.