### PR TITLE
chore(deps): update renovate to group tailwindcss-related deps into one

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,7 +124,7 @@ catalog:
   tailwind-merge: 2.6.1
   tailwindcss: 3.4.19
   tailwindcss-animate: 1.0.7
-  tailwindcss-react-aria-components: 2.2.0
+  tailwindcss-react-aria-components: 1.2.0
   tailwindcss-safe-area-capacitor: 0.5.1
   typescript: 6.0.3
   ulidx: 2.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,7 +124,7 @@ catalog:
   tailwind-merge: 2.6.1
   tailwindcss: 3.4.19
   tailwindcss-animate: 1.0.7
-  tailwindcss-react-aria-components: 1.2.0
+  tailwindcss-react-aria-components: 2.2.0
   tailwindcss-safe-area-capacitor: 0.5.1
   typescript: 6.0.3
   ulidx: 2.4.1

--- a/renovate.json
+++ b/renovate.json
@@ -82,14 +82,16 @@
       "groupName": "TanStack major updates"
     },
     {
+      "description": "Keep Tailwind CSS major updates with plugins that require the same Tailwind major.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["tailwindcss", "tailwindcss-react-aria-components"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Tailwind CSS major updates"
+    },
+    {
       "description": "Keep tightly coupled React Spectrum and React Aria major updates together.",
       "matchManagers": ["npm"],
-      "matchPackageNames": [
-        "@internationalized/*",
-        "react-aria",
-        "react-aria-components",
-        "tailwindcss-react-aria-components"
-      ],
+      "matchPackageNames": ["@internationalized/*", "react-aria", "react-aria-components"],
       "matchUpdateTypes": ["major"],
       "groupName": "React Spectrum major updates"
     },


### PR DESCRIPTION
Supersedes #319.
## Why
Reviewed chore(deps): update dependency tailwindcss-react-aria-components to v2 (#319); affected areas: pwa, workspace; updates: tailwindcss-react-aria-components 1.2.0 -> 2.2.0.
Blocked. The PR upgrades tailwindcss-react-aria-components to v2.2.0 without upgrading Tailwind from 3.4.19, and CI is failing during PWA CSS compilation because v2 requires Tailwind v4.
- [blocker] PR checks are failing: Check (build), Check (check), Deploy Preview, Mobile Sync (android), Mobile Sync (ios)
- [blocker] tailwindcss-react-aria-components v2 is incompatible with the current Tailwind 3 setup (pnpm-workspace.yaml): The workspace catalog still pins tailwindcss to 3.4.19 while this PR changes tailwindcss-react-aria-components to 2.2.0. npm metadata and the updated lockfile show v2.2.0 declares peerDependencies.tailwindcss as ^4.0.0, and Adobe's March 5, 2025 release notes describe the v2.0.0 line as the Tailwind v4 update. The PWA imports th
[truncated 442 bytes]
## What
- Updates: tailwindcss-react-aria-components 1.2.0 -> 2.2.0.
- Fix: Reused the existing superseding PR and refreshed local validation.
- Files: `.agents/skills/dinero-best-practices/SKILL.md`, `.agents/skills/dinero-best-practices/rules/_sections.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-allocate-not-divide.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-immutability.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-percentages.md`, and 58 more
## How
- Local validation: failed.
- [pass] `vp install --frozen-lockfile`
- [pass] `vp run --no-cache check`
- [fail] `vp run --no-cache test` (exit 1)
- Failed command: `vp run --no-cache test` (exit 1).
- Failure output:
```text
Error: Vitest failed to find the current suite. One of the following is possible:
Error: Vitest failed to find the current suite. One of the following is possible:
 Test Files  2 failed (2)
::error file=/tmp/trizum-renovate-existing-mkxCT3/packages/logging/src/github-actions.test.ts,title=[logging] src/github-actions.test.ts,line=45,column=1::Error: Vitest failed to find the current suite. One of the following is possible:%0A- "vitest" is imported directly without running "vitest" command%0A- "vitest" is imported inside "globalSetup" (to fix this, use "setupFiles" instead, because "globalSetup" runs in a different context)%0A- "vitest" is imported inside Vite / Vitest config file%0
[truncated 149 bytes]
::error file=/tmp/trizum-renovate-existing-mkxCT3/packages/logging/src/index.test.ts,title=[logging] src/index.test.ts,line=25,column=1::Error: Vitest failed to find the current suite. On
[truncated 420 bytes]
```
- CI on this PR is the source of truth for merge readiness.