### PR TITLE
refactor(pwa): migrate money handling to dinero v2

### DIFF
--- a/.agents/skills/dinero-best-practices/SKILL.md
+++ b/.agents/skills/dinero-best-practices/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: dinero-best-practices
+description: >
+  Core best practices for the Dinero.js money library. Use when writing,
+  reviewing, or refactoring code that creates Dinero objects, performs
+  arithmetic on monetary values, or handles money in JavaScript/TypeScript.
+  Triggers on imports from 'dinero.js', monetary calculations, or price/cost
+  handling logic.
+license: MIT
+metadata:
+  author: dinerojs
+  version: '1.0.0'
+---
+
+# Dinero.js Best Practices
+
+Core rules for working with [Dinero.js](https://v2.dinerojs.com), the JavaScript/TypeScript library for creating, calculating, and formatting money safely. Contains rules across 4 categories, prioritized by impact.
+
+## When to Apply
+
+Reference these guidelines when:
+
+- Creating Dinero objects from user input, API responses, or database values
+- Performing arithmetic on monetary values (adding, splitting, multiplying)
+- Choosing between `number` and `bigint` calculators
+- Importing from `dinero.js`, `dinero.js/currencies`, or `dinero.js/bigint`
+- Working with prices, costs, taxes, or any financial calculation
+
+## Rule Categories by Priority
+
+| Priority | Category        | Impact   | Prefix        |
+| -------- | --------------- | -------- | ------------- |
+| 1        | Object Creation | CRITICAL | `creation-`   |
+| 2        | Arithmetic      | CRITICAL | `arithmetic-` |
+| 3        | Precision       | HIGH     | `precision-`  |
+| 4        | Imports         | MEDIUM   | `imports-`    |
+
+## Quick Reference
+
+### 1. Object Creation (CRITICAL)
+
+- `creation-minor-units` - Always pass amounts as integers in minor currency units
+- `creation-from-floats` - Use a helper to convert float inputs to minor units
+- `creation-zero-exponent` - Currencies with exponent 0 (e.g., JPY) take major units directly
+
+### 2. Arithmetic (CRITICAL)
+
+- `arithmetic-immutability` - All operations return new objects; capture the return value
+- `arithmetic-allocate-not-divide` - Use `allocate` for splitting money, not manual division
+- `arithmetic-scaled-amounts` - Never multiply by a raw decimal; use scaled amounts
+- `arithmetic-percentages` - Calculate percentages with `allocate` or scaled `multiply`
+
+### 3. Precision (HIGH)
+
+- `precision-bigint` - Use `dinero.js/bigint` for amounts exceeding `Number.MAX_SAFE_INTEGER`
+- `precision-crypto` - Cryptocurrencies require bigint due to high exponents
+- `precision-trim-scale` - Use `trimScale` to remove trailing zeros after chained operations
+
+### 4. Imports (MEDIUM)
+
+- `imports-tree-shaking` - Import only what you use; standalone functions enable tree-shaking
+- `imports-bigint-currencies` - Match calculator type: use `dinero.js/bigint/currencies` with `dinero.js/bigint`
+
+## How to Use
+
+Read individual rule files for detailed explanations and code examples:
+
+```
+rules/creation-minor-units.md
+rules/arithmetic-allocate-not-divide.md
+```
+
+Each rule file contains:
+
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation
+- Additional context and references

--- a/.agents/skills/dinero-best-practices/rules/_sections.md
+++ b/.agents/skills/dinero-best-practices/rules/_sections.md
@@ -1,0 +1,26 @@
+# Sections
+
+This file defines all sections, their ordering, impact levels, and descriptions.
+The section ID (in parentheses) is the filename prefix used to group rules.
+
+---
+
+## 1. Object Creation (creation)
+
+**Impact:** CRITICAL
+**Description:** Dinero objects represent money in minor currency units as integers. Passing floats or major units silently produces wrong amounts or throws.
+
+## 2. Arithmetic (arithmetic)
+
+**Impact:** CRITICAL
+**Description:** Dinero.js uses pure functions and integer arithmetic. Forgetting immutability, using raw decimals, or dividing manually loses money.
+
+## 3. Precision (precision)
+
+**Impact:** HIGH
+**Description:** JavaScript `number` silently loses precision beyond `Number.MAX_SAFE_INTEGER`. Use bigint for large amounts or high-exponent currencies.
+
+## 4. Imports (imports)
+
+**Impact:** MEDIUM
+**Description:** Dinero.js uses standalone functions for tree-shaking and separate entry points for number vs. bigint calculators.

--- a/.agents/skills/dinero-best-practices/rules/arithmetic-allocate-not-divide.md
+++ b/.agents/skills/dinero-best-practices/rules/arithmetic-allocate-not-divide.md
@@ -1,0 +1,38 @@
+---
+title: Use allocate for Splitting Money, Not Manual Division
+impact: CRITICAL
+impactDescription: prevents lost cents from rounding
+tags: arithmetic, allocate, division, remainder
+---
+
+## Use allocate for Splitting Money, Not Manual Division
+
+When splitting money between parties, use `allocate` instead of dividing manually. `allocate` distributes remainders so no money is lost.
+
+**Incorrect (manual division loses money):**
+
+```js
+import { dinero, multiply } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const total = dinero({ amount: 1003, currency: USD }); // $10.03
+
+// Splitting three ways: 1003 / 3 = 334.33... — where does the extra cent go?
+const share = multiply(total, { amount: 1, scale: 0 }); // No good way to split evenly
+```
+
+**Correct (allocate distributes remainders):**
+
+```js
+import { dinero, allocate } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const total = dinero({ amount: 1003, currency: USD }); // $10.03
+
+const shares = allocate(total, [1, 1, 1]);
+// [$3.35, $3.34, $3.34] — extra cent goes to the first share
+```
+
+The ratios in `allocate` are relative. `[1, 1, 1]` splits evenly. `[70, 20, 10]` splits 70%/20%/10%.
+
+Reference: https://v2.dinerojs.com/api/mutations/allocate

--- a/.agents/skills/dinero-best-practices/rules/arithmetic-immutability.md
+++ b/.agents/skills/dinero-best-practices/rules/arithmetic-immutability.md
@@ -1,0 +1,38 @@
+---
+title: Capture Return Values — Dinero Objects Are Immutable
+impact: CRITICAL
+impactDescription: prevents silently lost calculations
+tags: arithmetic, immutability, pure-functions
+---
+
+## Capture Return Values — Dinero Objects Are Immutable
+
+All Dinero.js operations are pure functions that return new objects. The original objects are never modified. Discarding the return value means losing your calculation.
+
+**Incorrect (discarding the return value):**
+
+```js
+import { dinero, add } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1000, currency: USD });
+const tax = dinero({ amount: 100, currency: USD });
+
+add(price, tax); // Return value discarded — price is unchanged
+```
+
+**Correct (capturing the result):**
+
+```js
+import { dinero, add } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1000, currency: USD });
+const tax = dinero({ amount: 100, currency: USD });
+
+const total = add(price, tax); // $11.00
+```
+
+This applies to all operations: `add`, `subtract`, `multiply`, `allocate`, `convert`, `trimScale`, `transformScale`, and `normalizeScale`.
+
+Reference: https://v2.dinerojs.com/core-concepts/mutations

--- a/.agents/skills/dinero-best-practices/rules/arithmetic-percentages.md
+++ b/.agents/skills/dinero-best-practices/rules/arithmetic-percentages.md
@@ -1,0 +1,44 @@
+---
+title: Calculate Percentages with allocate or Scaled multiply
+impact: HIGH
+impactDescription: prevents precision loss and thrown errors on percentage calculations
+tags: arithmetic, percentages, tax, discount
+---
+
+## Calculate Percentages with allocate or Scaled multiply
+
+There are two safe ways to calculate percentages of a monetary value: `allocate` (for splitting into complementary parts) and `multiply` with a scaled amount (for extracting a percentage).
+
+**Incorrect (float percentage):**
+
+```js
+import { dinero, multiply } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const subtotal = dinero({ amount: 5000, currency: USD });
+const tax = multiply(subtotal, 0.15); // Risky: may throw if result is non-integer
+```
+
+**Correct (allocate for complementary parts):**
+
+```js
+import { dinero, allocate } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const subtotal = dinero({ amount: 5000, currency: USD });
+const [tax, net] = allocate(subtotal, [15, 85]); // 15% tax, 85% net
+```
+
+**Correct (scaled multiply for a single percentage):**
+
+```js
+import { dinero, multiply } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const subtotal = dinero({ amount: 5000, currency: USD });
+const tax = multiply(subtotal, { amount: 15, scale: 2 }); // 15/100 = 15%
+```
+
+Use `allocate` when you need both parts (e.g., tax and net) to guarantee they sum to the original. Use `multiply` when you only need one part.
+
+Reference: https://v2.dinerojs.com/guides/calculating-percentages

--- a/.agents/skills/dinero-best-practices/rules/arithmetic-scaled-amounts.md
+++ b/.agents/skills/dinero-best-practices/rules/arithmetic-scaled-amounts.md
@@ -1,0 +1,41 @@
+---
+title: Never Multiply by a Raw Decimal — Use Scaled Amounts
+impact: CRITICAL
+impactDescription: prevents throws from non-integer intermediate results
+tags: arithmetic, multiply, scaled-amounts, decimals
+---
+
+## Never Multiply by a Raw Decimal — Use Scaled Amounts
+
+Dinero.js uses integer arithmetic. Multiplying by a decimal that produces a non-integer result will throw. Use scaled amounts instead: `{ amount, scale }` represents `amount / (base ^ scale)`.
+
+**Incorrect (raw decimal multiplier):**
+
+```js
+import { dinero, multiply } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1001, currency: USD });
+multiply(price, 0.5); // Throws: 1001 * 0.5 = 500.5 (not an integer)
+```
+
+**Correct (scaled amount):**
+
+```js
+import { dinero, multiply } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1001, currency: USD });
+multiply(price, { amount: 5, scale: 1 }); // 5/10 = 0.5, result: amount 5005, scale 3
+```
+
+Common scaled amounts:
+
+| Decimal | Scaled amount              |
+| ------- | -------------------------- |
+| 0.5     | `{ amount: 5, scale: 1 }`  |
+| 0.1     | `{ amount: 1, scale: 1 }`  |
+| 0.15    | `{ amount: 15, scale: 2 }` |
+| 1.5     | `{ amount: 15, scale: 1 }` |
+
+Reference: https://v2.dinerojs.com/faq/can-i-multiply-by-a-decimal

--- a/.agents/skills/dinero-best-practices/rules/creation-from-floats.md
+++ b/.agents/skills/dinero-best-practices/rules/creation-from-floats.md
@@ -1,0 +1,41 @@
+---
+title: Convert Float Inputs to Minor Units with a Helper
+impact: CRITICAL
+impactDescription: prevents throws and precision bugs from float inputs
+tags: creation, floats, conversion, external-input
+---
+
+## Convert Float Inputs to Minor Units with a Helper
+
+When receiving float values from external sources (APIs, user input, databases), convert them to integer minor units before creating a Dinero object. Never pass floats directly.
+
+**Incorrect (passing a float directly):**
+
+```js
+import { dinero } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const priceFromApi = 19.99;
+const d = dinero({ amount: priceFromApi, currency: USD }); // Throws
+```
+
+**Correct (converting with a helper):**
+
+```js
+import { dinero } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+function dineroFromFloat({ amount: float, currency, scale }) {
+  const factor = currency.base ** (scale ?? currency.exponent);
+  const amount = Math.round(float * factor);
+
+  return dinero({ amount, currency, scale });
+}
+
+const priceFromApi = 19.99;
+const d = dineroFromFloat({ amount: priceFromApi, currency: USD }); // $19.99
+```
+
+`Math.round` is necessary to avoid floating-point artifacts (e.g., `19.99 * 100` evaluates to `1998.9999999999998` in JavaScript).
+
+Reference: https://v2.dinerojs.com/guides/creating-from-floats

--- a/.agents/skills/dinero-best-practices/rules/creation-minor-units.md
+++ b/.agents/skills/dinero-best-practices/rules/creation-minor-units.md
@@ -1,0 +1,35 @@
+---
+title: Always Pass Amounts as Integers in Minor Currency Units
+impact: CRITICAL
+impactDescription: prevents silent off-by-100x errors
+tags: creation, amount, minor-units, cents
+---
+
+## Always Pass Amounts as Integers in Minor Currency Units
+
+Dinero.js represents money in the smallest subdivision of a currency. For USD (exponent 2), the amount is in cents. Passing a major-unit value silently creates the wrong amount.
+
+**Incorrect (passing major units or floats):**
+
+```js
+import { dinero } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+// Wrong: 50 cents, not 50 dollars
+const d = dinero({ amount: 50, currency: USD });
+
+// Wrong: throws on non-integer
+const d = dinero({ amount: 19.99, currency: USD });
+```
+
+**Correct (minor units as integers):**
+
+```js
+import { dinero } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const d1 = dinero({ amount: 5000, currency: USD }); // $50.00
+const d2 = dinero({ amount: 1999, currency: USD }); // $19.99
+```
+
+Reference: https://v2.dinerojs.com/core-concepts/amount

--- a/.agents/skills/dinero-best-practices/rules/creation-zero-exponent.md
+++ b/.agents/skills/dinero-best-practices/rules/creation-zero-exponent.md
@@ -1,0 +1,34 @@
+---
+title: Currencies with Exponent 0 Take Major Units Directly
+impact: HIGH
+impactDescription: prevents wrong amounts for JPY, KRW, and similar currencies
+tags: creation, exponent, jpy, zero-decimal
+---
+
+## Currencies with Exponent 0 Take Major Units Directly
+
+Currencies like JPY and KRW have no minor units (exponent 0). The amount you pass is in major units directly.
+
+**Incorrect (treating JPY like USD):**
+
+```js
+import { dinero } from 'dinero.js';
+import { JPY } from 'dinero.js/currencies';
+
+// Wrong: this is 500,000 yen, not 5,000 yen
+const d = dinero({ amount: 500000, currency: JPY });
+```
+
+**Correct (major units for zero-exponent currencies):**
+
+```js
+import { dinero } from 'dinero.js';
+import { JPY } from 'dinero.js/currencies';
+
+// JPY has exponent 0, so 5000 means 5,000 yen
+const d = dinero({ amount: 5000, currency: JPY });
+```
+
+Check a currency's `exponent` property to determine the expected unit. USD has exponent 2 (cents), BHD has exponent 3 (fils), JPY has exponent 0 (yen).
+
+Reference: https://v2.dinerojs.com/core-concepts/amount

--- a/.agents/skills/dinero-best-practices/rules/imports-bigint-currencies.md
+++ b/.agents/skills/dinero-best-practices/rules/imports-bigint-currencies.md
@@ -1,0 +1,36 @@
+---
+title: Match Calculator Type — Use Matching Currency Imports
+impact: HIGH
+impactDescription: prevents TypeError from mixing number and bigint arithmetic
+tags: imports, bigint, currencies, type-mismatch
+---
+
+## Match Calculator Type — Use Matching Currency Imports
+
+Currency definitions from `dinero.js/currencies` use `number` for `base` and `exponent`. Currency definitions from `dinero.js/bigint/currencies` use `bigint`. Mixing them throws a `TypeError`.
+
+**Incorrect (mixing number currencies with bigint calculator):**
+
+```js
+import { dinero } from 'dinero.js/bigint';
+import { USD } from 'dinero.js/currencies'; // number-typed
+
+// TypeError: Cannot mix BigInt and other types
+const d = dinero({ amount: 500n, currency: USD });
+```
+
+**Correct (matching imports):**
+
+```js
+// Number calculator + number currencies
+import { dinero } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+const d = dinero({ amount: 500, currency: USD });
+
+// Bigint calculator + bigint currencies
+import { dinero } from 'dinero.js/bigint';
+import { USD } from 'dinero.js/bigint/currencies';
+const d = dinero({ amount: 500n, currency: USD });
+```
+
+Reference: https://v2.dinerojs.com/faq/why-cant-i-use-currencies-with-bigint

--- a/.agents/skills/dinero-best-practices/rules/imports-tree-shaking.md
+++ b/.agents/skills/dinero-best-practices/rules/imports-tree-shaking.md
@@ -1,0 +1,31 @@
+---
+title: Import Only What You Use — Standalone Functions Enable Tree-Shaking
+impact: MEDIUM
+impactDescription: reduces bundle size by excluding unused operations
+tags: imports, tree-shaking, bundle-size, functions
+---
+
+## Import Only What You Use — Standalone Functions Enable Tree-Shaking
+
+Dinero.js exports standalone functions instead of methods on objects. This means bundlers can eliminate unused code. Import only the functions you need.
+
+**How it works:**
+
+```js
+// Only add, toDecimal, and dinero are included in your bundle
+import { dinero, add, toDecimal } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const total = add(
+  dinero({ amount: 1000, currency: USD }),
+  dinero({ amount: 500, currency: USD }),
+);
+
+toDecimal(total); // "15.00"
+```
+
+Functions like `multiply`, `allocate`, `compare`, `greaterThan`, etc. are not shipped if you don't import them.
+
+Note: Dinero.js uses standalone functions, not methods. Write `add(d1, d2)`, not `d1.add(d2)`.
+
+Reference: https://v2.dinerojs.com/faq/why-functions-instead-of-methods

--- a/.agents/skills/dinero-best-practices/rules/precision-bigint.md
+++ b/.agents/skills/dinero-best-practices/rules/precision-bigint.md
@@ -1,0 +1,33 @@
+---
+title: Use bigint for Amounts Exceeding Number.MAX_SAFE_INTEGER
+impact: HIGH
+impactDescription: prevents silent precision loss on large monetary values
+tags: precision, bigint, large-amounts, safe-integer
+---
+
+## Use bigint for Amounts Exceeding Number.MAX_SAFE_INTEGER
+
+JavaScript `number` silently loses precision beyond `Number.MAX_SAFE_INTEGER` (9,007,199,254,740,991). For large monetary values, use the bigint entry point.
+
+**Incorrect (large amount with number calculator):**
+
+```js
+import { dinero } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+// 25800000000000000 exceeds safe integer range — silently wrong
+const d = dinero({ amount: 25800000000000000, currency: USD });
+```
+
+**Correct (bigint calculator):**
+
+```js
+import { dinero } from 'dinero.js/bigint';
+import { USD } from 'dinero.js/bigint/currencies';
+
+const d = dinero({ amount: 25800000000000000n, currency: USD });
+```
+
+Note: `dinero.js/bigint` uses its own currency definitions where `base` and `exponent` are bigint values. Always import currencies from `dinero.js/bigint/currencies` when using the bigint calculator.
+
+Reference: https://v2.dinerojs.com/guides/precision-and-large-numbers

--- a/.agents/skills/dinero-best-practices/rules/precision-crypto.md
+++ b/.agents/skills/dinero-best-practices/rules/precision-crypto.md
@@ -1,0 +1,33 @@
+---
+title: Cryptocurrencies Require bigint Due to High Exponents
+impact: HIGH
+impactDescription: prevents overflow on crypto amounts (e.g., 1 ETH = 10^18 wei)
+tags: precision, bigint, cryptocurrency, ethereum, bitcoin
+---
+
+## Cryptocurrencies Require bigint Due to High Exponents
+
+Cryptocurrencies like ETH (exponent 18) and BTC (exponent 8) produce amounts that exceed the safe integer range even for small values. Always use the bigint calculator for crypto.
+
+**Incorrect (number calculator for ETH):**
+
+```js
+import { dinero } from 'dinero.js';
+
+const ETH = { code: 'ETH', base: 10, exponent: 18 };
+// 1 ETH = 1000000000000000000 wei — exceeds Number.MAX_SAFE_INTEGER
+const d = dinero({ amount: 1000000000000000000, currency: ETH });
+```
+
+**Correct (bigint calculator):**
+
+```js
+import { dinero } from 'dinero.js/bigint';
+
+const ETH = { code: 'ETH', base: 10n, exponent: 18n };
+const d = dinero({ amount: 1000000000000000000n, currency: ETH });
+```
+
+Avoid naming files after cryptocurrency ticker codes (e.g., `xbt.js`, `xmr.js`). Ad blockers may flag these file names as crypto mining scripts and block them from loading.
+
+Reference: https://v2.dinerojs.com/guides/cryptocurrencies

--- a/.agents/skills/dinero-best-practices/rules/precision-trim-scale.md
+++ b/.agents/skills/dinero-best-practices/rules/precision-trim-scale.md
@@ -1,0 +1,32 @@
+---
+title: Use trimScale to Remove Trailing Zeros After Chained Operations
+impact: MEDIUM
+impactDescription: prevents unnecessary scale growth from chained operations
+tags: precision, scale, trim, chained-operations
+---
+
+## Use trimScale to Remove Trailing Zeros After Chained Operations
+
+Dinero.js automatically promotes to the highest scale when combining objects with different scales. Over many operations, scale can grow unnecessarily. Use `trimScale` to drop trailing zeros.
+
+**Before trimming:**
+
+```js
+import { dinero, add, trimScale } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const d1 = dinero({ amount: 100, currency: USD });
+const d2 = dinero({ amount: 2000000, currency: USD, scale: 6 });
+
+const result = add(d1, d2); // amount: 3000000, scale: 6
+```
+
+**After trimming:**
+
+```js
+const trimmed = trimScale(result); // amount: 300, scale: 2
+```
+
+This is especially useful before serialization (storing or transporting) where compact representation matters.
+
+Reference: https://v2.dinerojs.com/api/conversions/trim-scale

--- a/.agents/skills/dinero-currency-patterns/SKILL.md
+++ b/.agents/skills/dinero-currency-patterns/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dinero-currency-patterns
+description: >
+  Currency handling patterns for the Dinero.js money library. Use when working
+  with multiple currencies, converting between currencies, defining custom
+  currencies, storing monetary values in databases, or integrating with payment
+  services like Stripe or PayPal. Triggers on currency conversion, database
+  schema design for money, or payment API integration with Dinero objects.
+license: MIT
+metadata:
+  author: dinerojs
+  version: '1.0.0'
+---
+
+# Dinero.js Currency Patterns
+
+Patterns for handling currencies with [Dinero.js](https://v2.dinerojs.com): type safety, conversions, custom currencies, database storage, and payment service integration.
+
+## When to Apply
+
+Reference these guidelines when:
+
+- Converting between currencies with `convert`
+- Defining custom currencies (e.g., cryptocurrencies, loyalty points)
+- Looking up currencies dynamically from external input
+- Storing monetary values in a database
+- Integrating with payment services (Stripe, PayPal, Square)
+
+## Rule Categories by Priority
+
+| Priority | Category            | Impact | Prefix     |
+| -------- | ------------------- | ------ | ---------- |
+| 1        | Type Safety         | HIGH   | `types-`   |
+| 2        | Conversion          | HIGH   | `convert-` |
+| 3        | Storage             | HIGH   | `storage-` |
+| 4        | Payment Integration | MEDIUM | `payment-` |
+
+## Quick Reference
+
+### 1. Type Safety (HIGH)
+
+- `types-as-const` - Define custom currencies with `as const satisfies` for compile-time safety
+- `types-currency-mismatch` - TypeScript catches currency mismatches in operations at compile time
+- `types-lookup-validation` - Validate currency codes from external sources at runtime
+
+### 2. Conversion (HIGH)
+
+- `convert-scaled-rates` - Use scaled amounts for fractional exchange rates, not floats
+- `convert-reusable` - Build reusable converter functions with higher-order patterns
+
+### 3. Storage (HIGH)
+
+- `storage-database` - Store amount, currency code, and scale as separate columns
+- `storage-no-money-type` - Avoid PostgreSQL's `money` type for multi-currency applications
+
+### 4. Payment Integration (MEDIUM)
+
+- `payment-services` - Map Dinero objects to payment service formats with dedicated helpers
+
+## How to Use
+
+Read individual rule files for detailed explanations and code examples:
+
+```
+rules/types-as-const.md
+rules/convert-scaled-rates.md
+```
+
+Each rule file contains:
+
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation
+- Additional context and references

--- a/.agents/skills/dinero-currency-patterns/rules/_sections.md
+++ b/.agents/skills/dinero-currency-patterns/rules/_sections.md
@@ -1,0 +1,26 @@
+# Sections
+
+This file defines all sections, their ordering, impact levels, and descriptions.
+The section ID (in parentheses) is the filename prefix used to group rules.
+
+---
+
+## 1. Type Safety (types)
+
+**Impact:** HIGH
+**Description:** Using TypeScript's type system to catch currency mismatches at compile time and validating dynamic currency codes at runtime.
+
+## 2. Conversion (convert)
+
+**Impact:** HIGH
+**Description:** Converting between currencies safely using scaled rates and building reusable converters.
+
+## 3. Storage (storage)
+
+**Impact:** HIGH
+**Description:** Persisting monetary values in databases with the right schema design.
+
+## 4. Payment Integration (payment)
+
+**Impact:** MEDIUM
+**Description:** Mapping Dinero objects to the specific formats required by payment services.

--- a/.agents/skills/dinero-currency-patterns/rules/convert-reusable.md
+++ b/.agents/skills/dinero-currency-patterns/rules/convert-reusable.md
@@ -1,0 +1,33 @@
+---
+title: Build Reusable Converter Functions
+impact: MEDIUM
+impactDescription: eliminates repeated rate passing across conversion call sites
+tags: convert, reusable, higher-order, pattern
+---
+
+## Build Reusable Converter Functions
+
+When converting many objects with the same rates, wrap `convert` in a higher-order function to avoid passing rates every time.
+
+**Correct (reusable converter):**
+
+```js
+import { dinero, convert } from 'dinero.js';
+import { USD, EUR } from 'dinero.js/currencies';
+
+function createConverter(rates) {
+  return function converter(dineroObject, newCurrency) {
+    return convert(dineroObject, newCurrency, rates);
+  };
+}
+
+const rates = { EUR: { amount: 89, scale: 2 } };
+const convertWithRates = createConverter(rates);
+
+const price = dinero({ amount: 500, currency: USD });
+convertWithRates(price, EUR); // Dinero object in EUR
+```
+
+This pattern works well when rates are fetched once per request or session and reused across multiple conversions.
+
+Reference: https://v2.dinerojs.com/api/conversions/convert

--- a/.agents/skills/dinero-currency-patterns/rules/convert-scaled-rates.md
+++ b/.agents/skills/dinero-currency-patterns/rules/convert-scaled-rates.md
@@ -1,0 +1,41 @@
+---
+title: Use Scaled Amounts for Fractional Exchange Rates, Not Floats
+impact: HIGH
+impactDescription: prevents precision loss from floating-point exchange rates
+tags: convert, rates, scaled-amounts, exchange-rate
+---
+
+## Use Scaled Amounts for Fractional Exchange Rates, Not Floats
+
+When converting between currencies, fractional exchange rates should be passed as scaled amounts (`{ amount, scale }`) instead of floats. This avoids floating-point precision issues.
+
+**Incorrect (float rate):**
+
+```js
+import { dinero, convert } from 'dinero.js';
+import { USD, EUR } from 'dinero.js/currencies';
+
+const rates = { EUR: 0.89 }; // Float — imprecise
+const d = dinero({ amount: 500, currency: USD });
+convert(d, EUR, rates);
+```
+
+**Correct (scaled rate):**
+
+```js
+import { dinero, convert } from 'dinero.js';
+import { USD, EUR } from 'dinero.js/currencies';
+
+const rates = { EUR: { amount: 89, scale: 2 } }; // 89/100 = 0.89 — precise
+const d = dinero({ amount: 500, currency: USD });
+convert(d, EUR, rates); // Dinero object with amount 44500, scale 4
+```
+
+Integer rates can be passed directly without scaling:
+
+```js
+const rates = { IQD: 1199 }; // 1 USD = 1199 IQD (integer, no scaling needed)
+convert(d, IQD, rates);
+```
+
+Reference: https://v2.dinerojs.com/api/conversions/convert

--- a/.agents/skills/dinero-currency-patterns/rules/payment-services.md
+++ b/.agents/skills/dinero-currency-patterns/rules/payment-services.md
@@ -1,0 +1,65 @@
+---
+title: Map Dinero Objects to Payment Service Formats with Dedicated Helpers
+impact: MEDIUM
+impactDescription: prevents payment API errors from wrong amount/currency formats
+tags: payment, stripe, paypal, square, integration
+---
+
+## Map Dinero Objects to Payment Service Formats with Dedicated Helpers
+
+Each payment service expects a different money format. Build dedicated helper functions to convert Dinero objects to the right shape.
+
+**Stripe (minor units, lowercase currency):**
+
+```js
+import { toSnapshot } from 'dinero.js';
+
+function toStripeMoney(dineroObject) {
+  const { amount, currency } = toSnapshot(dineroObject);
+
+  return {
+    amount,
+    currency: currency.code.toLowerCase(),
+  };
+}
+
+// { amount: 1999, currency: 'usd' }
+```
+
+**PayPal (decimal string, uppercase currency):**
+
+```js
+import { toSnapshot, toDecimal } from 'dinero.js';
+
+function toPaypalMoney(dineroObject) {
+  const { currency } = toSnapshot(dineroObject);
+
+  return {
+    value: toDecimal(dineroObject),
+    currency_code: currency.code,
+  };
+}
+
+// { value: '19.99', currency_code: 'USD' }
+```
+
+**Square (BigInt amount, uppercase currency):**
+
+```js
+import { toSnapshot } from 'dinero.js';
+
+function toSquareMoney(dineroObject) {
+  const { amount, currency } = toSnapshot(dineroObject);
+
+  return {
+    amount: BigInt(amount),
+    currency: currency.code,
+  };
+}
+
+// { amount: 1999n, currency: 'USD' }
+```
+
+Keep these helpers in a single module (e.g., `lib/money.js`) so format changes only need updating in one place.
+
+Reference: https://v2.dinerojs.com/guides/integrating-with-payment-services

--- a/.agents/skills/dinero-currency-patterns/rules/storage-database.md
+++ b/.agents/skills/dinero-currency-patterns/rules/storage-database.md
@@ -1,0 +1,43 @@
+---
+title: Store Amount, Currency Code, and Scale as Separate Columns
+impact: HIGH
+impactDescription: prevents data loss and enables correct restoration of Dinero objects
+tags: storage, database, schema, columns, restoration
+---
+
+## Store Amount, Currency Code, and Scale as Separate Columns
+
+Store each component of a Dinero object separately. This is portable across databases and preserves all information needed for reconstruction.
+
+**Correct (SQL schema):**
+
+```sql
+CREATE TABLE products (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  price_amount BIGINT NOT NULL,
+  price_currency VARCHAR(3) NOT NULL,
+  price_scale INTEGER NOT NULL DEFAULT 2
+);
+```
+
+**Correct (restoration from database row):**
+
+```js
+import { dinero } from 'dinero.js';
+import { getCurrency } from './currencies'; // Your validation helper
+
+function dineroFromRow(row) {
+  const currency = getCurrency(row.price_currency);
+
+  return dinero({
+    amount: row.price_amount,
+    currency,
+    scale: row.price_scale,
+  });
+}
+```
+
+Always store the `scale`, not just the currency exponent. If a Dinero object was created with a custom scale (e.g., from a `multiply` with a scaled amount), restoring with just the exponent produces the wrong value.
+
+Reference: https://v2.dinerojs.com/guides/storing-in-a-database

--- a/.agents/skills/dinero-currency-patterns/rules/storage-no-money-type.md
+++ b/.agents/skills/dinero-currency-patterns/rules/storage-no-money-type.md
@@ -1,0 +1,34 @@
+---
+title: Avoid PostgreSQL's money Type for Multi-Currency Applications
+impact: HIGH
+impactDescription: prevents locale-dependent bugs and precision loss
+tags: storage, database, postgresql, money-type
+---
+
+## Avoid PostgreSQL's money Type for Multi-Currency Applications
+
+PostgreSQL's `money` type has no currency information, is locale-dependent, and has fixed 2-decimal precision. It fails for currencies with 0 decimals (JPY), 3 decimals (BHD), or multi-currency support.
+
+**Incorrect (PostgreSQL money type):**
+
+```sql
+CREATE TABLE products (
+  id SERIAL PRIMARY KEY,
+  price MONEY NOT NULL -- No currency info, locale-dependent, fixed precision
+);
+```
+
+**Correct (separate columns):**
+
+```sql
+CREATE TABLE products (
+  id SERIAL PRIMARY KEY,
+  price_amount BIGINT NOT NULL,
+  price_currency VARCHAR(3) NOT NULL,
+  price_scale INTEGER NOT NULL DEFAULT 2
+);
+```
+
+The same advice applies to other database-specific money types. Use standard integer and string columns for maximum portability and control.
+
+Reference: https://v2.dinerojs.com/guides/storing-in-a-database

--- a/.agents/skills/dinero-currency-patterns/rules/types-as-const.md
+++ b/.agents/skills/dinero-currency-patterns/rules/types-as-const.md
@@ -1,0 +1,44 @@
+---
+title: Define Custom Currencies with as const satisfies for Type Safety
+impact: HIGH
+impactDescription: enables compile-time currency mismatch detection
+tags: types, currency, typescript, as-const, custom-currency
+---
+
+## Define Custom Currencies with as const satisfies for Type Safety
+
+When defining custom currencies (e.g., cryptocurrencies, loyalty points), use `as const satisfies` to get a literal type for the `code` property. Without it, TypeScript infers `string`, losing compile-time currency mismatch detection.
+
+**Incorrect (code inferred as string):**
+
+```ts
+import type { Currency } from 'dinero.js';
+
+const BTC = { code: 'BTC', base: 10, exponent: 8 };
+// typeof BTC.code is string, not 'BTC'
+```
+
+**Correct (literal type with as const satisfies):**
+
+```ts
+import type { Currency } from 'dinero.js';
+
+const BTC = {
+  code: 'BTC',
+  base: 10,
+  exponent: 8,
+} as const satisfies Currency<number, 'BTC'>;
+// typeof BTC.code is 'BTC'
+```
+
+With literal types, TypeScript catches mistakes like adding BTC and USD at compile time:
+
+```ts
+const btcAmount = dinero({ amount: 100000000, currency: BTC });
+const usdAmount = dinero({ amount: 500, currency: USD });
+add(btcAmount, usdAmount); // Type error: 'USD' is not assignable to 'BTC'
+```
+
+All built-in currencies from `dinero.js/currencies` already have literal types.
+
+Reference: https://v2.dinerojs.com/guides/currency-type-safety

--- a/.agents/skills/dinero-currency-patterns/rules/types-currency-mismatch.md
+++ b/.agents/skills/dinero-currency-patterns/rules/types-currency-mismatch.md
@@ -1,0 +1,41 @@
+---
+title: TypeScript Catches Currency Mismatches at Compile Time
+impact: HIGH
+impactDescription: prevents adding, subtracting, or comparing different currencies
+tags: types, currency, mismatch, compile-time, typescript
+---
+
+## TypeScript Catches Currency Mismatches at Compile Time
+
+When using typed currencies, TypeScript prevents operations between different currencies. This catches bugs that would otherwise only fail at runtime.
+
+**Caught at compile time:**
+
+```ts
+import { dinero, add, subtract, equal } from 'dinero.js';
+import { USD, EUR } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 500, currency: USD }); // Dinero<number, 'USD'>
+const tax = dinero({ amount: 100, currency: EUR }); // Dinero<number, 'EUR'>
+
+add(price, tax); // Type error: 'EUR' is not assignable to 'USD'
+subtract(price, tax); // Type error
+equal(price, tax); // Type error
+```
+
+**Currency type preserved through operations:**
+
+```ts
+import { dinero, multiply, convert } from 'dinero.js';
+import { USD, EUR } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 500, currency: USD });
+const doubled = multiply(price, 2); // Dinero<number, 'USD'> — preserved
+const converted = convert(price, EUR, rates); // Dinero<number, 'EUR'> — changed
+
+add(doubled, converted); // Type error: 'EUR' is not assignable to 'USD'
+```
+
+Unary operations (`multiply`, `allocate`, `trimScale`) preserve the currency type. `convert` changes it to the target currency.
+
+Reference: https://v2.dinerojs.com/guides/currency-type-safety

--- a/.agents/skills/dinero-currency-patterns/rules/types-lookup-validation.md
+++ b/.agents/skills/dinero-currency-patterns/rules/types-lookup-validation.md
@@ -1,0 +1,45 @@
+---
+title: Validate Currency Codes from External Sources at Runtime
+impact: HIGH
+impactDescription: prevents undefined currency errors from invalid or unknown codes
+tags: types, validation, runtime, lookup, external-input
+---
+
+## Validate Currency Codes from External Sources at Runtime
+
+Currency codes from APIs, databases, or user input may be invalid. Always validate before looking up a currency definition.
+
+**Incorrect (direct lookup without validation):**
+
+```ts
+import * as currencies from 'dinero.js/currencies';
+
+function createPrice(amount: number, code: string) {
+  const currency = currencies[code]; // May be undefined
+  return dinero({ amount, currency }); // Runtime error
+}
+```
+
+**Correct (validate before lookup):**
+
+```ts
+import { dinero } from 'dinero.js';
+import * as currencies from 'dinero.js/currencies';
+
+function getCurrency(code: string) {
+  if (!(code in currencies)) {
+    throw new Error(`Unknown currency code: ${code}`);
+  }
+
+  return currencies[code as keyof typeof currencies];
+}
+
+function createPrice(amount: number, code: string) {
+  const currency = getCurrency(code);
+  return dinero({ amount, currency });
+}
+```
+
+Currency codes may also change between Dinero.js versions, as the library tracks ISO 4217 amendments. Pin your package version if you need stability.
+
+Reference: https://v2.dinerojs.com/faq/how-to-look-up-a-currency-by-code

--- a/.agents/skills/dinero-formatting/SKILL.md
+++ b/.agents/skills/dinero-formatting/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: dinero-formatting
+description: >
+  Formatting patterns for the Dinero.js money library. Use when displaying
+  monetary values to users, formatting prices with currency symbols, handling
+  locale-specific number formats, or working with non-decimal currencies.
+  Triggers on toDecimal, toUnits, toSnapshot calls, or Intl.NumberFormat
+  usage with Dinero objects.
+license: MIT
+metadata:
+  author: dinerojs
+  version: '1.0.0'
+---
+
+# Dinero.js Formatting
+
+Patterns for formatting [Dinero.js](https://v2.dinerojs.com) monetary values for display. Covers currency symbols, locale-aware formatting, non-decimal currencies, and serialization.
+
+## When to Apply
+
+Reference these guidelines when:
+
+- Displaying prices, totals, or monetary values in a UI
+- Adding currency symbols or locale-specific formatting
+- Formatting non-decimal currencies (e.g., historical currencies with non-base-10 subdivisions)
+- Serializing Dinero objects for APIs, databases, or transport
+- Building reusable formatting utilities
+
+## Rule Categories by Priority
+
+| Priority | Category      | Impact   | Prefix           |
+| -------- | ------------- | -------- | ---------------- |
+| 1        | Display       | CRITICAL | `display-`       |
+| 2        | Locale        | HIGH     | `locale-`        |
+| 3        | Serialization | HIGH     | `serialization-` |
+| 4        | Non-Decimal   | MEDIUM   | `nondecimal-`    |
+
+## Quick Reference
+
+### 1. Display (CRITICAL)
+
+- `display-to-decimal` - Use `toDecimal` for display strings, not `toSnapshot`
+- `display-no-currency-symbols` - Dinero.js does not format currency symbols; compose with `Intl.NumberFormat`
+
+### 2. Locale (HIGH)
+
+- `locale-intl-formatter` - Build reusable formatters with `Intl.NumberFormat`
+- `locale-multilingual` - Create locale-parameterized formatters for multilingual sites
+
+### 3. Serialization (HIGH)
+
+- `serialization-snapshot` - Use `toSnapshot` for transport and storage, not display
+- `serialization-bigint-json` - BigInt Dinero objects require a custom JSON replacer
+
+### 4. Non-Decimal (MEDIUM)
+
+- `nondecimal-to-units` - Use `toUnits` for non-decimal currencies, not `toDecimal`
+
+## How to Use
+
+Read individual rule files for detailed explanations and code examples:
+
+```
+rules/display-no-currency-symbols.md
+rules/locale-intl-formatter.md
+```
+
+Each rule file contains:
+
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation
+- Additional context and references

--- a/.agents/skills/dinero-formatting/rules/_sections.md
+++ b/.agents/skills/dinero-formatting/rules/_sections.md
@@ -1,0 +1,26 @@
+# Sections
+
+This file defines all sections, their ordering, impact levels, and descriptions.
+The section ID (in parentheses) is the filename prefix used to group rules.
+
+---
+
+## 1. Display (display)
+
+**Impact:** CRITICAL
+**Description:** Choosing the right formatting function and understanding that Dinero.js does not include currency symbols by design.
+
+## 2. Locale (locale)
+
+**Impact:** HIGH
+**Description:** Composing Dinero.js with `Intl.NumberFormat` for locale-aware currency formatting across languages and regions.
+
+## 3. Serialization (serialization)
+
+**Impact:** HIGH
+**Description:** Using the right output function for transport vs. display, and handling bigint serialization.
+
+## 4. Non-Decimal (nondecimal)
+
+**Impact:** MEDIUM
+**Description:** Formatting currencies with non-base-10 subdivisions using `toUnits` instead of `toDecimal`.

--- a/.agents/skills/dinero-formatting/rules/display-no-currency-symbols.md
+++ b/.agents/skills/dinero-formatting/rules/display-no-currency-symbols.md
@@ -1,0 +1,38 @@
+---
+title: Dinero.js Does Not Format Currency Symbols — Compose with Intl.NumberFormat
+impact: CRITICAL
+impactDescription: prevents missing currency symbols in UI
+tags: display, currency-symbols, intl, numberformat
+---
+
+## Dinero.js Does Not Format Currency Symbols — Compose with Intl.NumberFormat
+
+`toDecimal` returns a plain decimal string like `"19.99"`, not `"$19.99"`. This is by design: currency formatting varies by locale (`$19.99` in en-US, `19,99 $US` in fr-CA, `19,99 $` in fr-FR). Use `toDecimal` with a transformer to add locale-aware formatting.
+
+**Incorrect (expecting currency symbols from toDecimal):**
+
+```js
+import { dinero, toDecimal } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1999, currency: USD });
+toDecimal(price); // "19.99" — no currency symbol
+```
+
+**Correct (composing with Intl.NumberFormat):**
+
+```js
+import { dinero, toDecimal } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1999, currency: USD });
+
+toDecimal(price, ({ value, currency }) => {
+  return Number(value).toLocaleString('en-US', {
+    style: 'currency',
+    currency: currency.code,
+  });
+}); // "$19.99"
+```
+
+Reference: https://v2.dinerojs.com/faq/why-no-currency-formatting

--- a/.agents/skills/dinero-formatting/rules/display-to-decimal.md
+++ b/.agents/skills/dinero-formatting/rules/display-to-decimal.md
@@ -1,0 +1,35 @@
+---
+title: Use toDecimal for Display Strings, Not toSnapshot
+impact: CRITICAL
+impactDescription: prevents displaying raw minor-unit amounts to users
+tags: display, toDecimal, toSnapshot, formatting
+---
+
+## Use toDecimal for Display Strings, Not toSnapshot
+
+`toDecimal` returns a human-readable decimal string (e.g., `"19.99"`). `toSnapshot` returns the raw internal representation in minor units (e.g., `{ amount: 1999, ... }`). Use the right one for the right job.
+
+**Incorrect (using toSnapshot for display):**
+
+```js
+import { dinero, toSnapshot } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1999, currency: USD });
+const { amount } = toSnapshot(price);
+display.textContent = `$${amount}`; // Shows "$1999" — wrong
+```
+
+**Correct (using toDecimal for display):**
+
+```js
+import { dinero, toDecimal } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1999, currency: USD });
+toDecimal(price); // "19.99"
+```
+
+`toSnapshot` is for serialization (APIs, databases, transport). `toDecimal` is for rendering to users.
+
+Reference: https://v2.dinerojs.com/core-concepts/formatting

--- a/.agents/skills/dinero-formatting/rules/locale-intl-formatter.md
+++ b/.agents/skills/dinero-formatting/rules/locale-intl-formatter.md
@@ -1,0 +1,47 @@
+---
+title: Build Reusable Formatters with Intl.NumberFormat
+impact: HIGH
+impactDescription: eliminates duplicated formatting logic across the codebase
+tags: locale, formatter, intl, reusable, higher-order
+---
+
+## Build Reusable Formatters with Intl.NumberFormat
+
+Instead of inlining `Intl.NumberFormat` at every call site, build a reusable formatter function.
+
+**Correct (reusable formatter):**
+
+```js
+import { toDecimal } from 'dinero.js';
+
+function intlFormat(dineroObject, locale, options = {}) {
+  function transformer({ value, currency }) {
+    return Number(value).toLocaleString(locale, {
+      ...options,
+      style: 'currency',
+      currency: currency.code,
+    });
+  }
+
+  return toDecimal(dineroObject, transformer);
+}
+
+intlFormat(price, 'en-US'); // "$19.99"
+intlFormat(price, 'fr-FR'); // "19,99 $US"
+intlFormat(price, 'ja-JP'); // "$19.99"
+```
+
+You can also create a higher-order function that bakes in the locale:
+
+```js
+function createFormatter(locale, options = {}) {
+  return function format(dineroObject) {
+    return intlFormat(dineroObject, locale, options);
+  };
+}
+
+const formatUSD = createFormatter('en-US');
+formatUSD(price); // "$19.99"
+```
+
+Reference: https://v2.dinerojs.com/guides/formatting-in-a-multilingual-site

--- a/.agents/skills/dinero-formatting/rules/locale-multilingual.md
+++ b/.agents/skills/dinero-formatting/rules/locale-multilingual.md
@@ -1,0 +1,44 @@
+---
+title: Parameterize Locale for Multilingual Sites
+impact: HIGH
+impactDescription: prevents hardcoded locale strings in formatting logic
+tags: locale, multilingual, i18n, internationalization
+---
+
+## Parameterize Locale for Multilingual Sites
+
+In multilingual applications, pass the locale as a parameter rather than hardcoding it. This lets you format the same Dinero object differently depending on the user's language.
+
+**Incorrect (hardcoded locale):**
+
+```js
+function formatPrice(dineroObject) {
+  return toDecimal(dineroObject, ({ value, currency }) => {
+    return Number(value).toLocaleString('en-US', {
+      style: 'currency',
+      currency: currency.code,
+    });
+  });
+}
+```
+
+**Correct (locale as parameter):**
+
+```js
+function formatPrice(dineroObject, locale) {
+  return toDecimal(dineroObject, ({ value, currency }) => {
+    return Number(value).toLocaleString(locale, {
+      style: 'currency',
+      currency: currency.code,
+    });
+  });
+}
+
+formatPrice(price, 'en-US'); // "$19.99"
+formatPrice(price, 'de-DE'); // "19,99 $"
+formatPrice(price, 'ja-JP'); // "$19.99"
+```
+
+In React, you can get the locale from your i18n context (e.g., `next-intl`, `react-intl`, `react-i18next`) and pass it to your formatter.
+
+Reference: https://v2.dinerojs.com/guides/formatting-in-a-multilingual-site

--- a/.agents/skills/dinero-formatting/rules/nondecimal-to-units.md
+++ b/.agents/skills/dinero-formatting/rules/nondecimal-to-units.md
@@ -1,0 +1,42 @@
+---
+title: Use toUnits for Non-Decimal Currencies, Not toDecimal
+impact: MEDIUM
+impactDescription: prevents wrong output for currencies with non-base-10 subdivisions
+tags: nondecimal, toUnits, formatting, historical-currencies
+---
+
+## Use toUnits for Non-Decimal Currencies, Not toDecimal
+
+`toDecimal` assumes a decimal (base 10) currency. For currencies with non-decimal subdivisions (e.g., base 6, base 12, or multi-base like pre-decimal GBP), use `toUnits`.
+
+**Incorrect (toDecimal on non-decimal currency):**
+
+```js
+import { dinero, toDecimal } from 'dinero.js';
+
+const GRD = { code: 'GRD', base: 6, exponent: 1 };
+const d = dinero({ amount: 9, currency: GRD });
+
+toDecimal(d); // Throws or produces meaningless output
+```
+
+**Correct (toUnits with a custom transformer):**
+
+```js
+import { dinero, toUnits } from 'dinero.js';
+
+const GRD = { code: 'GRD', base: 6, exponent: 1 };
+const d = dinero({ amount: 9, currency: GRD });
+const labels = ['drachma', 'obol'];
+
+toUnits(d, ({ value }) =>
+  value
+    .filter((v) => v > 0)
+    .map((v, i) => `${v} ${labels[i]}`)
+    .join(', '),
+); // "1 drachma, 3 obols"
+```
+
+`toUnits` returns an array of unit values, one per subdivision level. It works with any base, including array bases like `[20, 12]` for pre-decimal GBP (pounds, shillings, pence).
+
+Reference: https://v2.dinerojs.com/guides/formatting-non-decimal-currencies

--- a/.agents/skills/dinero-formatting/rules/serialization-bigint-json.md
+++ b/.agents/skills/dinero-formatting/rules/serialization-bigint-json.md
@@ -1,0 +1,50 @@
+---
+title: BigInt Dinero Objects Require a Custom JSON Replacer
+impact: HIGH
+impactDescription: prevents TypeError when serializing bigint Dinero objects
+tags: serialization, bigint, json, stringify, replacer
+---
+
+## BigInt Dinero Objects Require a Custom JSON Replacer
+
+`JSON.stringify` throws a `TypeError` on bigint values. When using the bigint calculator, provide a custom replacer.
+
+**Incorrect (stringify without replacer):**
+
+```js
+import { dinero, toSnapshot } from 'dinero.js/bigint';
+import { USD } from 'dinero.js/bigint/currencies';
+
+const price = dinero({ amount: 500n, currency: USD });
+JSON.stringify(toSnapshot(price)); // TypeError: Do not know how to serialize a BigInt
+```
+
+**Correct (with replacer):**
+
+```js
+import { dinero, toSnapshot } from 'dinero.js/bigint';
+import { USD } from 'dinero.js/bigint/currencies';
+
+const price = dinero({ amount: 500n, currency: USD });
+
+JSON.stringify(toSnapshot(price), (key, value) => {
+  if (typeof value === 'bigint') {
+    return String(value);
+  }
+  return value;
+});
+```
+
+When restoring, convert string values back to bigint:
+
+```js
+const data = JSON.parse(json, (key, value) => {
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    return BigInt(value);
+  }
+  return value;
+});
+const restored = dinero(data.price);
+```
+
+Reference: https://v2.dinerojs.com/guides/transporting-and-restoring

--- a/.agents/skills/dinero-formatting/rules/serialization-snapshot.md
+++ b/.agents/skills/dinero-formatting/rules/serialization-snapshot.md
@@ -1,0 +1,40 @@
+---
+title: Use toSnapshot for Transport and Storage, Not Display
+impact: HIGH
+impactDescription: prevents data loss from using display-oriented functions for serialization
+tags: serialization, toSnapshot, transport, storage, json
+---
+
+## Use toSnapshot for Transport and Storage, Not Display
+
+`toSnapshot` returns the full internal representation as a plain object, suitable for JSON serialization. Use it for APIs, databases, and transport. Use `toDecimal` for user-facing display.
+
+**Correct (serialization with toSnapshot):**
+
+```js
+import { dinero, toSnapshot } from 'dinero.js';
+import { USD } from 'dinero.js/currencies';
+
+const price = dinero({ amount: 1999, currency: USD });
+const snapshot = toSnapshot(price);
+// { amount: 1999, currency: { code: 'USD', base: 10, exponent: 2 }, scale: 2 }
+
+// Send to API
+await fetch('/api/products', {
+  method: 'POST',
+  body: JSON.stringify({ price: snapshot }),
+});
+```
+
+**Correct (restoring from snapshot):**
+
+```js
+import { dinero } from 'dinero.js';
+
+// The snapshot can be passed directly to dinero()
+const restored = dinero(data.price);
+```
+
+Snapshots are plain objects with no methods, making them safe for `JSON.stringify`, database columns, and cross-service communication.
+
+Reference: https://v2.dinerojs.com/guides/transporting-and-restoring

--- a/.changeset/migrate-dinero-v2.md
+++ b/.changeset/migrate-dinero-v2.md
@@ -1,0 +1,10 @@
+---
+"@trizum/mobile": patch
+"@trizum/pwa": patch
+---
+
+Migrate app money calculations and formatting from Dinero.js v1 to Dinero.js v2.
+
+- Updates the PWA to use Dinero v2 standalone functions and snapshots.
+- Keeps Trizum's existing expense-share rounding behavior covered by tests.
+- Adds formatting and currency-boundary tests for the migration.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -166,7 +166,7 @@ msgstr "Align QR code here"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:451
+#: src/components/ExpenseEditor.tsx:449
 msgid "Amount"
 msgstr "Amount"
 
@@ -174,11 +174,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:769
+#: src/components/ExpenseEditor.tsx:767
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:441
+#: src/components/ExpenseEditor.tsx:439
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -274,7 +274,7 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:358
+#: src/components/ExpenseEditor.tsx:356
 #: src/routes/settings.tsx:430
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -789,7 +789,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:501
+#: src/components/ExpenseEditor.tsx:499
 msgid "Date"
 msgstr "Date"
 
@@ -1006,7 +1006,7 @@ msgstr "Exact"
 msgid "Expense added"
 msgstr "Expense added"
 
-#: src/components/ExpenseEditor.tsx:162
+#: src/components/ExpenseEditor.tsx:160
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
@@ -1027,7 +1027,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:980
+#: src/components/ExpenseEditor.tsx:978
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1072,7 +1072,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:955
+#: src/components/ExpenseEditor.tsx:953
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -1198,7 +1198,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:857
+#: src/components/ExpenseEditor.tsx:855
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -1287,7 +1287,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:545
+#: src/components/ExpenseEditor.tsx:543
 msgid "Include all"
 msgstr "Include all"
 
@@ -1519,7 +1519,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:349
+#: src/components/ExpenseEditor.tsx:347
 #: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:88
 #: src/routes/party.$partyId/route.tsx:174
@@ -1774,7 +1774,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:361
+#: src/components/ExpenseEditor.tsx:359
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1819,7 +1819,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:476
+#: src/components/ExpenseEditor.tsx:474
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -2033,7 +2033,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:875
+#: src/components/ExpenseEditor.tsx:873
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -2110,7 +2110,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1072
+#: src/components/ExpenseEditor.tsx:1070
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2179,7 +2179,7 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:277
+#: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:111
@@ -2282,7 +2282,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:731
+#: src/components/ExpenseEditor.tsx:729
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -2290,7 +2290,7 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:861
+#: src/components/ExpenseEditor.tsx:859
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
@@ -2448,7 +2448,7 @@ msgstr "Stop trizum cloud on this device"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:277
+#: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:111
@@ -2495,11 +2495,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:755
+#: src/components/ExpenseEditor.tsx:753
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:756
+#: src/components/ExpenseEditor.tsx:754
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2538,8 +2538,8 @@ msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:1000
-#: src/components/ExpenseEditor.tsx:1014
+#: src/components/ExpenseEditor.tsx:998
+#: src/components/ExpenseEditor.tsx:1012
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2638,7 +2638,7 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:417
+#: src/components/ExpenseEditor.tsx:415
 msgid "Title"
 msgstr "Title"
 
@@ -2837,14 +2837,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:900
+#: src/components/ExpenseEditor.tsx:898
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1009
-#: src/components/ExpenseEditor.tsx:1026
+#: src/components/ExpenseEditor.tsx:1007
+#: src/components/ExpenseEditor.tsx:1024
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2857,7 +2857,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:940
+#: src/components/ExpenseEditor.tsx:938
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2942,7 +2942,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1061
+#: src/components/ExpenseEditor.tsx:1059
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -158,7 +158,7 @@ msgstr "Alinea el código QR aquí"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:451
+#: src/components/ExpenseEditor.tsx:449
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -166,11 +166,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:769
+#: src/components/ExpenseEditor.tsx:767
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:441
+#: src/components/ExpenseEditor.tsx:439
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -262,7 +262,7 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:358
+#: src/components/ExpenseEditor.tsx:356
 #: src/routes/settings.tsx:430
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -761,7 +761,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:501
+#: src/components/ExpenseEditor.tsx:499
 msgid "Date"
 msgstr "Fecha"
 
@@ -970,7 +970,7 @@ msgstr "Por ahora todo está archivado. Puedes reabrir cualquier grupo desde la 
 msgid "Expense added"
 msgstr "Gasto añadido"
 
-#: src/components/ExpenseEditor.tsx:162
+#: src/components/ExpenseEditor.tsx:160
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
@@ -987,7 +987,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:980
+#: src/components/ExpenseEditor.tsx:978
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1028,7 +1028,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:955
+#: src/components/ExpenseEditor.tsx:953
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -1150,7 +1150,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:857
+#: src/components/ExpenseEditor.tsx:855
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -1239,7 +1239,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:545
+#: src/components/ExpenseEditor.tsx:543
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1467,7 +1467,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:349
+#: src/components/ExpenseEditor.tsx:347
 #: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:88
 #: src/routes/party.$partyId/route.tsx:174
@@ -1718,7 +1718,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:361
+#: src/components/ExpenseEditor.tsx:359
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1759,7 +1759,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:476
+#: src/components/ExpenseEditor.tsx:474
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -1965,7 +1965,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:875
+#: src/components/ExpenseEditor.tsx:873
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -2038,7 +2038,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1072
+#: src/components/ExpenseEditor.tsx:1070
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2107,7 +2107,7 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:277
+#: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:111
@@ -2210,7 +2210,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:731
+#: src/components/ExpenseEditor.tsx:729
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -2218,7 +2218,7 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:861
+#: src/components/ExpenseEditor.tsx:859
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
@@ -2372,7 +2372,7 @@ msgstr "Detener trizum cloud en este dispositivo"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:277
+#: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:111
@@ -2419,11 +2419,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:755
+#: src/components/ExpenseEditor.tsx:753
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:756
+#: src/components/ExpenseEditor.tsx:754
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2462,8 +2462,8 @@ msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:1000
-#: src/components/ExpenseEditor.tsx:1014
+#: src/components/ExpenseEditor.tsx:998
+#: src/components/ExpenseEditor.tsx:1012
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2562,7 +2562,7 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:417
+#: src/components/ExpenseEditor.tsx:415
 msgid "Title"
 msgstr "Título"
 
@@ -2749,14 +2749,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:900
+#: src/components/ExpenseEditor.tsx:898
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1009
-#: src/components/ExpenseEditor.tsx:1026
+#: src/components/ExpenseEditor.tsx:1007
+#: src/components/ExpenseEditor.tsx:1024
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2764,7 +2764,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:940
+#: src/components/ExpenseEditor.tsx:938
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2845,7 +2845,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1061
+#: src/components/ExpenseEditor.tsx:1059
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -89,7 +89,6 @@
     "@tanstack/router-plugin": "catalog:",
     "@trizum/icon-sprite": "workspace:*",
     "@trizum/tsconfig": "workspace:*",
-    "@types/dinero.js": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/packages/pwa/src/components/CurrencyContext.tsx
+++ b/packages/pwa/src/components/CurrencyContext.tsx
@@ -1,4 +1,4 @@
-import type { Currency } from "dinero.js";
+import type { CurrencyCode } from "#src/lib/money.ts";
 import { createContext } from "react";
 
-export const CurrencyContext = createContext<Currency>("EUR");
+export const CurrencyContext = createContext<CurrencyCode>("EUR");

--- a/packages/pwa/src/components/CurrencyText.test.tsx
+++ b/packages/pwa/src/components/CurrencyText.test.tsx
@@ -17,4 +17,11 @@ describe("CurrencyText", () => {
     expect(markup).toContain("12,34");
     expect(markup).not.toContain("€");
   });
+
+  test("formats currencies with non-decimal Dinero metadata as app decimal amounts", () => {
+    const markup = renderToStaticMarkup(<CurrencyText amount={1234} currency="MGA" />);
+
+    expect(markup).toContain("12,34");
+    expect(markup).toContain("MGA");
+  });
 });

--- a/packages/pwa/src/components/CurrencyText.test.tsx
+++ b/packages/pwa/src/components/CurrencyText.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vite-plus/test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CurrencyText } from "./CurrencyText.tsx";
+
+describe("CurrencyText", () => {
+  test("formats currency amounts with the Spanish locale", () => {
+    const markup = renderToStaticMarkup(<CurrencyText amount={1234} currency="EUR" />);
+
+    expect(markup).toContain("12,34\u00A0€");
+  });
+
+  test("formats currency amounts without a currency symbol", () => {
+    const markup = renderToStaticMarkup(
+      <CurrencyText amount={1234} currency="EUR" format="0.00" />,
+    );
+
+    expect(markup).toContain("12,34");
+    expect(markup).not.toContain("€");
+  });
+});

