### PR TITLE
chore(deps): update dependency tailwind-merge to v3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ catalogs:
       specifier: 12.4.0
       version: 12.4.0
     tailwind-merge:
-      specifier: 2.6.1
-      version: 2.6.1
+      specifier: 3.6.0
+      version: 3.6.0
     tailwindcss:
       specifier: 3.4.19
       version: 3.4.19
@@ -726,7 +726,7 @@ importers:
         version: 0.1.0(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       tailwind-merge:
         specifier: 'catalog:'
-        version: 2.6.1
+        version: 3.6.0
       ulidx:
         specifier: 'catalog:'
         version: 2.4.1
@@ -8511,8 +8511,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwind-merge@2.6.1:
-    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -12749,7 +12749,7 @@ snapshots:
       react-window: 2.2.7(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       sonner: 2.0.7(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       suspense: 0.1.0(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
-      tailwind-merge: 2.6.1
+      tailwind-merge: 3.6.0
       ulidx: 2.4.1
       workbox-build: 7.4.1(@types/babel__core@7.20.5)
       workbox-window: 7.4.1
@@ -17429,7 +17429,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwind-merge@2.6.1: {}
+  tailwind-merge@3.6.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.23))(@swc/wasm@1.13.3)(@types/node@24.13.2)(typescript@5.9.3))):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -120,7 +120,7 @@ catalog:
   svgexport: 0.4.2
   svgo: 4.0.1
   syncpack: 12.4.0
-  tailwind-merge: 2.6.1
+  tailwind-merge: 3.6.0
   tailwindcss: 3.4.19
   tailwindcss-animate: 1.0.7
   tailwindcss-react-aria-components: 1.2.0


### PR DESCRIPTION
Supersedes #316.
## Why
Reviewed chore(deps): update dependency tailwind-merge to v3 (#316); affected areas: workspace; updates: tailwind-merge 2.6.1 -> 3.6.0.
Blocker: this PR upgrades tailwind-merge to v3.6.0 while the workspace still uses Tailwind CSS 3.4.19. Upstream v3 explicitly drops Tailwind CSS v3 support, and the PWA uses twMerge centrally through cn(), so this can silently change class conflict resolution across shared UI despite green CI.
- [blocker] tailwind-merge v3 is incompatible with the repo's Tailwind CSS v3 setup (pnpm-workspace.yaml): The PR changes tailwind-merge from 2.6.1 to 3.6.0 in the workspace catalog, but tailwindcss remains 3.4.19. Upstream v3.0.0 release notes say v3 drops Tailwind CSS v3 support and should be upgraded together with Tailwind CSS v4; the README also says Tailwind v3 users should use tailwind-merge v2.6.x. This repo imports twMerge in packages/pwa/s
[truncated 188 bytes]
- [warning] No targeted class-merge regression coverage (packages/pwa/src/ui/utils.ts): CI is green and the lockfile is present, but there are no focused tests around packages/pwa/src/ui/utils.ts cn()/twMerge behavior. Because this dependency controls Tailwind conflict resolution for most UI components, a major-version upgrade should either be paired with the Tailwind v4 migration or covered by representative merge assertions before merge.
## What
- Updates: tailwind-merge 2.6.1 -> 3.6.0.
- Fix: Reused the existing superseding PR and refreshed local validation.
- Files: `.agents/skills/dinero-best-practices/SKILL.md`, `.agents/skills/dinero-best-practices/rules/_sections.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-allocate-not-divide.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-immutability.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-percentages.md`, and 86 more
## How
- Local validation: failed.
- [pass] `vp install --frozen-lockfile`
- [pass] `vp run --no-cache check`
- [fail] `vp run --no-cache test` (exit 1)
- Failed command: `vp run --no-cache test` (exit 1).
- Failure output:
```text
Error: Vitest failed to find the current suite. One of the following is possible:
Error: Vitest failed to find the current suite. One of the following is possible:
 Test Files  2 failed (2)
::error file=/tmp/trizum-renovate-existing-bzNLk0/packages/logging/src/github-actions.test.ts,title=[logging] src/github-actions.test.ts,line=45,column=1::Error: Vitest failed to find the current suite. One of the following is possible:%0A- "vitest" is imported directly without running "vitest" command%0A- "vitest" is imported inside "globalSetup" (to fix this, use "setupFiles" instead, because "globalSetup" runs in a different context)%0A- "vitest" is imported inside Vite / Vitest config file%0
[truncated 149 bytes]
::error file=/tmp/trizum-renovate-existing-bzNLk0/packages/logging/src/index.test.ts,title=[logging] src/index.test.ts,line=25,column=1::Error: Vitest failed to find the current suite. On
[truncated 420 bytes]
```
- CI on this PR is the source of truth for merge readiness.