### PR TITLE
chore(deps): update dependency dinero.js to v2

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -89,7 +89,6 @@
     "@tanstack/router-plugin": "catalog:",
     "@trizum/icon-sprite": "workspace:*",
     "@trizum/tsconfig": "workspace:*",
-    "@types/dinero.js": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/packages/pwa/src/components/CurrencyContext.tsx
+++ b/packages/pwa/src/components/CurrencyContext.tsx
@@ -1,4 +1,4 @@
-import type { Currency } from "dinero.js";
+import type { Currency } from "#src/lib/money.js";
 import { createContext } from "react";
 
 export const CurrencyContext = createContext<Currency>("EUR");

--- a/packages/pwa/src/components/CurrencyText.tsx
+++ b/packages/pwa/src/components/CurrencyText.tsx
@@ -1,5 +1,5 @@
 import { cn } from "#src/ui/utils.js";
-import Dinero, { type Currency } from "dinero.js";
+import { formatMoney, type Currency } from "#src/lib/money.js";
 
 export interface CurrencyTextProps extends React.HTMLAttributes<HTMLSpanElement> {
   amount: number;
@@ -34,7 +34,7 @@ export function CurrencyText({
 
   return (
     <span className={cn(color, className)} {...props}>
-      {Dinero({ amount, currency }).setLocale("es-ES").toFormat(format)}
+      {formatMoney({ amount, currency, format, locale: "es-ES" })}
     </span>
   );
 }

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -11,7 +11,7 @@ import { AppNumberField, AppTextField } from "#src/ui/fields/TextField.js";
 import { CurrencyField } from "./CurrencyField";
 import { convertToUnits } from "#src/lib/expenses.js";
 import { toast } from "sonner";
-import Dinero from "dinero.js";
+import { createMoney as Dinero } from "#src/lib/money.js";
 import { useExpenseParticipants } from "#src/hooks/useExpenseParticipants.ts";
 import { useCurrentParty } from "#src/hooks/useParty.ts";
 import { Checkbox } from "#src/ui/Checkbox.tsx";

--- a/packages/pwa/src/lib/expenses.ts
+++ b/packages/pwa/src/lib/expenses.ts
@@ -1,4 +1,4 @@
-import Dinero from "dinero.js";
+import { createMoney as Dinero } from "#src/lib/money.js";
 
 export type ExpenseUser = string;
 

--- a/packages/pwa/src/lib/money.ts
+++ b/packages/pwa/src/lib/money.ts
@@ -1,0 +1,143 @@
+import {
+  add,
+  dinero,
+  equal,
+  greaterThan,
+  halfEven,
+  lessThan,
+  multiply as multiplyDinero,
+  subtract,
+  toDecimal,
+  toSnapshot,
+  transformScale,
+  type Dinero,
+  type DineroCurrency,
+  type DineroScaledAmount,
+} from "dinero.js";
+import * as dineroCurrencies from "dinero.js/currencies";
+
+const APP_MONEY_SCALE = 2;
+const DEFAULT_CURRENCY = "USD";
+const currencyByCode = dineroCurrencies as Record<string, DineroCurrency<number>>;
+
+export type Currency = string;
+
+export interface Money {
+  add(addend: Money): Money;
+  subtract(subtrahend: Money): Money;
+  multiply(multiplier: number): Money;
+  lessThan(comparator: Money): boolean;
+  greaterThan(comparator: Money): boolean;
+  equalsTo(comparator: Money): boolean;
+  getAmount(): number;
+  toDecimal(): string;
+}
+
+interface MoneyOptions {
+  amount: number;
+  currency?: Currency;
+}
+
+interface FormatMoneyOptions {
+  amount: number;
+  currency: Currency;
+  format: "$0.00" | "0.00";
+  locale: string;
+}
+
+class DineroMoney implements Money {
+  constructor(readonly value: Dinero<number>) {}
+
+  add(addend: Money) {
+    return new DineroMoney(add(this.value, unwrapMoney(addend)));
+  }
+
+  subtract(subtrahend: Money) {
+    return new DineroMoney(subtract(this.value, unwrapMoney(subtrahend)));
+  }
+
+  multiply(multiplier: number) {
+    const multiplied = multiplyDinero(this.value, toScaledAmount(multiplier));
+    return new DineroMoney(transformScale(multiplied, APP_MONEY_SCALE, halfEven));
+  }
+
+  lessThan(comparator: Money) {
+    return lessThan(this.value, unwrapMoney(comparator));
+  }
+
+  greaterThan(comparator: Money) {
+    return greaterThan(this.value, unwrapMoney(comparator));
+  }
+
+  equalsTo(comparator: Money) {
+    return equal(this.value, unwrapMoney(comparator));
+  }
+
+  getAmount() {
+    return toSnapshot(this.value).amount;
+  }
+
+  toDecimal() {
+    return toDecimal(this.value);
+  }
+}
+
+export function createMoney({ amount, currency = DEFAULT_CURRENCY }: MoneyOptions): Money {
+  return new DineroMoney(
+    dinero({
+      amount,
+      currency: getDineroCurrency(currency),
+      scale: APP_MONEY_SCALE,
+    }),
+  );
+}
+
+export function formatMoney({ amount, currency, format, locale }: FormatMoneyOptions) {
+  const value = Number(createMoney({ amount, currency }).toDecimal());
+  const options: Intl.NumberFormatOptions =
+    format === "$0.00"
+      ? { currency, maximumFractionDigits: 2, minimumFractionDigits: 2, style: "currency" }
+      : { maximumFractionDigits: 2, minimumFractionDigits: 2 };
+
+  return value.toLocaleString(locale, options);
+}
+
+function getDineroCurrency(currency: Currency): DineroCurrency<number> {
+  return currencyByCode[currency] ?? { base: 10, code: currency, exponent: APP_MONEY_SCALE };
+}
+
+function unwrapMoney(money: Money) {
+  return (money as DineroMoney).value;
+}
+
+function toScaledAmount(value: number): DineroScaledAmount<number> | number {
+  if (Number.isInteger(value)) {
+    return value;
+  }
+
+  const [coefficient, exponentText] = value.toString().toLowerCase().split("e");
+
+  if (exponentText === undefined) {
+    const sign = coefficient.startsWith("-") ? -1 : 1;
+    const [integerPart, fractionalPart = ""] = coefficient.replace("-", "").split(".");
+
+    return {
+      amount: sign * Number(`${integerPart}${fractionalPart}`),
+      scale: fractionalPart.length,
+    };
+  }
+
+  const sign = coefficient.startsWith("-") ? -1 : 1;
+  const [integerPart, fractionalPart = ""] = coefficient.replace("-", "").split(".");
+  const digits = `${integerPart}${fractionalPart}`;
+  const scale = fractionalPart.length - Number(exponentText);
+
+  if (scale <= 0) {
+    return sign * Number(`${digits}${"0".repeat(Math.abs(scale))}`);
+  }
+
+  return {
+    amount: sign * Number(digits),
+    scale,
+  };
+}

--- a/packages/pwa/src/models/expense.ts
+++ b/packages/pwa/src/models/expense.ts
@@ -1,7 +1,7 @@
 import { calculateLogStatsOfUser, type ExpenseInput, type ExpenseUser } from "#src/lib/expenses.js";
+import { createMoney as Dinero } from "#src/lib/money.js";
 import type { DocumentId } from "@automerge/automerge-repo";
 import { ulid } from "ulidx";
-import Dinero from "dinero.js";
 import type { MediaFile } from "./media";
 import { diff } from "@opentf/obj-diff";
 import { patchMutate } from "#src/lib/patchMutate.ts";

--- a/packages/pwa/src/models/migrationData.ts
+++ b/packages/pwa/src/models/migrationData.ts
@@ -1,4 +1,4 @@
-import type { Currency } from "dinero.js";
+import type { Currency } from "#src/lib/money.js";
 
 export interface MigrationData {
   party: {

--- a/packages/pwa/src/models/party.ts
+++ b/packages/pwa/src/models/party.ts
@@ -1,7 +1,7 @@
 import type { DocumentId } from "@automerge/automerge-repo/slim";
 import type { ExpenseUser } from "#src/lib/expenses.js";
+import type { Currency } from "#src/lib/money.js";
 import type { BalancesByParticipant, Expense } from "./expense";
-import type { Currency } from "dinero.js";
 import type { MediaFile } from "./media";
 
 export interface Party {

--- a/packages/pwa/src/routes/new/-components/NewPartyDetailsFields.tsx
+++ b/packages/pwa/src/routes/new/-components/NewPartyDetailsFields.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/core/macro";
-import type { Currency } from "dinero.js";
+import type { Currency } from "#src/lib/money.js";
 import { AppEmojiField } from "#src/components/AppEmojiField.tsx";
 import type { AppFormApi } from "#src/lib/reactFormTypes.ts";
 import {

--- a/packages/pwa/src/routes/new/-components/types.ts
+++ b/packages/pwa/src/routes/new/-components/types.ts
@@ -1,4 +1,4 @@
-import type { Currency } from "dinero.js";
+import type { Currency } from "#src/lib/money.js";
 import type { PartyParticipant } from "#src/models/party.js";
 
 export interface CurrencyOption {

--- a/packages/pwa/src/routes/new/route.tsx
+++ b/packages/pwa/src/routes/new/route.tsx
@@ -8,7 +8,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
 import { Suspense, useId, useState } from "react";
 import { toast } from "sonner";
-import type { Currency } from "dinero.js";
+import type { Currency } from "#src/lib/money.js";
 import { NewPartyDetailsFields } from "./-components/NewPartyDetailsFields.js";
 import { NewPartyHeader } from "./-components/NewPartyHeader.js";
 import { NewPartyParticipantsField } from "./-components/NewPartyParticipantsField.js";

--- a/packages/pwa/src/routes/party_.$partyId.transfer-debt/-components/TransferReviewCard.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.transfer-debt/-components/TransferReviewCard.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
-import type { Currency } from "dinero.js";
+import type { Currency } from "#src/lib/money.js";
 import { CurrencyText } from "#src/components/CurrencyText.tsx";
 import type { Party, PartyParticipant } from "#src/models/party.ts";
 import { ReviewParticipantInline, ReviewPartyRow } from "./ReviewPartyRow.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,8 +167,8 @@ catalogs:
       specifier: 1.168.18
       version: 1.168.18
     '@types/dinero.js':
-      specifier: 1.9.4
-      version: 1.9.4
+      specifier: 2.0.0
+      version: 2.0.0
     '@types/node':
       specifier: 24.13.2
       version: 24.13.2
@@ -215,8 +215,8 @@ catalogs:
       specifier: 1.7.5
       version: 1.7.5
     dinero.js:
-      specifier: 1.9.1
-      version: 1.9.1
+      specifier: 2.0.2
+      version: 2.0.2
     drizzle-kit:
       specifier: 0.31.10
       version: 0.31.10
@@ -666,7 +666,7 @@ importers:
         version: 1.7.5
       dinero.js:
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 2.0.2
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2)
@@ -778,7 +778,7 @@ importers:
         version: link:../tsconfig
       '@types/dinero.js':
         specifier: 'catalog:'
-        version: 1.9.4
+        version: 2.0.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -4556,8 +4556,9 @@ packages:
   '@types/deep-equal@1.0.4':
     resolution: {integrity: sha512-tqdiS4otQP4KmY0PR3u6KbZ5EWvhNdUoS/jc93UuK23C220lOZ/9TvjfxdPcKvqwwDVtmtSCrnr0p/2dirAxkA==}
 
-  '@types/dinero.js@1.9.4':
-    resolution: {integrity: sha512-mtJnan4ajy9MqvoJGVXu0tC9EAAzFjeoKc3d+8AW+H/Od9+8IiC59ymjrZF+JdTToyDvkLReacTsc50Z8eYr6Q==}
+  '@types/dinero.js@2.0.0':
+    resolution: {integrity: sha512-hurUZwUL8hlk9U1GsJeCk8+vQsRfU1ISU3osm0Pn1cJMfYC1cVQZ1gzNKz54CnucWQzAcUCHKsFAsJFCvMYnpw==}
+    deprecated: This is a stub types definition. dinero.js provides its own type definitions, so you do not need this installed.
 
   '@types/emscripten@1.41.5':
     resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
@@ -5815,8 +5816,9 @@ packages:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
 
-  dinero.js@1.9.1:
-    resolution: {integrity: sha512-1HXiF2vv3ZeRQ23yr+9lFxj/PbZqutuYWJnE0qfCB9xYBPnuaJ8lXtli1cJM0TvUXW1JTOaePldmqN5JVNxKSA==}
+  dinero.js@2.0.2:
+    resolution: {integrity: sha512-d+4egJTvNinkb66KSed11Daqz6MWaOHzyalLu6h3p+BLrsmwKFjHjvOKivOWeM7WyoX89te+xx4cKI6zrDtCfQ==}
+    engines: {node: '>=20.0.0'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -12729,7 +12731,7 @@ snapshots:
       capacitor-plugin-safe-area: 5.0.0(@capacitor/core@8.4.1)
       clsx: 2.1.1
       comctx: 1.7.5
-      dinero.js: 1.9.1
+      dinero.js: 2.0.2
       drizzle-orm: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2)
       emojibase: 17.0.0
       emojibase-data: 17.0.0(emojibase@17.0.0)
@@ -12855,7 +12857,9 @@ snapshots:
 
   '@types/deep-equal@1.0.4': {}
 
-  '@types/dinero.js@1.9.4': {}
+  '@types/dinero.js@2.0.0':
+    dependencies:
+      dinero.js: 2.0.2
 
   '@types/emscripten@1.41.5': {}
 
@@ -14232,7 +14236,7 @@ snapshots:
 
   diff@8.0.2: {}
 
-  dinero.js@1.9.1: {}
+  dinero.js@2.0.2: {}
 
   dir-glob@3.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,9 +166,6 @@ catalogs:
     '@tanstack/router-plugin':
       specifier: 1.168.18
       version: 1.168.18
-    '@types/dinero.js':
-      specifier: 2.0.0
-      version: 2.0.0
     '@types/node':
       specifier: 24.13.2
       version: 24.13.2
@@ -776,9 +773,6 @@ importers:
       '@trizum/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      '@types/dinero.js':
-        specifier: 'catalog:'
-        version: 2.0.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -4555,10 +4549,6 @@ packages:
 
   '@types/deep-equal@1.0.4':
     resolution: {integrity: sha512-tqdiS4otQP4KmY0PR3u6KbZ5EWvhNdUoS/jc93UuK23C220lOZ/9TvjfxdPcKvqwwDVtmtSCrnr0p/2dirAxkA==}
-
-  '@types/dinero.js@2.0.0':
-    resolution: {integrity: sha512-hurUZwUL8hlk9U1GsJeCk8+vQsRfU1ISU3osm0Pn1cJMfYC1cVQZ1gzNKz54CnucWQzAcUCHKsFAsJFCvMYnpw==}
-    deprecated: This is a stub types definition. dinero.js provides its own type definitions, so you do not need this installed.
 
   '@types/emscripten@1.41.5':
     resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
@@ -12856,10 +12846,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/deep-equal@1.0.4': {}
-
-  '@types/dinero.js@2.0.0':
-    dependencies:
-      dinero.js: 2.0.2
 
   '@types/emscripten@1.41.5': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,7 +67,7 @@ catalog:
   "@tanstack/react-router": 1.170.16
   "@tanstack/router-devtools": 1.167.0
   "@tanstack/router-plugin": 1.168.18
-  "@types/dinero.js": 1.9.4
+  "@types/dinero.js": 2.0.0
   "@types/node": 24.13.2
   "@types/react": npm:types-react@rc
   "@types/react-dom": npm:types-react-dom@rc
@@ -85,7 +85,7 @@ catalog:
   capacitor-plugin-safe-area: 5.0.0
   clsx: 2.1.1
   comctx: 1.7.5
-  dinero.js: 1.9.1
+  dinero.js: 2.0.2
   drizzle-kit: 0.31.10
   drizzle-orm: 0.45.2
   emojibase: 17.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,7 +67,6 @@ catalog:
   "@tanstack/react-router": 1.170.16
   "@tanstack/router-devtools": 1.167.0
   "@tanstack/router-plugin": 1.168.18
-  "@types/dinero.js": 2.0.0
   "@types/node": 24.13.2
   "@types/react": npm:types-react@rc
   "@types/react-dom": npm:types-react-dom@rc


### PR DESCRIPTION
Supersedes #309.
## Why
Reviewed chore(deps): update dependency dinero.js to v2 (#309); affected areas: workspace; updates: @types/dinero.js 1.9.4 -> 2.0.0, dinero.js 1.9.1 -> 2.0.2.
Not mergeable. The PR only updates dinero.js and its lockfile entries, but Dinero.js v2 is a breaking rewrite and the PWA still uses the v1 default import, string currency type, chainable methods, and formatting APIs. CI is red for exactly those incompatibilities.
- [blocker] PR checks are failing: Mobile Sync (ios), Deploy Preview, Check (test), Autofix & Extract Messages, Check (build), Mobile Sync (android), Check (check)
- [blocker] Dinero v2 migration code is missing (packages/pwa/src/components/CurrencyText.tsx): The diff updates dinero.js from 1.9.1 to 2.0.2 without migrating usage sites. The PWA still imports a default Dinero export and type Currency from dinero.js and uses v1 methods such as add, subtract, multiply, getAmount, equalsTo, lessThan, greaterThan, setLocale, and toFormat. CI confirms this with 13 type errors in vp run check and missing default expo
[truncated 203 bytes]
## What
- Updates: @types/dinero.js 1.9.4 -> 2.0.0, dinero.js 1.9.1 -> 2.0.2.
- Fix: Reused the existing superseding PR and refreshed local validation.
- Files: `.changeset/stable-tricount-imports.md`, `.github/workflows/android-internal-testing.yml`, `.github/workflows/android-playstore-deploy.yml`, `.github/workflows/ci.yml`, `.github/workflows/ios-appstore-deploy.yml`, and 28 more
## How
- Local validation: failed.
- [pass] `vp install --frozen-lockfile`
- [pass] `vp run --no-cache check`
- [fail] `vp run --no-cache test` (exit 1)
- Failed command: `vp run --no-cache test` (exit 1).
- Failure output:
```text
Error: Vitest failed to find the current suite. One of the following is possible:
Error: Vitest failed to find the current suite. One of the following is possible:
 Test Files  2 failed (2)
::error file=/tmp/trizum-renovate-existing-L7VTT2/packages/logging/src/github-actions.test.ts,title=[logging] src/github-actions.test.ts,line=45,column=1::Error: Vitest failed to find the current suite. One of the following is possible:%0A- "vitest" is imported directly without running "vitest" command%0A- "vitest" is imported inside "globalSetup" (to fix this, use "setupFiles" instead, because "globalSetup" runs in a different context)%0A- "vitest" is imported inside Vite / Vitest config file%0
[truncated 149 bytes]
::error file=/tmp/trizum-renovate-existing-L7VTT2/packages/logging/src/index.test.ts,title=[logging] src/index.test.ts,line=25,column=1::Error: Vitest failed to find the current suite. On
[truncated 420 bytes]
```
- CI on this PR is the source of truth for merge readiness.