--- a/packages/pwa/src/components/CurrencyText.tsx
+++ b/packages/pwa/src/components/CurrencyText.tsx
@@ -1,6 +1,6 @@
 import { cn } from "#src/ui/utils.js";
 import { dinero, toDecimal } from "dinero.js";
-import { getDineroCurrency, type CurrencyCode } from "#src/lib/money.ts";
+import { getDisplayDineroCurrency, type CurrencyCode } from "#src/lib/money.ts";
 
 export interface CurrencyTextProps extends React.HTMLAttributes<HTMLSpanElement> {
   amount: number;
@@ -45,7 +45,7 @@ function formatCurrencyAmount(
   currency: CurrencyCode,
   format: NonNullable<CurrencyTextProps["format"]>,
 ) {
-  const money = dinero({ amount, currency: getDineroCurrency(currency), scale: 2 });
+  const money = dinero({ amount, currency: getDisplayDineroCurrency(currency), scale: 2 });
 
   return toDecimal(money, ({ value, currency }) => {
     const numericValue = Number(value);

--- a/packages/pwa/src/components/CurrencyText.tsx
+++ b/packages/pwa/src/components/CurrencyText.tsx
@@ -1,9 +1,10 @@
 import { cn } from "#src/ui/utils.js";
-import Dinero, { type Currency } from "dinero.js";
+import { dinero, toDecimal } from "dinero.js";
+import { getDineroCurrency, type CurrencyCode } from "#src/lib/money.ts";
 
 export interface CurrencyTextProps extends React.HTMLAttributes<HTMLSpanElement> {
   amount: number;
-  currency: Currency;
+  currency: CurrencyCode;
   variant?: "diff" | "default" | "inherit";
   format?: "$0.00" | "0.00";
 }
@@ -34,7 +35,33 @@ export function CurrencyText({
 
   return (
     <span className={cn(color, className)} {...props}>
-      {Dinero({ amount, currency }).setLocale("es-ES").toFormat(format)}
+      {formatCurrencyAmount(amount, currency, format)}
     </span>
   );
+}
+
+function formatCurrencyAmount(
+  amount: number,
+  currency: CurrencyCode,
+  format: NonNullable<CurrencyTextProps["format"]>,
+) {
+  const money = dinero({ amount, currency: getDineroCurrency(currency), scale: 2 });
+
+  return toDecimal(money, ({ value, currency }) => {
+    const numericValue = Number(value);
+
+    if (format === "0.00") {
+      return numericValue.toLocaleString("es-ES", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+    }
+
+    return numericValue.toLocaleString("es-ES", {
+      style: "currency",
+      currency: currency.code,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  });
 }

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -11,7 +11,7 @@ import { AppNumberField, AppTextField } from "#src/ui/fields/TextField.js";
 import { CurrencyField } from "./CurrencyField";
 import { convertToUnits } from "#src/lib/expenses.js";
 import { toast } from "sonner";
-import Dinero from "dinero.js";
+import { add, equal, subtract } from "dinero.js";
 import { useExpenseParticipants } from "#src/hooks/useExpenseParticipants.ts";
 import { useCurrentParty } from "#src/hooks/useParty.ts";
 import { Checkbox } from "#src/ui/Checkbox.tsx";
@@ -32,6 +32,7 @@ import { useMediaFile } from "#src/hooks/useMediaFile.ts";
 import { Skeleton } from "#src/ui/Skeleton.tsx";
 import type { MediaFile } from "#src/models/media.ts";
 import { getImageUploadErrorMessage, useMediaFileActions } from "#src/hooks/useMediaFileActions.ts";
+import { createMoney } from "#src/lib/money.ts";
 import {
   compressionPresets,
   imageCaptureAccept,
@@ -125,7 +126,7 @@ export function ExpenseEditor({
 
       // Validate that amounts add up correctly using Dinero.js for precise calculations
       const activeParticipants = Object.keys(value.shares);
-      const totalAmount = Dinero({ amount: convertToUnits(value.amount) });
+      const totalAmount = createMoney(convertToUnits(value.amount));
 
       // Calculate total shares for divide participants
       const totalShares = activeParticipants.reduce((total, participantId) => {
@@ -137,28 +138,25 @@ export function ExpenseEditor({
       }, 0);
 
       // Calculate total amount taken by exact shares using Dinero.js
-      const exactTotal = activeParticipants.reduce(
-        (total, participantId) => {
-          const share = value.shares[participantId];
-          if (share?.type === "exact") {
-            // Use Math.round to handle any floating point precision issues
-            return total.add(Dinero({ amount: Math.round(share.value) }));
-          }
-          return total;
-        },
-        Dinero({ amount: 0 }),
-      );
+      const exactTotal = activeParticipants.reduce((total, participantId) => {
+        const share = value.shares[participantId];
+        if (share?.type === "exact") {
+          // Use Math.round to handle any floating point precision issues
+          return add(total, createMoney(Math.round(share.value)));
+        }
+        return total;
+      }, createMoney(0));
 
       // Calculate total split amount using Dinero.js
       let totalSplit = exactTotal;
       if (totalShares > 0) {
         // Calculate remaining amount for divide participants
-        const remainingAmount = totalAmount.subtract(exactTotal);
-        totalSplit = exactTotal.add(remainingAmount);
+        const remainingAmount = subtract(totalAmount, exactTotal);
+        totalSplit = add(exactTotal, remainingAmount);
       }
 
       // Compare using Dinero.js equality
-      if (!totalSplit.equalsTo(totalAmount)) {
+      if (!equal(totalSplit, totalAmount)) {
         toast.error(t`Expense amounts don't match total. Please check your split configuration.`);
         return;
       }

--- a/packages/pwa/src/lib/expenses.test.ts
+++ b/packages/pwa/src/lib/expenses.test.ts
@@ -5,6 +5,7 @@ import {
   convertToUnits,
   type ExpenseInput,
 } from "./expenses";
+import { getMoneyAmount } from "./money.ts";
 
 describe("convertToUnits", () => {
   test("should convert display amounts to cents correctly", () => {
@@ -49,7 +50,7 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     const result = calculateLogStatsBetweenTwoUsers(user, otherUser, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(0);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(0);
   });
 
   test("should return diffUnsplitted=-100 when expenses splits are 50%, user1 paid 100, and user1 paid 300", () => {
@@ -72,7 +73,7 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     const result = calculateLogStatsBetweenTwoUsers(user, otherUser, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(-100);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(-100);
   });
 
   test("should return diffUnsplitted=100 when expenses splits are 50%, user1 paid 300, and user2 paid 100", () => {
@@ -95,7 +96,7 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     const result = calculateLogStatsBetweenTwoUsers(user, otherUser, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(100);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(100);
   });
 
   test("should return diffUnsplitted=0 when expenses are splitted evenly", () => {
@@ -118,7 +119,7 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     const result = calculateLogStatsBetweenTwoUsers(user, otherUser, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(0);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(0);
   });
 
   test("should return diffUnsplitted=-50 when user1 pays something for themselves", () => {
@@ -141,7 +142,7 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     const result = calculateLogStatsBetweenTwoUsers(user, otherUser, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(-50);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(-50);
   });
 
   test("should return diffUnsplitted=50 when user1 pays something for themselves", () => {
@@ -164,7 +165,7 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     const result = calculateLogStatsBetweenTwoUsers(user, otherUser, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(50);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(50);
   });
 
   test("should return diffUnsplitted=0 when user2 pays a debt to user1", () => {
@@ -187,11 +188,11 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     let result = calculateLogStatsBetweenTwoUsers(user, otherUser, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(0);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(0);
 
     result = calculateLogStatsBetweenTwoUsers(otherUser, user, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(0);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(0);
   });
 
   test("should return diffUnsplitted=-1667 for user2, diffUnsplitted=3333 for user3", () => {
@@ -219,11 +220,11 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     let result = calculateLogStatsBetweenTwoUsers(user1, user2, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(-1667);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(-1667);
 
     result = calculateLogStatsBetweenTwoUsers(user1, user3, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(3333);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(3333);
   });
 
   test("should return diffUnsplitted=3333 for user2, diffUnsplitted=3333 for user3", () => {
@@ -260,11 +261,11 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
 
     let result = calculateLogStatsBetweenTwoUsers(user1, user2, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(3333);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(3333);
 
     result = calculateLogStatsBetweenTwoUsers(user1, user3, expenses);
 
-    expect(result.diffUnsplitted.getAmount()).toEqual(3333);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(3333);
   });
 
   test("should return diffUnsplited=100 for user1, and diffUnsplited=-100 for user2, when user1 pays something for user2", () => {
@@ -281,10 +282,10 @@ describe("calculateLogStatsBetweenTwoUsers", () => {
     ];
 
     let result = calculateLogStatsBetweenTwoUsers(user1, user2, expenses);
-    expect(result.diffUnsplitted.getAmount()).toEqual(100);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(100);
 
     result = calculateLogStatsBetweenTwoUsers(user2, user1, expenses);
-    expect(result.diffUnsplitted.getAmount()).toEqual(-100);
+    expect(getMoneyAmount(result.diffUnsplitted)).toEqual(-100);
   });
 });
 
@@ -321,11 +322,11 @@ describe("calculateLogStatsOfUser", () => {
 
     const result = calculateLogStatsOfUser(user, otherUsers, expenses);
 
-    expect(result.userOwes.getAmount()).toEqual(100);
-    expect(result.owedToUser.getAmount()).toEqual(0);
+    expect(getMoneyAmount(result.userOwes)).toEqual(100);
+    expect(getMoneyAmount(result.owedToUser)).toEqual(0);
 
-    expect(result.diffs.user2.diffUnsplitted.getAmount()).toEqual(0);
-    expect(result.diffs.user3.diffUnsplitted.getAmount()).toEqual(-100);
+    expect(getMoneyAmount(result.diffs.user2.diffUnsplitted)).toEqual(0);
+    expect(getMoneyAmount(result.diffs.user3.diffUnsplitted)).toEqual(-100);
   });
 
   test("user2 should owe 2 to user1", () => {
@@ -354,9 +355,9 @@ describe("calculateLogStatsOfUser", () => {
 
     const result = calculateLogStatsOfUser(user, otherUsers, expenses);
 
-    expect(result.userOwes.getAmount()).toEqual(0);
-    expect(result.owedToUser.getAmount()).toEqual(100);
-    expect(result.diffs.user2.diffUnsplitted.getAmount()).toEqual(100);
+    expect(getMoneyAmount(result.userOwes)).toEqual(0);
+    expect(getMoneyAmount(result.owedToUser)).toEqual(100);
+    expect(getMoneyAmount(result.diffs.user2.diffUnsplitted)).toEqual(100);
   });
 
   test("user2 should owe 200 to user1, and user3 should owe 150 to user1, but user3 should only owe 50 to user2", () => {
@@ -383,14 +384,14 @@ describe("calculateLogStatsOfUser", () => {
 
     let result = calculateLogStatsOfUser("user1", ["user2", "user3"], expenses);
 
-    expect(result.userOwes.getAmount()).toEqual(0);
-    expect(result.owedToUser.getAmount()).toEqual(166);
-    expect(result.diffs.user2.diffUnsplitted.getAmount()).toEqual(66);
+    expect(getMoneyAmount(result.userOwes)).toEqual(0);
+    expect(getMoneyAmount(result.owedToUser)).toEqual(166);
+    expect(getMoneyAmount(result.diffs.user2.diffUnsplitted)).toEqual(66);
 
     result = calculateLogStatsOfUser("user3", ["user2", "user1"], expenses);
 
-    expect(result.userOwes.getAmount()).toEqual(133);
-    expect(result.owedToUser.getAmount()).toEqual(0);
-    expect(result.diffs.user2.diffUnsplitted.getAmount()).toEqual(-33);
+    expect(getMoneyAmount(result.userOwes)).toEqual(133);
+    expect(getMoneyAmount(result.owedToUser)).toEqual(0);
+    expect(getMoneyAmount(result.diffs.user2.diffUnsplitted)).toEqual(-33);
   });
 });

--- a/packages/pwa/src/lib/expenses.ts
+++ b/packages/pwa/src/lib/expenses.ts
@@ -1,4 +1,5 @@
-import Dinero from "dinero.js";
+import { add, greaterThan, lessThan, subtract } from "dinero.js";
+import { createMoney, getMoneyAmount } from "./money.ts";
 
 export type ExpenseUser = string;
 
@@ -52,7 +53,7 @@ export function calculateLogStatsBetweenTwoUsers(
    */
   const whatU1HasToPayToU2 = getSplitTotal(otherUserExpenses, userUid);
 
-  const diff = whatU2HasToPayToU1.subtract(whatU1HasToPayToU2);
+  const diff = subtract(whatU2HasToPayToU1, whatU1HasToPayToU2);
 
   return {
     diffUnsplitted: diff,
@@ -72,16 +73,16 @@ export function calculateLogStatsOfUser(
     diffs[otherUserUid] = calculateLogStatsBetweenTwoUsers(userUid, otherUserUid, expenses);
   }
 
-  const zero = Dinero({ amount: 0 });
+  const zero = createMoney(0);
 
-  let userOwes = Dinero({ amount: 0 });
-  let owedToUser = Dinero({ amount: 0 });
+  let userOwes = createMoney(0);
+  let owedToUser = createMoney(0);
 
   for (const diff of Object.values(diffs)) {
-    if (diff.diffUnsplitted.lessThan(zero)) {
-      userOwes = userOwes.add(Dinero({ amount: Math.abs(diff.diffUnsplitted.getAmount()) }));
-    } else if (diff.diffUnsplitted.greaterThan(zero)) {
-      owedToUser = owedToUser.add(diff.diffUnsplitted);
+    if (lessThan(diff.diffUnsplitted, zero)) {
+      userOwes = add(userOwes, createMoney(Math.abs(getMoneyAmount(diff.diffUnsplitted))));
+    } else if (greaterThan(diff.diffUnsplitted, zero)) {
+      owedToUser = add(owedToUser, diff.diffUnsplitted);
     }
   }
 
@@ -89,25 +90,16 @@ export function calculateLogStatsOfUser(
     userOwes,
     owedToUser,
     diffs,
-    balance: owedToUser.subtract(userOwes),
+    balance: subtract(owedToUser, userOwes),
   };
 }
 
-function getSplitTotal(expenses: ExpenseInput[], uid: ExpenseUser, reverse = false) {
-  return expenses.reduce(
-    (prev, next) => {
-      let amount = Dinero({
-        amount: next.expense,
-      });
+function getSplitTotal(expenses: ExpenseInput[], uid: ExpenseUser) {
+  return expenses.reduce((prev, next) => {
+    const amount = createMoney(next.paidFor[uid]);
 
-      amount = reverse
-        ? Dinero({ amount: next.expense }).subtract(Dinero({ amount: next.paidFor[uid] }))
-        : Dinero({ amount: next.paidFor[uid] });
-
-      return prev.add(amount);
-    },
-    Dinero({ amount: 0 }),
-  );
+    return add(prev, amount);
+  }, createMoney(0));
 }
 
 export function convertToUnits(amount: number) {

--- a/packages/pwa/src/lib/money.test.ts
+++ b/packages/pwa/src/lib/money.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vite-plus/test";
-import { createMoney, getDineroCurrency, getMoneyAmount, isCurrencyCode } from "./money.ts";
+import {
+  createMoney,
+  getDineroCurrency,
+  getDisplayDineroCurrency,
+  getMoneyAmount,
+  isCurrencyCode,
+} from "./money.ts";
 
 describe("money", () => {
   test("creates app money values in minor units", () => {
@@ -19,5 +25,13 @@ describe("money", () => {
     expect(isCurrencyCode("EUR")).toBe(true);
     expect(isCurrencyCode("HRK")).toBe(true);
     expect(isCurrencyCode("missing")).toBe(false);
+  });
+
+  test("resolves display currencies as decimal app amounts", () => {
+    expect(getDisplayDineroCurrency("MGA")).toStrictEqual({
+      code: "MGA",
+      base: 10,
+      exponent: 2,
+    });
   });
 });

--- a/packages/pwa/src/lib/money.test.ts
+++ b/packages/pwa/src/lib/money.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vite-plus/test";
+import { createMoney, getDineroCurrency, getMoneyAmount, isCurrencyCode } from "./money.ts";
+
+describe("money", () => {
+  test("creates app money values in minor units", () => {
+    expect(getMoneyAmount(createMoney(1234))).toBe(1234);
+  });
+
+  test("resolves Dinero v2 currencies for persisted app currency codes", () => {
+    expect(getDineroCurrency("EUR").code).toBe("EUR");
+    expect(getDineroCurrency("HRK")).toStrictEqual({
+      code: "HRK",
+      base: 10,
+      exponent: 2,
+    });
+  });
+
+  test("validates app currency codes", () => {
+    expect(isCurrencyCode("EUR")).toBe(true);
+    expect(isCurrencyCode("HRK")).toBe(true);
+    expect(isCurrencyCode("missing")).toBe(false);
+  });
+});

--- a/packages/pwa/src/lib/money.ts
+++ b/packages/pwa/src/lib/money.ts
@@ -1,0 +1,48 @@
+import { dinero, toSnapshot, type Dinero, type DineroCurrency } from "dinero.js";
+import { EUR } from "dinero.js/currencies";
+import * as currencies from "dinero.js/currencies";
+
+const trizumCurrencies = {
+  ANG: { code: "ANG", base: 10, exponent: 2 },
+  CUC: { code: "CUC", base: 10, exponent: 2 },
+  HRK: { code: "HRK", base: 10, exponent: 2 },
+  SLL: { code: "SLL", base: 10, exponent: 2 },
+  XAG: { code: "XAG", base: 10, exponent: 2 },
+  XAU: { code: "XAU", base: 10, exponent: 2 },
+  XBA: { code: "XBA", base: 10, exponent: 2 },
+  XBB: { code: "XBB", base: 10, exponent: 2 },
+  XBC: { code: "XBC", base: 10, exponent: 2 },
+  XBD: { code: "XBD", base: 10, exponent: 2 },
+  XDR: { code: "XDR", base: 10, exponent: 2 },
+  XPD: { code: "XPD", base: 10, exponent: 2 },
+  XPT: { code: "XPT", base: 10, exponent: 2 },
+  XSU: { code: "XSU", base: 10, exponent: 2 },
+  XTS: { code: "XTS", base: 10, exponent: 2 },
+  XUA: { code: "XUA", base: 10, exponent: 2 },
+  XXX: { code: "XXX", base: 10, exponent: 2 },
+  ZWL: { code: "ZWL", base: 10, exponent: 2 },
+} as const satisfies Record<string, DineroCurrency<number>>;
+
+const appCurrencies = {
+  ...currencies,
+  ...trizumCurrencies,
+};
+
+export type CurrencyCode = keyof typeof appCurrencies;
+export type Money = Dinero<number>;
+
+export function createMoney(amount: number): Money {
+  return dinero({ amount, currency: EUR });
+}
+
+export function getMoneyAmount(money: Money): number {
+  return toSnapshot(money).amount;
+}
+
+export function isCurrencyCode(currency: string): currency is CurrencyCode {
+  return currency in appCurrencies;
+}
+
+export function getDineroCurrency(currency: CurrencyCode): DineroCurrency<number, CurrencyCode> {
+  return appCurrencies[currency];
+}

--- a/packages/pwa/src/lib/money.ts
+++ b/packages/pwa/src/lib/money.ts
@@ -46,3 +46,11 @@ export function isCurrencyCode(currency: string): currency is CurrencyCode {
 export function getDineroCurrency(currency: CurrencyCode): DineroCurrency<number, CurrencyCode> {
   return appCurrencies[currency];
 }
+
+export function getDisplayDineroCurrency(currency: CurrencyCode): DineroCurrency<number> {
+  return {
+    code: currency,
+    base: 10,
+    exponent: 2,
+  };
+}

--- a/packages/pwa/src/models/expense.test.ts
+++ b/packages/pwa/src/models/expense.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vite-plus/test";
 import {
+  calculateBalancesByParticipant,
   createExpenseId,
   exportIntoInput,
   findExpenseById,
@@ -270,7 +271,7 @@ describe("exportIntoInput(Expense): ExpenseInput[]", () => {
     expect(totalPaidFor).toBe(1000);
   });
 
-  test("preserves Dinero v1 half-even tie rounding before distributing remainders", () => {
+  test("preserves main rounding for party balance divide shares", () => {
     const expense = createExpense({
       paidBy: {
         user1: 5,
@@ -286,12 +287,25 @@ describe("exportIntoInput(Expense): ExpenseInput[]", () => {
         version: 1,
         paidBy: "user1",
         paidFor: {
-          user1: 3,
-          user2: 2,
+          user1: 2,
+          user2: 3,
         },
         expense: 5,
       },
     ]);
+  });
+
+  test("preserves Dinero v1 half-even tie rounding for calculated unit shares", () => {
+    const expense = createExpense({
+      paidBy: {
+        user1: 5,
+      },
+      shares: {
+        user1: { type: "divide", value: 1 },
+        user2: { type: "divide", value: 1 },
+      },
+    });
+
     expect(getExpenseUnitShares(expense)).toStrictEqual({
       user1: 3,
       user2: 2,
@@ -429,6 +443,30 @@ describe("getImpactOnBalanceForUser", () => {
 
     // user3 is not involved in this expense, so impact should be 0
     expect(impact).toBe(0);
+  });
+});
+
+describe("calculateBalancesByParticipant", () => {
+  test("preserves main rounding for party balances", () => {
+    const expense = createExpense({
+      paidBy: {
+        alice: 5,
+      },
+      shares: {
+        alice: { type: "divide", value: 1 },
+        bob: { type: "divide", value: 1 },
+      },
+    });
+
+    const balances = calculateBalancesByParticipant([expense], {
+      alice: { id: "alice", name: "Alice" },
+      bob: { id: "bob", name: "Bob" },
+    });
+
+    expect(balances.alice.stats.balance).toBe(3);
+    expect(balances.bob.stats.balance).toBe(-3);
+    expect(balances.alice.stats.diffs.bob.diffUnsplitted).toBe(3);
+    expect(balances.bob.stats.diffs.alice.diffUnsplitted).toBe(-3);
   });
 });
 

--- a/packages/pwa/src/models/expense.test.ts
+++ b/packages/pwa/src/models/expense.test.ts
@@ -4,6 +4,7 @@ import {
   exportIntoInput,
   findExpenseById,
   getImpactOnBalanceForUser,
+  getExpenseUnitShares,
   type Expense,
   type ExpenseShare,
 } from "./expense";
@@ -267,6 +268,34 @@ describe("exportIntoInput(Expense): ExpenseInput[]", () => {
     // Verify the total adds up exactly
     const totalPaidFor = Object.values(result[0].paidFor).reduce((sum, amount) => sum + amount, 0);
     expect(totalPaidFor).toBe(1000);
+  });
+
+  test("preserves Dinero v1 half-even tie rounding before distributing remainders", () => {
+    const expense = createExpense({
+      paidBy: {
+        user1: 5,
+      },
+      shares: {
+        user1: { type: "divide", value: 1 },
+        user2: { type: "divide", value: 1 },
+      },
+    });
+
+    expect(exportIntoInput(expense)).toStrictEqual([
+      {
+        version: 1,
+        paidBy: "user1",
+        paidFor: {
+          user1: 3,
+          user2: 2,
+        },
+        expense: 5,
+      },
+    ]);
+    expect(getExpenseUnitShares(expense)).toStrictEqual({
+      user1: 3,
+      user2: 2,
+    });
   });
 });
 

--- a/packages/pwa/src/models/expense.ts
+++ b/packages/pwa/src/models/expense.ts
@@ -87,6 +87,7 @@ export function exportIntoInput(expense: Expense): ExpenseInput[] {
       const divideAmounts = allocateMinorUnitsByNearest(
         totalLeftForDivides,
         divideUsers.map((divide) => divides[divide].value),
+        Math.round,
       );
 
       // Apply the calculated amounts
@@ -199,6 +200,7 @@ export function getExpenseUnitShares({ shares, paidBy }: Pick<Expense, "shares" 
         const share = shares[participantId];
         return share?.type === "divide" ? share.value : 0;
       }),
+      roundHalfEven,
     );
 
     // First pass: calculate proportional amounts
@@ -226,14 +228,18 @@ export function getExpenseUnitShares({ shares, paidBy }: Pick<Expense, "shares" 
   return participantAmounts;
 }
 
-function allocateMinorUnitsByNearest(amount: number, ratios: number[]) {
+function allocateMinorUnitsByNearest(
+  amount: number,
+  ratios: number[],
+  roundAmount: (value: number) => number,
+) {
   const totalRatio = ratios.reduce((total, ratio) => total + ratio, 0);
 
   if (totalRatio <= 0) {
     return ratios.map(() => 0);
   }
 
-  const amounts = ratios.map((ratio) => roundHalfEven(amount * (ratio / totalRatio)));
+  const amounts = ratios.map((ratio) => roundAmount(amount * (ratio / totalRatio)));
   const distributedTotal = amounts.reduce((total, next) => total + next, 0);
   const roundingError = amount - distributedTotal;
 

--- a/packages/pwa/src/models/expense.ts
+++ b/packages/pwa/src/models/expense.ts
@@ -1,7 +1,7 @@
 import { calculateLogStatsOfUser, type ExpenseInput, type ExpenseUser } from "#src/lib/expenses.js";
 import type { DocumentId } from "@automerge/automerge-repo";
 import { ulid } from "ulidx";
-import Dinero from "dinero.js";
+import { add, subtract } from "dinero.js";
 import type { MediaFile } from "./media";
 import { diff } from "@opentf/obj-diff";
 import { patchMutate } from "#src/lib/patchMutate.ts";
@@ -10,6 +10,7 @@ import { md5 } from "@takker/md5";
 import type { Party, PartyParticipant } from "./party";
 import { assertNever } from "#src/lib/assertNever.ts";
 import { getLogger } from "#src/lib/log.ts";
+import { createMoney, getMoneyAmount } from "#src/lib/money.ts";
 
 const logger = getLogger("models", "expense");
 
@@ -51,16 +52,12 @@ export function exportIntoInput(expense: Expense): ExpenseInput[] {
     return [];
   }
 
-  const total = Object.values(expense.paidBy).reduce(
-    (acc, curr) => acc.add(Dinero({ amount: curr })),
-    Dinero({ amount: 0 }),
-  );
+  const total = getExpenseTotalAmount(expense);
 
   return Object.keys(expense.paidBy).map((user): ExpenseInput => {
     const partial = expense.paidBy[user];
-    const factor = partial / total.getAmount();
     const paidFor: Record<ExpenseUser, number> = {};
-    let amountLeft = Dinero({ amount: partial });
+    let amountLeft = createMoney(partial);
 
     const exacts: Record<ExpenseUser, ExpenseShareExact> = Object.keys(expense.shares)
       .filter((share) => expense.shares[share].type === "exact")
@@ -71,12 +68,12 @@ export function exportIntoInput(expense: Expense): ExpenseInput[] {
       .reduce((acc, curr) => ({ ...acc, [curr]: expense.shares[curr] }), {});
 
     for (const exact of Object.keys(exacts)) {
-      const amount = Dinero({ amount: exacts[exact].value }).multiply(factor);
-      paidFor[exact] = amount.getAmount();
-      amountLeft = amountLeft.subtract(amount);
+      const amount = createMoney(Math.round((exacts[exact].value * partial) / total));
+      paidFor[exact] = getMoneyAmount(amount);
+      amountLeft = subtract(amountLeft, amount);
     }
 
-    if (amountLeft.getAmount() < 0) {
+    if (getMoneyAmount(amountLeft) < 0) {
       logger.error("Negative amounts left while exporting expense input", {
         expenseId: expense.id,
       });
@@ -85,55 +82,18 @@ export function exportIntoInput(expense: Expense): ExpenseInput[] {
     const totalDivides = Object.values(divides).reduce((acc, curr) => acc + curr.value, 0);
 
     if (totalDivides > 0) {
-      const totalLeftForDivides = amountLeft.getAmount();
+      const totalLeftForDivides = getMoneyAmount(amountLeft);
       const divideUsers = Object.keys(divides);
-
-      // Calculate divide shares with proper rounding
-      let distributedTotal = 0;
-      const divideAmounts: Record<ExpenseUser, number> = {};
-
-      // First pass: calculate initial amounts
-      for (const divide of divideUsers) {
-        const dFactor = divides[divide].value / totalDivides;
-        const amount = Math.round(totalLeftForDivides * dFactor);
-        divideAmounts[divide] = amount;
-        distributedTotal += amount;
-      }
-
-      // Second pass: adjust for rounding errors
-      const roundingError = totalLeftForDivides - distributedTotal;
-      if (roundingError !== 0 && divideUsers.length > 0) {
-        // Distribute rounding error more fairly among divide participants
-        const absRoundingError = Math.abs(roundingError);
-
-        // Sort participants by their current amount to distribute rounding errors
-        // to those with the smallest amounts first (for positive error) or
-        // to those with the largest amounts first (for negative error)
-        const sortedDivideUsers = divideUsers.slice();
-        sortedDivideUsers.sort((a, b) => {
-          if (roundingError > 0) {
-            return divideAmounts[a] - divideAmounts[b];
-          } else {
-            return divideAmounts[b] - divideAmounts[a];
-          }
-        });
-
-        // Distribute rounding error one by one to divide participants
-        for (let i = 0; i < absRoundingError; i++) {
-          const participantIndex = i % sortedDivideUsers.length;
-          const participantId = sortedDivideUsers[participantIndex];
-          if (roundingError > 0) {
-            divideAmounts[participantId] += 1;
-          } else {
-            divideAmounts[participantId] -= 1;
-          }
-        }
-      }
+      const divideAmounts = allocateMinorUnitsByNearest(
+        totalLeftForDivides,
+        divideUsers.map((divide) => divides[divide].value),
+      );
 
       // Apply the calculated amounts
-      for (const divide of divideUsers) {
-        paidFor[divide] = divideAmounts[divide];
-        amountLeft = amountLeft.subtract(Dinero({ amount: divideAmounts[divide] }));
+      for (const [index, divide] of divideUsers.entries()) {
+        const divideAmount = divideAmounts[index];
+        paidFor[divide] = divideAmount;
+        amountLeft = subtract(amountLeft, createMoney(divideAmount));
       }
     }
 
@@ -207,40 +167,39 @@ export function getImpactOnBalanceForUser(expense: Expense, userId: string) {
 
   const { userOwes, owedToUser } = calculateLogStatsOfUser(userId, expenseParticipantsIds, input);
 
-  return owedToUser.subtract(userOwes).getAmount();
+  return getMoneyAmount(subtract(owedToUser, userOwes));
 }
 
 export function getExpenseUnitShares({ shares, paidBy }: Pick<Expense, "shares" | "paidBy">) {
   const amountInUnits = getExpenseTotalAmount({ paidBy });
   const activeParticipants = Object.keys(shares);
 
-  // Calculate total shares for divide participants (this is just a count, not money)
-  const totalShares = activeParticipants.reduce((total, participantId) => {
-    const share = shares[participantId];
-    if (share?.type === "divide") {
-      return total + share.value;
-    }
-    return total;
-  }, 0);
-
   const participantAmounts = (() => {
-    const totalAmount = Dinero({ amount: amountInUnits });
+    const totalAmount = createMoney(amountInUnits);
 
     // First, calculate the total amount taken by exact shares using Dinero.js
-    const exactTotal = activeParticipants.reduce(
-      (total, participantId) => {
-        const share = shares[participantId];
-        if (share?.type === "exact") {
-          // Use Math.round to handle any floating point precision issues
-          return total.add(Dinero({ amount: Math.round(share.value) }));
-        }
-        return total;
-      },
-      Dinero({ amount: 0 }),
-    );
+    const exactTotal = activeParticipants.reduce((total, participantId) => {
+      const share = shares[participantId];
+      if (share?.type === "exact") {
+        // Use Math.round to handle any floating point precision issues
+        return add(total, createMoney(Math.round(share.value)));
+      }
+      return total;
+    }, createMoney(0));
 
     // Remaining amount to be split among divide shares using Dinero.js
-    const remainingAmount = totalAmount.subtract(exactTotal);
+    const remainingAmount = subtract(totalAmount, exactTotal);
+    const divideParticipants = activeParticipants.filter((participantId) => {
+      const share = shares[participantId];
+      return share?.type === "divide";
+    });
+    const divideAmounts = allocateMinorUnitsByNearest(
+      getMoneyAmount(remainingAmount),
+      divideParticipants.map((participantId) => {
+        const share = shares[participantId];
+        return share?.type === "divide" ? share.value : 0;
+      }),
+    );
 
     // First pass: calculate proportional amounts
     const proportionalAmounts = activeParticipants.reduce(
@@ -249,12 +208,7 @@ export function getExpenseUnitShares({ shares, paidBy }: Pick<Expense, "shares" 
         let participantAmount = 0;
 
         if (share?.type === "divide") {
-          // Calculate using Dinero.js for precise division
-          if (totalShares > 0) {
-            const shareRatio = share.value / totalShares;
-            const amountInUnits = remainingAmount.multiply(shareRatio);
-            participantAmount = amountInUnits.getAmount();
-          }
+          participantAmount = divideAmounts[divideParticipants.indexOf(participantId)] ?? 0;
         } else if (share?.type === "exact") {
           // Exact shares are already in units
           participantAmount = share.value;
@@ -266,51 +220,42 @@ export function getExpenseUnitShares({ shares, paidBy }: Pick<Expense, "shares" 
       {} as Record<string, number>,
     );
 
-    // Second pass: distribute remaining cents to ensure total adds up exactly
-    const totalCalculated = Object.values(proportionalAmounts).reduce(
-      (sum, amount) => sum + amount,
-      0,
-    );
-    const remainingCents = amountInUnits - totalCalculated;
-
-    if (remainingCents !== 0) {
-      // Find divide participants to distribute remaining cents
-      const divideParticipants = activeParticipants.filter((participantId) => {
-        const share = shares[participantId];
-        return share?.type === "divide";
-      });
-
-      if (divideParticipants.length > 0) {
-        // Sort participants by their current amount to distribute remaining cents
-        // to those with the smallest amounts first (for positive remaining) or
-        // to those with the largest amounts first (for negative remaining)
-        const sortedParticipants = divideParticipants.slice();
-        sortedParticipants.sort((a, b) => {
-          if (remainingCents > 0) {
-            return proportionalAmounts[a] - proportionalAmounts[b];
-          } else {
-            return proportionalAmounts[b] - proportionalAmounts[a];
-          }
-        });
-
-        // Distribute remaining cents one by one to divide participants
-        const absRemainingCents = Math.abs(remainingCents);
-        for (let i = 0; i < absRemainingCents; i++) {
-          const participantIndex = i % sortedParticipants.length;
-          const participantId = sortedParticipants[participantIndex];
-          if (remainingCents > 0) {
-            proportionalAmounts[participantId] += 1;
-          } else {
-            proportionalAmounts[participantId] -= 1;
-          }
-        }
-      }
-    }
-
     return proportionalAmounts;
   })();
 
   return participantAmounts;
+}
+
+function allocateMinorUnitsByNearest(amount: number, ratios: number[]) {
+  const totalRatio = ratios.reduce((total, ratio) => total + ratio, 0);
+
+  if (totalRatio <= 0) {
+    return ratios.map(() => 0);
+  }
+
+  const amounts = ratios.map((ratio) => Math.round(amount * (ratio / totalRatio)));
+  const distributedTotal = amounts.reduce((total, next) => total + next, 0);
+  const roundingError = amount - distributedTotal;
+
+  if (roundingError === 0 || amounts.length === 0) {
+    return amounts;
+  }
+
+  const sortedIndexes = amounts.map((_, index) => index);
+  sortedIndexes.sort((a, b) => {
+    if (roundingError > 0) {
+      return amounts[a] - amounts[b];
+    }
+
+    return amounts[b] - amounts[a];
+  });
+
+  for (let i = 0; i < Math.abs(roundingError); i++) {
+    const participantIndex = sortedIndexes[i % sortedIndexes.length];
+    amounts[participantIndex] += roundingError > 0 ? 1 : -1;
+  }
+
+  return amounts;
 }
 
 export function getExpenseDiff(base: Expense, updated: Expense) {
@@ -463,17 +408,17 @@ export function calculateBalancesByParticipant(
     return {
       participantId,
       stats: {
-        userOwes: dineroStats.userOwes.getAmount(),
-        owedToUser: dineroStats.owedToUser.getAmount(),
+        userOwes: getMoneyAmount(dineroStats.userOwes),
+        owedToUser: getMoneyAmount(dineroStats.owedToUser),
         diffs: Object.fromEntries(
           Object.entries(dineroStats.diffs).map(([participantId, diff]) => [
             participantId,
             {
-              diffUnsplitted: diff.diffUnsplitted.getAmount(),
+              diffUnsplitted: getMoneyAmount(diff.diffUnsplitted),
             },
           ]),
         ),
-        balance: dineroStats.balance.getAmount(),
+        balance: getMoneyAmount(dineroStats.balance),
       },
       visualRatio: 0,
     };

--- a/packages/pwa/src/models/expense.ts
+++ b/packages/pwa/src/models/expense.ts
@@ -68,7 +68,7 @@ export function exportIntoInput(expense: Expense): ExpenseInput[] {
       .reduce((acc, curr) => ({ ...acc, [curr]: expense.shares[curr] }), {});
 
     for (const exact of Object.keys(exacts)) {
-      const amount = createMoney(Math.round((exacts[exact].value * partial) / total));
+      const amount = createMoney(roundHalfEven((exacts[exact].value * partial) / total));
       paidFor[exact] = getMoneyAmount(amount);
       amountLeft = subtract(amountLeft, amount);
     }
@@ -233,7 +233,7 @@ function allocateMinorUnitsByNearest(amount: number, ratios: number[]) {
     return ratios.map(() => 0);
   }
 
-  const amounts = ratios.map((ratio) => Math.round(amount * (ratio / totalRatio)));
+  const amounts = ratios.map((ratio) => roundHalfEven(amount * (ratio / totalRatio)));
   const distributedTotal = amounts.reduce((total, next) => total + next, 0);
   const roundingError = amount - distributedTotal;
 
@@ -256,6 +256,19 @@ function allocateMinorUnitsByNearest(amount: number, ratios: number[]) {
   }
 
   return amounts;
+}
+
+function roundHalfEven(value: number) {
+  const sign = value < 0 ? -1 : 1;
+  const absoluteValue = Math.abs(value);
+  const floor = Math.floor(absoluteValue);
+  const fraction = absoluteValue - floor;
+
+  if (Math.abs(fraction - 0.5) < 1e-10) {
+    return sign * (floor % 2 === 0 ? floor : floor + 1);
+  }
+
+  return sign * Math.round(absoluteValue);
 }
 
 export function getExpenseDiff(base: Expense, updated: Expense) {

--- a/packages/pwa/src/models/migrationData.ts
+++ b/packages/pwa/src/models/migrationData.ts
@@ -1,8 +1,8 @@
-import type { Currency } from "dinero.js";
+import type { CurrencyCode } from "#src/lib/money.ts";
 
 export interface MigrationData {
   party: {
-    currency: Currency;
+    currency: CurrencyCode;
     description: string;
     name: string;
     participants: Record<string, MigrationParticipant>;

--- a/packages/pwa/src/models/party.ts
+++ b/packages/pwa/src/models/party.ts
@@ -1,7 +1,7 @@
 import type { DocumentId } from "@automerge/automerge-repo/slim";
 import type { ExpenseUser } from "#src/lib/expenses.js";
 import type { BalancesByParticipant, Expense } from "./expense";
-import type { Currency } from "dinero.js";
+import type { CurrencyCode } from "#src/lib/money.ts";
 import type { MediaFile } from "./media";
 
 export interface Party {
@@ -10,7 +10,7 @@ export interface Party {
   name: string;
   symbol?: string;
   description: string;
-  currency: Currency;
+  currency: CurrencyCode;
   participants: Record<ExpenseUser, PartyParticipant>;
   chunkRefs: PartyExpenseChunkRef[];
 }

--- a/packages/pwa/src/routes/new/-components/NewPartyDetailsFields.tsx
+++ b/packages/pwa/src/routes/new/-components/NewPartyDetailsFields.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/core/macro";
-import type { Currency } from "dinero.js";
+import type { CurrencyCode } from "#src/lib/money.ts";
 import { AppEmojiField } from "#src/components/AppEmojiField.tsx";
 import type { AppFormApi } from "#src/lib/reactFormTypes.ts";
 import {
@@ -94,7 +94,7 @@ export function NewPartyDetailsFields({
             selectedKey={field.state.value}
             onSelectionChange={(value) => {
               if (value) {
-                field.handleChange(value as Currency);
+                field.handleChange(value as CurrencyCode);
               }
             }}
           >

--- a/packages/pwa/src/routes/new/-components/types.ts
+++ b/packages/pwa/src/routes/new/-components/types.ts
@@ -1,8 +1,8 @@
-import type { Currency } from "dinero.js";
+import type { CurrencyCode } from "#src/lib/money.ts";
 import type { PartyParticipant } from "#src/models/party.js";
 
 export interface CurrencyOption {
-  id: Currency;
+  id: CurrencyCode;
   name: string;
   symbol: string;
 }
@@ -11,7 +11,7 @@ export interface NewPartyFormValues {
   name: string;
   symbol: string;
   description: string;
-  currency: Currency;
+  currency: CurrencyCode;
   participants: Pick<PartyParticipant, "id" | "name">[];
 }
 

--- a/packages/pwa/src/routes/new/route.tsx
+++ b/packages/pwa/src/routes/new/route.tsx
@@ -8,7 +8,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
 import { Suspense, useId, useState } from "react";
 import { toast } from "sonner";
-import type { Currency } from "dinero.js";
+import type { CurrencyCode } from "#src/lib/money.ts";
 import { NewPartyDetailsFields } from "./-components/NewPartyDetailsFields.js";
 import { NewPartyHeader } from "./-components/NewPartyHeader.js";
 import { NewPartyParticipantsField } from "./-components/NewPartyParticipantsField.js";
@@ -76,7 +76,7 @@ function New() {
       name: "",
       symbol: DEFAULT_PARTY_SYMBOL,
       description: "",
-      currency: "EUR" as Currency,
+      currency: "EUR" as CurrencyCode,
       participants: [initialParticipant],
     },
     onSubmit: ({ value }) => {
@@ -152,7 +152,7 @@ function New() {
 }
 
 /**
- * Returns all ISO 4217 currencies supported by dinero.js.
+ * Returns the currencies users can choose for a party.
  * Common currencies are listed first for convenience.
  */
 function getCurrencyOptions(): CurrencyOption[] {

--- a/packages/pwa/src/routes/party_.$partyId.transfer-debt/-components/TransferReviewCard.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.transfer-debt/-components/TransferReviewCard.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
-import type { Currency } from "dinero.js";
+import type { CurrencyCode } from "#src/lib/money.ts";
 import { CurrencyText } from "#src/components/CurrencyText.tsx";
 import type { Party, PartyParticipant } from "#src/models/party.ts";
 import { ReviewParticipantInline, ReviewPartyRow } from "./ReviewPartyRow.js";
@@ -16,7 +16,7 @@ export function TransferReviewCard({
   destinationCreditor,
 }: {
   amount: number;
-  currency: Currency;
+  currency: CurrencyCode;
   originParty: Party;
   destinationParty?: Party;
   from: PartyParticipant;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,9 +166,6 @@ catalogs:
     '@tanstack/router-plugin':
       specifier: 1.168.18
       version: 1.168.18
-    '@types/dinero.js':
-      specifier: 1.9.4
-      version: 1.9.4
     '@types/node':
       specifier: 24.13.2
       version: 24.13.2
@@ -215,8 +212,8 @@ catalogs:
       specifier: 1.7.5
       version: 1.7.5
     dinero.js:
-      specifier: 1.9.1
-      version: 1.9.1
+      specifier: 2.0.2
+      version: 2.0.2
     drizzle-kit:
       specifier: 0.31.10
       version: 0.31.10
@@ -666,7 +663,7 @@ importers:
         version: 1.7.5
       dinero.js:
         specifier: 'catalog:'
-        version: 1.9.1
+        version: 2.0.2
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2)
@@ -776,9 +773,6 @@ importers:
       '@trizum/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      '@types/dinero.js':
-        specifier: 'catalog:'
-        version: 1.9.4
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -1888,11 +1882,9 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -4538,9 +4530,6 @@ packages:
   '@types/deep-equal@1.0.4':
     resolution: {integrity: sha512-tqdiS4otQP4KmY0PR3u6KbZ5EWvhNdUoS/jc93UuK23C220lOZ/9TvjfxdPcKvqwwDVtmtSCrnr0p/2dirAxkA==}
 
-  '@types/dinero.js@1.9.4':
-    resolution: {integrity: sha512-mtJnan4ajy9MqvoJGVXu0tC9EAAzFjeoKc3d+8AW+H/Od9+8IiC59ymjrZF+JdTToyDvkLReacTsc50Z8eYr6Q==}
-
   '@types/emscripten@1.41.5':
     resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
 
@@ -4845,7 +4834,6 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
@@ -5498,12 +5486,10 @@ packages:
   conventional-changelog-atom@2.0.8:
     resolution: {integrity: sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==}
     engines: {node: '>=10'}
-    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-codemirror@2.0.8:
     resolution: {integrity: sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==}
     engines: {node: '>=10'}
-    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-conventionalcommits@4.6.3:
     resolution: {integrity: sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==}
@@ -5512,32 +5498,26 @@ packages:
   conventional-changelog-core@4.2.4:
     resolution: {integrity: sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==}
     engines: {node: '>=10'}
-    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-ember@2.0.9:
     resolution: {integrity: sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==}
     engines: {node: '>=10'}
-    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-eslint@3.0.9:
     resolution: {integrity: sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==}
     engines: {node: '>=10'}
-    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-express@2.0.6:
     resolution: {integrity: sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==}
     engines: {node: '>=10'}
-    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jquery@3.0.11:
     resolution: {integrity: sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==}
     engines: {node: '>=10'}
-    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jshint@2.0.9:
     resolution: {integrity: sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==}
     engines: {node: '>=10'}
-    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-preset-loader@2.3.4:
     resolution: {integrity: sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==}
@@ -5776,8 +5756,9 @@ packages:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
 
-  dinero.js@1.9.1:
-    resolution: {integrity: sha512-1HXiF2vv3ZeRQ23yr+9lFxj/PbZqutuYWJnE0qfCB9xYBPnuaJ8lXtli1cJM0TvUXW1JTOaePldmqN5JVNxKSA==}
+  dinero.js@2.0.2:
+    resolution: {integrity: sha512-d+4egJTvNinkb66KSed11Daqz6MWaOHzyalLu6h3p+BLrsmwKFjHjvOKivOWeM7WyoX89te+xx4cKI6zrDtCfQ==}
+    engines: {node: '>=20.0.0'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -6339,7 +6320,6 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -6349,7 +6329,6 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -6368,13 +6347,11 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:
@@ -6383,12 +6360,10 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -6534,7 +6509,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -7676,7 +7650,6 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -7741,15 +7714,10 @@ packages:
   puppeteer@3.3.0:
     resolution: {integrity: sha512-23zNqRltZ1PPoK28uRefWJ/zKb5Jhnzbbwbpcna2o5+QMn17F0khq5s1bdH3vPlyj+J36pubccR8wiNA/VE0Vw==}
     engines: {node: '>=10.18.1'}
-    deprecated: < 24.15.0 is no longer supported
 
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
-    deprecated: |-
-      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
-      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qr-code-styling@1.9.2:
     resolution: {integrity: sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg==}
@@ -7952,7 +7920,6 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@4.4.1:
@@ -8192,7 +8159,6 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
-    deprecated: The work that was done in this beta branch won't be included in future versions
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -8446,7 +8412,6 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.19:
     resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
@@ -8800,17 +8765,14 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uzip@0.20201231.0:
@@ -12581,7 +12543,7 @@ snapshots:
       capacitor-plugin-safe-area: 5.0.0(@capacitor/core@8.4.1)
       clsx: 2.1.1
       comctx: 1.7.5
-      dinero.js: 1.9.1
+      dinero.js: 2.0.2
       drizzle-orm: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2)
       emojibase: 17.0.0
       emojibase-data: 17.0.0(emojibase@17.0.0)
@@ -12706,8 +12668,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/deep-equal@1.0.4': {}
-
-  '@types/dinero.js@1.9.4': {}
 
   '@types/emscripten@1.41.5': {}
 
@@ -14049,7 +14009,7 @@ snapshots:
 
   diff@8.0.2: {}
 
-  dinero.js@1.9.1: {}
+  dinero.js@2.0.2: {}
 
   dir-glob@3.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,6 @@ catalog:
   "@tanstack/react-router": 1.170.16
   "@tanstack/router-devtools": 1.167.0
   "@tanstack/router-plugin": 1.168.18
-  "@types/dinero.js": 1.9.4
   "@types/node": 24.13.2
   "@types/react": npm:types-react@rc
   "@types/react-dom": npm:types-react-dom@rc
@@ -86,7 +85,7 @@ catalog:
   capacitor-plugin-safe-area: 5.0.0
   clsx: 2.1.1
   comctx: 1.7.5
-  dinero.js: 1.9.1
+  dinero.js: 2.0.2
   drizzle-kit: 0.31.10
   drizzle-orm: 0.45.2
   emojibase: 17.0.0

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -16,6 +16,24 @@
       "sourceType": "github",
       "computedHash": "8883a7d459c07a0b2ee06972e79baa634009aa3bab969a6650acbefac394ad41"
     },
+    "dinero-best-practices": {
+      "source": "dinerojs/skills",
+      "sourceType": "github",
+      "skillPath": "skills/dinero-best-practices/SKILL.md",
+      "computedHash": "5782a3167685788e8dbd61cc594af9132e5adf29145d9f796193627093e9ce6c"
+    },
+    "dinero-currency-patterns": {
+      "source": "dinerojs/skills",
+      "sourceType": "github",
+      "skillPath": "skills/dinero-currency-patterns/SKILL.md",
+      "computedHash": "50b60a4c1523f89d64717ca10c8156a7f0e2c28667f1a6d337c31eae3902f48d"
+    },
+    "dinero-formatting": {
+      "source": "dinerojs/skills",
+      "sourceType": "github",
+      "skillPath": "skills/dinero-formatting/SKILL.md",
+      "computedHash": "8f176bd8c9cc2a9b0d587fbbed1f3adf2fb9a66597c75a0bed9721dcaf763594"
+    },
     "enhanced-message-context": {
       "source": "lingui/skills",
       "sourceType": "github",


### PR DESCRIPTION
## Description

Migrates the PWA from Dinero.js v1 to Dinero.js v2 following the official upgrade guide. The app now uses v2 standalone functions, explicit currency objects, and snapshots for amount reads while preserving the persisted party currency-code model.

Also installs the Dinero.js agent skills in the repository:

- `dinero-best-practices`
- `dinero-currency-patterns`
- `dinero-formatting`

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other: dependency migration

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this is a dependency and money-logic migration with no intended UI changes.

## Additional Notes

References used:

- Dinero.js upgrade guide: https://www.dinerojs.com/getting-started/upgrade-guide#upgrading-from-v1-x
- Dinero.js agent skills: https://www.dinerojs.com/agent-skills

Validation run locally:

- `vp run check`
- `vp run test`
- `vp run build`
- `vp exec changeset status`
- `pnpm install --frozen-lockfile --config.minimumReleaseAge=0`
