### PR TITLE
chore(deps): update pnpm to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-save-prefix=''
-public-hoist-pattern[]=workbox-window
-auto-install-peers=true

--- a/package.json
+++ b/package.json
@@ -41,20 +41,5 @@
   "engines": {
     "node": "^24"
   },
-  "packageManager": "pnpm@11.9.0",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "agent-browser",
-      "@sentry-internal/node-cpu-profiler",
-      "@sentry/cli",
-      "@swc/core",
-      "cbor-extract",
-      "core-js-pure",
-      "esbuild",
-      "puppeteer",
-      "sharp",
-      "unrs-resolver",
-      "workerd"
-    ]
-  }
+  "packageManager": "pnpm@11.9.0"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "engines": {
     "node": "^24"
   },
-  "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af",
+  "packageManager": "pnpm@11.9.0",
   "pnpm": {
     "onlyBuiltDependencies": [
       "agent-browser",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,24 @@
 packages:
   - packages/*
+autoInstallPeers: true
 injectWorkspacePackages: true
 minimumReleaseAge: 1440
+publicHoistPattern:
+  - workbox-window
+savePrefix: ""
+allowBuilds:
+  "@sentry-internal/node-cpu-profiler": true
+  "@sentry/cli": true
+  "@sentry/node-cpu-profiler": true
+  "@swc/core": true
+  agent-browser: true
+  cbor-extract: true
+  core-js-pure: true
+  esbuild: true
+  puppeteer: true
+  sharp: true
+  unrs-resolver: true
+  workerd: true
 overrides:
   vite: "catalog:"
   esbuild: 0.28.1


### PR DESCRIPTION
Supersedes #325.
## Why
Reviewed chore(deps): update pnpm to v11 (#325); affected areas: workspace; updates: no parsed dependency updates.
The pnpm 11 update is not mergeable. The lockfile was refreshed, but the v11 configuration migration is incomplete and required checks fail during setup-vp because vp install exits on unapproved dependency build scripts.
- [warning] No parsed dependency update: No dependency version changes were detected in package manifests or the workspace catalog.
- [blocker] PR checks are failing: Check (test), Mobile Sync (ios), Check (check), Mobile Sync (android), Autofix & Extract Messages, Deploy Preview, react-doctor, Check (build)
## What
- Updates: chore(deps): update pnpm to v11.
- Fix: Reused the existing superseding PR and refreshed local validation.
- Files: `.agents/skills/dinero-best-practices/SKILL.md`, `.agents/skills/dinero-best-practices/rules/_sections.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-allocate-not-divide.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-immutability.md`, `.agents/skills/dinero-best-practices/rules/arithmetic-percentages.md`, and 60 more
## How
- Local validation: failed.
- [pass] `vp install --frozen-lockfile`
- [pass] `vp run --no-cache check`
- [fail] `vp run --no-cache test` (exit 1)
- Failed command: `vp run --no-cache test` (exit 1).
- Failure output:
```text
Error: Vitest failed to find the current suite. One of the following is possible:
Error: Vitest failed to find the current suite. One of the following is possible:
 Test Files  2 failed (2)
::error file=/tmp/trizum-renovate-existing-tQfs44/packages/logging/src/github-actions.test.ts,title=[logging] src/github-actions.test.ts,line=45,column=1::Error: Vitest failed to find the current suite. One of the following is possible:%0A- "vitest" is imported directly without running "vitest" command%0A- "vitest" is imported inside "globalSetup" (to fix this, use "setupFiles" instead, because "globalSetup" runs in a different context)%0A- "vitest" is imported inside Vite / Vitest config file%0
[truncated 149 bytes]
::error file=/tmp/trizum-renovate-existing-tQfs44/packages/logging/src/index.test.ts,title=[logging] src/index.test.ts,line=25,column=1::Error: Vitest failed to find the current suite. On
[truncated 420 bytes]
```
- CI on this PR is the source of truth for merge readiness.