### PR TITLE
chore(deps): require one-day release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
 injectWorkspacePackages: true
+minimumReleaseAge: 1440
 overrides:
   vite: "catalog:"
   esbuild: 0.28.1

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "platformAutomerge": false,
+  "minimumReleaseAge": "1 day",
   "gitIgnoredAuthors": ["259750894+PUNK-02@users.noreply.github.com"],
   "packageRules": [
     {


### PR DESCRIPTION
## Description

Configures dependency freshness checks so package updates must be at least one day old before they are selected.

- Adds Renovate `minimumReleaseAge: "1 day"`.
- Adds pnpm workspace `minimumReleaseAge: 1440` so installs and lockfile refreshes use the same 24-hour age gate.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (dependency automation config)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [ ] I've added tests for new functionality (if applicable)
- [ ] I've run `vp run lingui:extract` (if I added new strings)
- [ ] I've added a changeset (if this is a user-facing change)

## Screenshots

N/A. No UI changes.

## Additional Notes

No changeset is included because this only changes dependency automation/tooling configuration.
