### PR TITLE
fix(pwa): make tricount imports deterministic

### DIFF
--- a/.changeset/stable-tricount-imports.md
+++ b/.changeset/stable-tricount-imports.md
@@ -7,4 +7,4 @@ Make Tricount imports deterministic by normalizing remote response order before 
 
 - Sorts imported memberships, registry entries, and allocations before building party data.
 - Keeps repeated imports from assigning rounding cents to different participants.
-- Flushes imported party documents before recalculating balances at the end of migration.
+- Recalculates balances before opening the migrated party.

--- a/.changeset/stable-tricount-imports.md
+++ b/.changeset/stable-tricount-imports.md
@@ -1,0 +1,9 @@
+---
+"@trizum/mobile": patch
+"@trizum/pwa": patch
+---
+
+Make Tricount imports deterministic by normalizing remote response order before creating expenses.
+
+- Sorts imported memberships, registry entries, and allocations before building party data.
+- Keeps repeated imports from assigning rounding cents to different participants.

--- a/.changeset/stable-tricount-imports.md
+++ b/.changeset/stable-tricount-imports.md
@@ -7,3 +7,4 @@ Make Tricount imports deterministic by normalizing remote response order before 
 
 - Sorts imported memberships, registry entries, and allocations before building party data.
 - Keeps repeated imports from assigning rounding cents to different participants.
+- Flushes imported party documents before recalculating balances at the end of migration.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -1150,7 +1150,7 @@ msgstr "Go Back"
 msgid "Go back and try again from the balances list."
 msgstr "Go back and try again from the balances list."
 
-#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:44
+#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:48
 msgid "Go back to home"
 msgstr "Go back to home"
 
@@ -1283,7 +1283,7 @@ msgstr "Imported {0} ({1} of {2})"
 msgid "Importing attachments ({0} of {1})"
 msgstr "Importing attachments ({0} of {1})"
 
-#: src/routes/migrate_.tricount/route.tsx:56
+#: src/routes/migrate_.tricount/route.tsx:57
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
@@ -1544,7 +1544,7 @@ msgstr "Migrate from Tricount"
 msgid "Migration in progress"
 msgstr "Migration in progress"
 
-#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:11
+#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:14
 msgid "Migration successful"
 msgstr "Migration successful"
 
@@ -2387,7 +2387,7 @@ msgstr "Somali Shilling"
 msgid "Something is not working properly. Restart trizum to recover. If this keeps happening, check for updates or contact support."
 msgstr "Something is not working properly. Restart trizum to recover. If this keeps happening, check for updates or contact support."
 
-#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:34
+#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:38
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
@@ -2938,7 +2938,7 @@ msgstr "Vietnamese Dong"
 msgid "View on GitHub"
 msgstr "View on GitHub"
 
-#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:21
+#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:25
 msgid "View party"
 msgstr "View party"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -1106,7 +1106,7 @@ msgstr "Volver"
 msgid "Go back and try again from the balances list."
 msgstr "Vuelve atrás e inténtalo de nuevo desde la lista de saldos."
 
-#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:44
+#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:48
 msgid "Go back to home"
 msgstr "Volver al inicio"
 
@@ -1235,7 +1235,7 @@ msgstr "Importado {0} ({1} de {2})"
 msgid "Importing attachments ({0} of {1})"
 msgstr "Importando adjuntos ({0} de {1})"
 
-#: src/routes/migrate_.tricount/route.tsx:56
+#: src/routes/migrate_.tricount/route.tsx:57
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
@@ -1492,7 +1492,7 @@ msgstr "Migrar desde Tricount"
 msgid "Migration in progress"
 msgstr "Migración en progreso"
 
-#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:11
+#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:14
 msgid "Migration successful"
 msgstr "Migración exitosa"
 
@@ -2311,7 +2311,7 @@ msgstr "Chelín Somalí"
 msgid "Something is not working properly. Restart trizum to recover. If this keeps happening, check for updates or contact support."
 msgstr "Algo no está funcionando correctamente. Reinicia trizum para recuperarlo. Si sigue ocurriendo, comprueba si hay actualizaciones o contacta con soporte."
 
-#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:34
+#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:38
 msgid "Something went wrong"
 msgstr "Algo salió mal"
 
@@ -2841,7 +2841,7 @@ msgstr "Dong Vietnamita"
 msgid "View on GitHub"
 msgstr "Ver en GitHub"
 
-#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:21
+#: src/routes/migrate_.tricount/-components/FinishedStates.tsx:25
 msgid "View party"
 msgstr "Ver grupo"
 

--- a/packages/pwa/src/lib/tricountMigration.test.ts
+++ b/packages/pwa/src/lib/tricountMigration.test.ts
@@ -319,6 +319,55 @@ describe("parseTricountData", () => {
     });
   });
 
+  test("keeps mixed exact and ratio allocation ordering transitive", () => {
+    const memberships = [
+      createMembership(1, "Alice"),
+      createMembership(2, "Bob"),
+      createMembership(3, "Cora"),
+    ];
+    const data = createTricountResponse({
+      memberships,
+      entries: [
+        createEntry({
+          id: 111,
+          amount: "0.06",
+          description: "mixed rounding",
+          paidBy: "Alice",
+          allocations: [
+            createRatioAllocation("Cora", "0.02"),
+            createAmountAllocation("Bob", "0.01"),
+            createRatioAllocation("Alice", "0.03"),
+          ],
+        }),
+      ],
+    });
+    const dataWithReversedAllocations = createTricountResponse({
+      memberships: memberships.slice().reverse(),
+      entries: [
+        createEntry({
+          id: 111,
+          amount: "0.06",
+          description: "mixed rounding",
+          paidBy: "Alice",
+          allocations: [
+            createRatioAllocation("Alice", "0.03"),
+            createAmountAllocation("Bob", "0.01"),
+            createRatioAllocation("Cora", "0.02"),
+          ],
+        }),
+      ],
+    });
+
+    expect(getBalancesByParticipantName(data)).toStrictEqual({
+      Alice: 3,
+      Bob: -1,
+      Cora: -2,
+    });
+    expect(getBalancesByParticipantName(dataWithReversedAllocations)).toStrictEqual(
+      getBalancesByParticipantName(data),
+    );
+  });
+
   test("warns and skips entries with missing payer or allocation participants", () => {
     const data = createTricountResponse({
       memberships: [createMembership(1, "Alice"), createMembership(2, "Bob")],

--- a/packages/pwa/src/lib/tricountMigration.test.ts
+++ b/packages/pwa/src/lib/tricountMigration.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, test, vi } from "vite-plus/test";
-import { getExpenseUnitShares } from "#src/models/expense.ts";
+import {
+  calculateBalancesByParticipant,
+  getExpenseUnitShares,
+  type Expense,
+} from "#src/models/expense.ts";
+import type { Party } from "#src/models/party.ts";
 import { parseTricountData, type TricountResponse } from "./tricountMigration.ts";
 
 const warningRecords = vi.hoisted(
@@ -233,6 +238,48 @@ describe("parseTricountData", () => {
     expect(secondExpense!.photos).toStrictEqual([sharedPhoto!.id, secondPhoto!.id]);
   });
 
+  test("keeps balances stable when Tricount returns allocations in a different order", () => {
+    const memberships = [createMembership(1, "Alice"), createMembership(2, "Bob")];
+    const data = createTricountResponse({
+      memberships,
+      entries: [
+        createEntry({
+          id: 109,
+          amount: "0.05",
+          description: "rounding",
+          paidBy: "Alice",
+          allocations: [
+            createRatioAllocation("Alice", "0.03"),
+            createRatioAllocation("Bob", "0.02"),
+          ],
+        }),
+      ],
+    });
+    const dataWithReversedAllocations = createTricountResponse({
+      memberships: memberships.slice().reverse(),
+      entries: [
+        createEntry({
+          id: 109,
+          amount: "0.05",
+          description: "rounding",
+          paidBy: "Alice",
+          allocations: [
+            createRatioAllocation("Bob", "0.02"),
+            createRatioAllocation("Alice", "0.03"),
+          ],
+        }),
+      ],
+    });
+
+    expect(getBalancesByParticipantName(data)).toStrictEqual({
+      Alice: 3,
+      Bob: -3,
+    });
+    expect(getBalancesByParticipantName(dataWithReversedAllocations)).toStrictEqual(
+      getBalancesByParticipantName(data),
+    );
+  });
+
   test("warns and skips entries with missing payer or allocation participants", () => {
     const data = createTricountResponse({
       memberships: [createMembership(1, "Alice"), createMembership(2, "Bob")],
@@ -277,6 +324,36 @@ describe("parseTricountData", () => {
     ]);
   });
 });
+
+function getBalancesByParticipantName(data: TricountResponse): Record<string, number> {
+  const migrationData = parseTricountData(data);
+  const expenses: Expense[] = migrationData.expenses.map((expense, index) => ({
+    id: `expense-${index}`,
+    name: expense.name,
+    paidAt: new Date(expense.paidAt),
+    paidBy: expense.paidBy,
+    shares: expense.shares,
+    photos: [],
+    isTransfer: expense.isTransfer,
+    __hash: "",
+  }));
+  const balances = calculateBalancesByParticipant(
+    expenses,
+    migrationData.party.participants as Party["participants"],
+  );
+
+  return Object.fromEntries(
+    Object.values(balances).map((balance) => {
+      const participant = migrationData.party.participants[balance.participantId];
+
+      if (!participant) {
+        throw new Error(`Expected participant ${balance.participantId} to exist`);
+      }
+
+      return [participant.name, balance.stats.balance];
+    }),
+  );
+}
 
 function getParticipantIdByName(
   participants: TricountResponseMigrationParticipants,

--- a/packages/pwa/src/lib/tricountMigration.test.ts
+++ b/packages/pwa/src/lib/tricountMigration.test.ts
@@ -93,6 +93,7 @@ describe("parseTricountData", () => {
     const bobId = getParticipantIdByName(migrationData.party.participants, "Bob");
     const coraId = getParticipantIdByName(migrationData.party.participants, "Cora");
 
+    expect([aliceId, bobId, coraId]).toStrictEqual(["TCM_1", "TCM_2", "TCM_3"]);
     expect(expense.shares).toStrictEqual({
       [aliceId]: { type: "divide", value: 1 },
       [bobId]: { type: "divide", value: 1 },
@@ -232,6 +233,7 @@ describe("parseTricountData", () => {
     const secondPhoto = migrationData.photos.find((photo) => photo.url === secondUrl);
 
     expect(migrationData.photos).toHaveLength(2);
+    expect(migrationData.photos.map((photo) => photo.id)).toStrictEqual(["TCA_1", "TCA_2"]);
     expect(sharedPhoto).toBeDefined();
     expect(secondPhoto).toBeDefined();
     expect(firstExpense!.photos).toStrictEqual([sharedPhoto!.id]);
@@ -272,8 +274,8 @@ describe("parseTricountData", () => {
     });
 
     expect(getBalancesByParticipantName(data)).toStrictEqual({
-      Alice: 3,
-      Bob: -3,
+      Alice: 2,
+      Bob: -2,
     });
     expect(getBalancesByParticipantName(dataWithReversedAllocations)).toStrictEqual(
       getBalancesByParticipantName(data),

--- a/packages/pwa/src/lib/tricountMigration.test.ts
+++ b/packages/pwa/src/lib/tricountMigration.test.ts
@@ -282,6 +282,43 @@ describe("parseTricountData", () => {
     );
   });
 
+  test("uses a total source-aware order for ratio allocation rounding", () => {
+    const memberships = [
+      createMembership(1, "Alice"),
+      createMembership(2, "Bob"),
+      createMembership(3, "Cora"),
+    ];
+    const data = createTricountResponse({
+      memberships: memberships.slice().reverse(),
+      entries: [
+        createEntry({
+          id: 110,
+          amount: "0.02",
+          description: "transitive rounding",
+          paidBy: "Alice",
+          allocations: [
+            createRatioAllocation("Cora", "0.01", 3),
+            createRatioAllocation("Bob", "0.00", 1),
+            createRatioAllocation("Alice", "0.01", 1),
+          ],
+        }),
+      ],
+    });
+
+    const migrationData = parseTricountData(data);
+    const expense = migrationData.expenses[0]!;
+    const aliceId = getParticipantIdByName(migrationData.party.participants, "Alice");
+    const bobId = getParticipantIdByName(migrationData.party.participants, "Bob");
+    const coraId = getParticipantIdByName(migrationData.party.participants, "Cora");
+
+    expect(Object.keys(expense.shares)).toStrictEqual([aliceId, bobId, coraId]);
+    expect(getExpenseUnitShares(expense)).toStrictEqual({
+      [aliceId]: 1,
+      [bobId]: 0,
+      [coraId]: 1,
+    });
+  });
+
   test("warns and skips entries with missing payer or allocation participants", () => {
     const data = createTricountResponse({
       memberships: [createMembership(1, "Alice"), createMembership(2, "Bob")],

--- a/packages/pwa/src/lib/tricountMigration.ts
+++ b/packages/pwa/src/lib/tricountMigration.ts
@@ -283,6 +283,12 @@ function compareAllocations(
   right: TricountAllocation,
   ratioMetadata: RatioAllocationSortMetadata,
 ) {
+  const typeDifference = getAllocationTypeSortRank(left) - getAllocationTypeSortRank(right);
+
+  if (typeDifference !== 0) {
+    return typeDifference;
+  }
+
   if (left.type === "RATIO" && right.type === "RATIO" && ratioMetadata.roundingError !== 0) {
     const leftPreliminaryAmount = ratioMetadata.preliminaryAmountByAllocation.get(left);
     const rightPreliminaryAmount = ratioMetadata.preliminaryAmountByAllocation.get(right);
@@ -314,6 +320,10 @@ function compareAllocations(
     left.membership.RegistryMembershipNonUser,
     right.membership.RegistryMembershipNonUser,
   );
+}
+
+function getAllocationTypeSortRank(allocation: TricountAllocation) {
+  return allocation.type === "AMOUNT" ? 0 : 1;
 }
 
 function getRatioAllocationSortMetadata(transaction: TricountEntry): RatioAllocationSortMetadata {

--- a/packages/pwa/src/lib/tricountMigration.ts
+++ b/packages/pwa/src/lib/tricountMigration.ts
@@ -287,11 +287,16 @@ function compareAllocations(
     const leftPreliminaryAmount = ratioMetadata.preliminaryAmountByAllocation.get(left);
     const rightPreliminaryAmount = ratioMetadata.preliminaryAmountByAllocation.get(right);
 
-    if (
-      leftPreliminaryAmount !== undefined &&
-      rightPreliminaryAmount !== undefined &&
-      leftPreliminaryAmount === rightPreliminaryAmount
-    ) {
+    if (leftPreliminaryAmount !== undefined && rightPreliminaryAmount !== undefined) {
+      const preliminaryAmountDifference =
+        ratioMetadata.roundingError > 0
+          ? leftPreliminaryAmount - rightPreliminaryAmount
+          : rightPreliminaryAmount - leftPreliminaryAmount;
+
+      if (preliminaryAmountDifference !== 0) {
+        return preliminaryAmountDifference;
+      }
+
       const leftSourceAmount = ratioMetadata.sourceAmountByAllocation.get(left) ?? 0;
       const rightSourceAmount = ratioMetadata.sourceAmountByAllocation.get(right) ?? 0;
       const sourceAmountDifference =

--- a/packages/pwa/src/lib/tricountMigration.ts
+++ b/packages/pwa/src/lib/tricountMigration.ts
@@ -7,6 +7,25 @@ import type {
 
 const logger = getLogger("lib", "tricountMigration");
 
+interface TricountMembership {
+  id: number;
+  alias: {
+    display_name: string;
+  };
+}
+
+interface TricountMembershipReference {
+  id?: number;
+  alias: {
+    display_name: string;
+  };
+}
+
+type TricountRegistry = TricountResponse["Response"][number]["Registry"];
+type TricountRegistryMembership = TricountRegistry["memberships"][number];
+type TricountRegistryEntry = TricountRegistry["all_registry_entry"][number];
+type TricountAllocation = TricountRegistryEntry["RegistryEntry"]["allocations"][number];
+
 export interface TricountResponse {
   Response: Array<{
     Registry: {
@@ -15,12 +34,7 @@ export interface TricountResponse {
       description: string | null;
       currency: string;
       memberships: Array<{
-        RegistryMembershipNonUser: {
-          id: number;
-          alias: {
-            display_name: string;
-          };
-        };
+        RegistryMembershipNonUser: TricountMembership;
       }>;
       all_registry_entry: Array<{
         RegistryEntry: {
@@ -33,11 +47,7 @@ export interface TricountResponse {
           date: string;
           type_transaction: string;
           membership_owned: {
-            RegistryMembershipNonUser: {
-              alias: {
-                display_name: string;
-              };
-            };
+            RegistryMembershipNonUser: TricountMembershipReference;
           };
           allocations: Array<{
             amount: {
@@ -45,11 +55,7 @@ export interface TricountResponse {
               value: string;
             };
             membership: {
-              RegistryMembershipNonUser: {
-                alias: {
-                  display_name: string;
-                };
-              };
+              RegistryMembershipNonUser: TricountMembershipReference;
             };
             type: string;
             share_ratio?: number;
@@ -74,19 +80,20 @@ export interface TricountResponse {
 
 export function parseTricountData(data: TricountResponse): MigrationData {
   const registry = data.Response[0].Registry;
+  const registryEntries = registry.all_registry_entry.slice().sort(compareRegistryEntries);
 
   // Create photo mapping with temporary IDs
   const photoMap = new Map<string, string>();
   const photos: { id: string; url: string }[] = [];
 
   // Extract all photos from transactions
-  for (const entry of registry.all_registry_entry) {
+  for (const entry of registryEntries) {
     const transaction = entry.RegistryEntry;
     for (const attachment of transaction.attachment) {
       if (attachment.urls && attachment.urls.length > 0) {
         const url = attachment.urls[0].url;
         if (!photoMap.has(url)) {
-          const tempId = crypto.randomUUID();
+          const tempId = `tricount-photo-${photoMap.size + 1}`;
           photoMap.set(url, tempId);
           photos.push({ id: tempId, url });
         }
@@ -96,19 +103,24 @@ export function parseTricountData(data: TricountResponse): MigrationData {
 
   // Create participants mapping
   const participants: Record<string, MigrationParticipant> = {};
-  for (const membership of registry.memberships) {
+  const participantIdByMembershipId = new Map<number, string>();
+  const participantIdByName = new Map<string, string>();
+  const memberships = registry.memberships.slice().sort(compareMembershipEntries);
+
+  for (const membership of memberships) {
     const member = membership.RegistryMembershipNonUser;
-    const participantId = crypto.randomUUID();
+    const memberName = member.alias.display_name;
+    const participantId = createParticipantId(member.id);
     participants[participantId] = {
       id: participantId,
-      name: member.alias.display_name,
+      name: memberName,
     };
-  }
 
-  // Create name to participant ID mapping
-  const nameToIdMap = new Map<string, string>();
-  for (const [participantId, participant] of Object.entries(participants)) {
-    nameToIdMap.set(participant.name, participantId);
+    participantIdByMembershipId.set(member.id, participantId);
+
+    if (!participantIdByName.has(memberName)) {
+      participantIdByName.set(memberName, participantId);
+    }
   }
 
   // Transform expenses
@@ -117,13 +129,18 @@ export function parseTricountData(data: TricountResponse): MigrationData {
     photos: string[];
   })[] = [];
 
-  for (const entry of registry.all_registry_entry) {
+  for (const entry of registryEntries) {
     const transaction = entry.RegistryEntry;
 
     const totalAmount = Math.abs(parseFloat(transaction.amount.value));
     const totalAmountInCents = Math.round(totalAmount * 100);
-    const paidByName = transaction.membership_owned.RegistryMembershipNonUser.alias.display_name;
-    const paidById = nameToIdMap.get(paidByName);
+    const paidByMember = transaction.membership_owned.RegistryMembershipNonUser;
+    const paidByName = paidByMember.alias.display_name;
+    const paidById = getParticipantId(
+      paidByMember,
+      participantIdByMembershipId,
+      participantIdByName,
+    );
 
     if (!paidById) {
       logger.warning("Could not find participant ID for payer {paidByName}", {
@@ -142,9 +159,14 @@ export function parseTricountData(data: TricountResponse): MigrationData {
     // Create shares record
     const shares: Record<string, MigrationExpenseShare> = {};
 
-    for (const allocation of transaction.allocations) {
-      const participantName = allocation.membership.RegistryMembershipNonUser.alias.display_name;
-      const participantId = nameToIdMap.get(participantName);
+    for (const allocation of transaction.allocations.slice().sort(compareAllocations)) {
+      const participantMember = allocation.membership.RegistryMembershipNonUser;
+      const participantName = participantMember.alias.display_name;
+      const participantId = getParticipantId(
+        participantMember,
+        participantIdByMembershipId,
+        participantIdByName,
+      );
 
       if (!participantId) {
         logger.warning("Could not find participant ID for participant {participantName}", {
@@ -216,4 +238,65 @@ export function parseTricountData(data: TricountResponse): MigrationData {
     expenses,
     photos,
   };
+}
+
+function createParticipantId(membershipId: number) {
+  return `tricount-membership-${membershipId}`;
+}
+
+function getParticipantId(
+  member: TricountMembershipReference,
+  participantIdByMembershipId: Map<number, string>,
+  participantIdByName: Map<string, string>,
+) {
+  if (typeof member.id === "number") {
+    return participantIdByMembershipId.get(member.id);
+  }
+
+  return participantIdByName.get(member.alias.display_name);
+}
+
+function compareMembershipEntries(
+  left: TricountRegistryMembership,
+  right: TricountRegistryMembership,
+) {
+  return compareMemberships(left.RegistryMembershipNonUser, right.RegistryMembershipNonUser);
+}
+
+function compareAllocations(left: TricountAllocation, right: TricountAllocation) {
+  return compareMemberships(
+    left.membership.RegistryMembershipNonUser,
+    right.membership.RegistryMembershipNonUser,
+  );
+}
+
+function compareMemberships(left: TricountMembershipReference, right: TricountMembershipReference) {
+  const idDifference = (left.id ?? Number.MAX_SAFE_INTEGER) - (right.id ?? Number.MAX_SAFE_INTEGER);
+
+  if (idDifference !== 0) {
+    return idDifference;
+  }
+
+  return left.alias.display_name.localeCompare(right.alias.display_name);
+}
+
+function compareRegistryEntries(left: TricountRegistryEntry, right: TricountRegistryEntry) {
+  const leftEntry = left.RegistryEntry;
+  const rightEntry = right.RegistryEntry;
+  const dateDifference = getDateTimestamp(leftEntry.date) - getDateTimestamp(rightEntry.date);
+
+  if (dateDifference !== 0) {
+    return dateDifference;
+  }
+
+  if (leftEntry.id !== rightEntry.id) {
+    return leftEntry.id - rightEntry.id;
+  }
+
+  return leftEntry.description.localeCompare(rightEntry.description);
+}
+
+function getDateTimestamp(date: string) {
+  const timestamp = Date.parse(date);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
 }

--- a/packages/pwa/src/lib/tricountMigration.ts
+++ b/packages/pwa/src/lib/tricountMigration.ts
@@ -24,7 +24,14 @@ interface TricountMembershipReference {
 type TricountRegistry = TricountResponse["Response"][number]["Registry"];
 type TricountRegistryMembership = TricountRegistry["memberships"][number];
 type TricountRegistryEntry = TricountRegistry["all_registry_entry"][number];
+type TricountEntry = TricountRegistryEntry["RegistryEntry"];
 type TricountAllocation = TricountRegistryEntry["RegistryEntry"]["allocations"][number];
+
+interface RatioAllocationSortMetadata {
+  preliminaryAmountByAllocation: Map<TricountAllocation, number>;
+  roundingError: number;
+  sourceAmountByAllocation: Map<TricountAllocation, number>;
+}
 
 export interface TricountResponse {
   Response: Array<{
@@ -93,7 +100,7 @@ export function parseTricountData(data: TricountResponse): MigrationData {
       if (attachment.urls && attachment.urls.length > 0) {
         const url = attachment.urls[0].url;
         if (!photoMap.has(url)) {
-          const tempId = `tricount-photo-${photoMap.size + 1}`;
+          const tempId = `TCA_${photoMap.size + 1}`;
           photoMap.set(url, tempId);
           photos.push({ id: tempId, url });
         }
@@ -132,8 +139,7 @@ export function parseTricountData(data: TricountResponse): MigrationData {
   for (const entry of registryEntries) {
     const transaction = entry.RegistryEntry;
 
-    const totalAmount = Math.abs(parseFloat(transaction.amount.value));
-    const totalAmountInCents = Math.round(totalAmount * 100);
+    const totalAmountInCents = parseAmountInCents(transaction.amount.value);
     const paidByMember = transaction.membership_owned.RegistryMembershipNonUser;
     const paidByName = paidByMember.alias.display_name;
     const paidById = getParticipantId(
@@ -159,7 +165,9 @@ export function parseTricountData(data: TricountResponse): MigrationData {
     // Create shares record
     const shares: Record<string, MigrationExpenseShare> = {};
 
-    for (const allocation of transaction.allocations.slice().sort(compareAllocations)) {
+    for (const allocation of transaction.allocations
+      .slice()
+      .sort(createAllocationComparator(transaction))) {
       const participantMember = allocation.membership.RegistryMembershipNonUser;
       const participantName = participantMember.alias.display_name;
       const participantId = getParticipantId(
@@ -175,8 +183,7 @@ export function parseTricountData(data: TricountResponse): MigrationData {
         continue;
       }
 
-      const amount = Math.abs(parseFloat(allocation.amount.value));
-      const amountInCents = Math.round(amount * 100);
+      const amountInCents = parseAmountInCents(allocation.amount.value);
 
       if (allocation.type === "AMOUNT") {
         if (amountInCents === 0) {
@@ -241,7 +248,7 @@ export function parseTricountData(data: TricountResponse): MigrationData {
 }
 
 function createParticipantId(membershipId: number) {
-  return `tricount-membership-${membershipId}`;
+  return `TCM_${membershipId}`;
 }
 
 function getParticipantId(
@@ -263,11 +270,91 @@ function compareMembershipEntries(
   return compareMemberships(left.RegistryMembershipNonUser, right.RegistryMembershipNonUser);
 }
 
-function compareAllocations(left: TricountAllocation, right: TricountAllocation) {
+function createAllocationComparator(transaction: TricountEntry) {
+  const ratioMetadata = getRatioAllocationSortMetadata(transaction);
+
+  return (left: TricountAllocation, right: TricountAllocation) => {
+    return compareAllocations(left, right, ratioMetadata);
+  };
+}
+
+function compareAllocations(
+  left: TricountAllocation,
+  right: TricountAllocation,
+  ratioMetadata: RatioAllocationSortMetadata,
+) {
+  if (left.type === "RATIO" && right.type === "RATIO" && ratioMetadata.roundingError !== 0) {
+    const leftPreliminaryAmount = ratioMetadata.preliminaryAmountByAllocation.get(left);
+    const rightPreliminaryAmount = ratioMetadata.preliminaryAmountByAllocation.get(right);
+
+    if (
+      leftPreliminaryAmount !== undefined &&
+      rightPreliminaryAmount !== undefined &&
+      leftPreliminaryAmount === rightPreliminaryAmount
+    ) {
+      const leftSourceAmount = ratioMetadata.sourceAmountByAllocation.get(left) ?? 0;
+      const rightSourceAmount = ratioMetadata.sourceAmountByAllocation.get(right) ?? 0;
+      const sourceAmountDifference =
+        ratioMetadata.roundingError > 0
+          ? rightSourceAmount - leftSourceAmount
+          : leftSourceAmount - rightSourceAmount;
+
+      if (sourceAmountDifference !== 0) {
+        return sourceAmountDifference;
+      }
+    }
+  }
+
   return compareMemberships(
     left.membership.RegistryMembershipNonUser,
     right.membership.RegistryMembershipNonUser,
   );
+}
+
+function getRatioAllocationSortMetadata(transaction: TricountEntry): RatioAllocationSortMetadata {
+  const preliminaryAmountByAllocation = new Map<TricountAllocation, number>();
+  const sourceAmountByAllocation = new Map<TricountAllocation, number>();
+  const ratioAllocations = transaction.allocations.filter(
+    (allocation) => allocation.type === "RATIO",
+  );
+  const totalRatio = ratioAllocations.reduce(
+    (total, allocation) => total + (allocation.share_ratio ?? 1),
+    0,
+  );
+
+  if (totalRatio <= 0) {
+    return {
+      preliminaryAmountByAllocation,
+      roundingError: 0,
+      sourceAmountByAllocation,
+    };
+  }
+
+  const exactAmountInCents = transaction.allocations.reduce((total, allocation) => {
+    if (allocation.type !== "AMOUNT") {
+      return total;
+    }
+
+    return total + parseAmountInCents(allocation.amount.value);
+  }, 0);
+  const amountLeftForRatioAllocations =
+    parseAmountInCents(transaction.amount.value) - exactAmountInCents;
+  let preliminaryTotal = 0;
+
+  for (const allocation of ratioAllocations) {
+    const preliminaryAmount = Math.round(
+      amountLeftForRatioAllocations * ((allocation.share_ratio ?? 1) / totalRatio),
+    );
+    preliminaryAmountByAllocation.set(allocation, preliminaryAmount);
+    sourceAmountByAllocation.set(allocation, parseAmountInCents(allocation.amount.value));
+    preliminaryTotal += preliminaryAmount;
+  }
+
+  return {
+    preliminaryAmountByAllocation,
+    roundingError: amountLeftForRatioAllocations - preliminaryTotal,
+    sourceAmountByAllocation,
+  };
 }
 
 function compareMemberships(left: TricountMembershipReference, right: TricountMembershipReference) {
@@ -299,4 +386,8 @@ function compareRegistryEntries(left: TricountRegistryEntry, right: TricountRegi
 function getDateTimestamp(date: string) {
   const timestamp = Date.parse(date);
   return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function parseAmountInCents(value: string) {
+  return Math.round(Math.abs(parseFloat(value)) * 100);
 }

--- a/packages/pwa/src/models/migration.test.ts
+++ b/packages/pwa/src/models/migration.test.ts
@@ -1,16 +1,13 @@
-import type { DocumentId, Repo } from "@automerge/automerge-repo/slim";
+import type { Repo } from "@automerge/automerge-repo/slim";
 import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
 import type { Party } from "./party";
-import type { Expense } from "./expense";
 
 const addExpenseToPartyMock =
-  vi.fn<(expense: Omit<Expense, "id" | "__hash">) => Promise<Expense>>();
-const recalculateBalancesMock = vi.fn<() => Promise<boolean>>();
+  vi.fn<(expense: MigrationData["expenses"][number]) => Promise<unknown>>();
 
 vi.mock("#src/hooks/useParty.ts", () => ({
   getPartyHelpers: () => ({
     addExpenseToParty: addExpenseToPartyMock,
-    recalculateBalances: recalculateBalancesMock,
   }),
 }));
 
@@ -24,19 +21,6 @@ vi.mock("#src/hooks/useMediaFileActions.ts", () => ({
         ) => Promise<readonly [mediaFileId: string, handle: unknown]>
       >(),
   }),
-}));
-
-vi.mock("#src/lib/requestIdleCallback.ts", () => ({
-  requestIdleCallback: (
-    callback: (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void,
-  ) => {
-    callback({
-      didTimeout: false,
-      timeRemaining: () => 50,
-    });
-
-    return 0;
-  },
 }));
 
 import { createPartyFromMigrationData, type MigrationData } from "./migration";
@@ -65,7 +49,6 @@ function assertNoUndefinedValues(value: unknown, path: string) {
 
 function createMockRepo() {
   let nextId = 0;
-  const flush = vi.fn<(documents?: DocumentId[]) => Promise<void>>(() => Promise.resolve());
   let lastCreatedHandle:
     | {
         doc: () => Party;
@@ -91,9 +74,7 @@ function createMockRepo() {
 
         return handle;
       },
-      flush,
     } as unknown as Repo,
-    flush,
     getLastCreatedHandle: () => {
       if (!lastCreatedHandle) {
         throw new Error("Expected a created party handle");
@@ -125,8 +106,6 @@ function createMigrationData(
 describe("createPartyFromMigrationData", () => {
   beforeEach(() => {
     addExpenseToPartyMock.mockReset();
-    recalculateBalancesMock.mockReset();
-    recalculateBalancesMock.mockResolvedValue(true);
   });
 
   test("omits an undefined party symbol before creating the Automerge document", async () => {
@@ -156,122 +135,4 @@ describe("createPartyFromMigrationData", () => {
       symbol: "🏕️",
     });
   });
-
-  test("flushes imported party documents before waiting for balance recalculation", async () => {
-    const mockRepo = createMockRepo();
-    const balanceRecalculation = createDeferred<boolean>();
-
-    addExpenseToPartyMock.mockImplementation(async () => {
-      mockRepo
-        .getLastCreatedHandle()
-        .doc()
-        .chunkRefs.push({
-          chunkId: "chunk-1" as DocumentId,
-          createdAt: new Date("2024-01-01T00:00:00.000Z"),
-          balancesId: "balances-1" as DocumentId,
-        });
-
-      return createExpense();
-    });
-    recalculateBalancesMock.mockReturnValueOnce(balanceRecalculation.promise);
-
-    const migrationPromise = createPartyFromMigrationData({
-      repo: mockRepo.repo,
-      data: createMigrationData(
-        {
-          participants: {
-            alice: { id: "alice", name: "Alice" },
-            bob: { id: "bob", name: "Bob" },
-          },
-        },
-        {
-          expenses: [createMigrationExpense()],
-        },
-      ),
-    });
-
-    await vi.waitFor(() => {
-      expect(mockRepo.flush).toHaveBeenCalledWith(["mock-doc-1", "chunk-1", "balances-1"]);
-    });
-
-    expect(recalculateBalancesMock).toHaveBeenCalledOnce();
-    expect(mockRepo.flush.mock.invocationCallOrder[0]).toBeLessThan(
-      recalculateBalancesMock.mock.invocationCallOrder[0]!,
-    );
-
-    let resolved = false;
-    void migrationPromise.then(() => {
-      resolved = true;
-    });
-
-    await flushPromises();
-    expect(resolved).toBe(false);
-
-    balanceRecalculation.resolve(true);
-
-    await expect(migrationPromise).resolves.toBe("mock-doc-1");
-    expect(resolved).toBe(true);
-  });
 });
-
-function createMigrationExpense(): MigrationData["expenses"][number] {
-  return {
-    name: "Lunch",
-    paidAt: "2024-01-01T12:00:00.000Z",
-    paidBy: {
-      alice: 1000,
-    },
-    shares: {
-      alice: {
-        type: "divide",
-        value: 1,
-      },
-      bob: {
-        type: "divide",
-        value: 1,
-      },
-    },
-    photos: [],
-  };
-}
-
-function createExpense(): Expense {
-  return {
-    id: "expense-1",
-    name: "Lunch",
-    paidAt: new Date("2024-01-01T12:00:00.000Z"),
-    paidBy: {
-      alice: 1000,
-    },
-    shares: {
-      alice: {
-        type: "divide",
-        value: 1,
-      },
-      bob: {
-        type: "divide",
-        value: 1,
-      },
-    },
-    photos: [],
-    __hash: "hash",
-  };
-}
-
-function createDeferred<T>() {
-  let resolve: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve;
-  });
-
-  return {
-    promise,
-    resolve: resolve!,
-  };
-}
-
-async function flushPromises() {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-}

--- a/packages/pwa/src/models/migration.test.ts
+++ b/packages/pwa/src/models/migration.test.ts
@@ -1,14 +1,16 @@
-import type { Repo } from "@automerge/automerge-repo/slim";
+import type { DocumentId, Repo } from "@automerge/automerge-repo/slim";
 import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
 import type { Party } from "./party";
 import type { Expense } from "./expense";
 
 const addExpenseToPartyMock =
   vi.fn<(expense: Omit<Expense, "id" | "__hash">) => Promise<Expense>>();
+const recalculateBalancesMock = vi.fn<() => Promise<boolean>>();
 
 vi.mock("#src/hooks/useParty.ts", () => ({
   getPartyHelpers: () => ({
     addExpenseToParty: addExpenseToPartyMock,
+    recalculateBalances: recalculateBalancesMock,
   }),
 }));
 
@@ -22,6 +24,19 @@ vi.mock("#src/hooks/useMediaFileActions.ts", () => ({
         ) => Promise<readonly [mediaFileId: string, handle: unknown]>
       >(),
   }),
+}));
+
+vi.mock("#src/lib/requestIdleCallback.ts", () => ({
+  requestIdleCallback: (
+    callback: (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void,
+  ) => {
+    callback({
+      didTimeout: false,
+      timeRemaining: () => 50,
+    });
+
+    return 0;
+  },
 }));
 
 import { createPartyFromMigrationData, type MigrationData } from "./migration";
@@ -50,9 +65,10 @@ function assertNoUndefinedValues(value: unknown, path: string) {
 
 function createMockRepo() {
   let nextId = 0;
+  const flush = vi.fn<(documents?: DocumentId[]) => Promise<void>>(() => Promise.resolve());
   let lastCreatedHandle:
     | {
-        doc: Party;
+        doc: () => Party;
         documentId: string;
         change: (changeFn: (nextDoc: Party) => void) => void;
       }
@@ -64,10 +80,10 @@ function createMockRepo() {
         assertNoUndefinedValues(doc, "");
 
         const handle = {
-          doc,
+          doc: () => doc,
           documentId: `mock-doc-${++nextId}`,
           change(changeFn: (nextDoc: T) => void) {
-            changeFn(handle.doc);
+            changeFn(doc);
           },
         };
 
@@ -75,7 +91,9 @@ function createMockRepo() {
 
         return handle;
       },
+      flush,
     } as unknown as Repo,
+    flush,
     getLastCreatedHandle: () => {
       if (!lastCreatedHandle) {
         throw new Error("Expected a created party handle");
@@ -86,7 +104,10 @@ function createMockRepo() {
   };
 }
 
-function createMigrationData(partyOverrides: Partial<MigrationData["party"]> = {}): MigrationData {
+function createMigrationData(
+  partyOverrides: Partial<MigrationData["party"]> = {},
+  dataOverrides: Partial<Pick<MigrationData, "expenses" | "photos">> = {},
+): MigrationData {
   return {
     party: {
       type: "party",
@@ -96,14 +117,16 @@ function createMigrationData(partyOverrides: Partial<MigrationData["party"]> = {
       participants: {},
       ...partyOverrides,
     },
-    expenses: [],
-    photos: [],
+    expenses: dataOverrides.expenses ?? [],
+    photos: dataOverrides.photos ?? [],
   };
 }
 
 describe("createPartyFromMigrationData", () => {
   beforeEach(() => {
     addExpenseToPartyMock.mockReset();
+    recalculateBalancesMock.mockReset();
+    recalculateBalancesMock.mockResolvedValue(true);
   });
 
   test("omits an undefined party symbol before creating the Automerge document", async () => {
@@ -116,7 +139,7 @@ describe("createPartyFromMigrationData", () => {
       }),
     ).resolves.toBe("mock-doc-1");
 
-    expect(mockRepo.getLastCreatedHandle().doc).not.toHaveProperty("symbol");
+    expect(mockRepo.getLastCreatedHandle().doc()).not.toHaveProperty("symbol");
   });
 
   test("preserves the party symbol when migration data includes one", async () => {
@@ -129,8 +152,126 @@ describe("createPartyFromMigrationData", () => {
       }),
     });
 
-    expect(mockRepo.getLastCreatedHandle().doc).toMatchObject({
+    expect(mockRepo.getLastCreatedHandle().doc()).toMatchObject({
       symbol: "🏕️",
     });
   });
+
+  test("flushes imported party documents before waiting for balance recalculation", async () => {
+    const mockRepo = createMockRepo();
+    const balanceRecalculation = createDeferred<boolean>();
+
+    addExpenseToPartyMock.mockImplementation(async () => {
+      mockRepo
+        .getLastCreatedHandle()
+        .doc()
+        .chunkRefs.push({
+          chunkId: "chunk-1" as DocumentId,
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+          balancesId: "balances-1" as DocumentId,
+        });
+
+      return createExpense();
+    });
+    recalculateBalancesMock.mockReturnValueOnce(balanceRecalculation.promise);
+
+    const migrationPromise = createPartyFromMigrationData({
+      repo: mockRepo.repo,
+      data: createMigrationData(
+        {
+          participants: {
+            alice: { id: "alice", name: "Alice" },
+            bob: { id: "bob", name: "Bob" },
+          },
+        },
+        {
+          expenses: [createMigrationExpense()],
+        },
+      ),
+    });
+
+    await vi.waitFor(() => {
+      expect(mockRepo.flush).toHaveBeenCalledWith(["mock-doc-1", "chunk-1", "balances-1"]);
+    });
+
+    expect(recalculateBalancesMock).toHaveBeenCalledOnce();
+    expect(mockRepo.flush.mock.invocationCallOrder[0]).toBeLessThan(
+      recalculateBalancesMock.mock.invocationCallOrder[0]!,
+    );
+
+    let resolved = false;
+    void migrationPromise.then(() => {
+      resolved = true;
+    });
+
+    await flushPromises();
+    expect(resolved).toBe(false);
+
+    balanceRecalculation.resolve(true);
+
+    await expect(migrationPromise).resolves.toBe("mock-doc-1");
+    expect(resolved).toBe(true);
+  });
 });
+
+function createMigrationExpense(): MigrationData["expenses"][number] {
+  return {
+    name: "Lunch",
+    paidAt: "2024-01-01T12:00:00.000Z",
+    paidBy: {
+      alice: 1000,
+    },
+    shares: {
+      alice: {
+        type: "divide",
+        value: 1,
+      },
+      bob: {
+        type: "divide",
+        value: 1,
+      },
+    },
+    photos: [],
+  };
+}
+
+function createExpense(): Expense {
+  return {
+    id: "expense-1",
+    name: "Lunch",
+    paidAt: new Date("2024-01-01T12:00:00.000Z"),
+    paidBy: {
+      alice: 1000,
+    },
+    shares: {
+      alice: {
+        type: "divide",
+        value: 1,
+      },
+      bob: {
+        type: "divide",
+        value: 1,
+      },
+    },
+    photos: [],
+    __hash: "hash",
+  };
+}
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return {
+    promise,
+    resolve: resolve!,
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/packages/pwa/src/models/migration.ts
+++ b/packages/pwa/src/models/migration.ts
@@ -92,7 +92,23 @@ export async function createPartyFromMigrationData({
     });
   }
 
+  // eslint-disable-next-line react-doctor/async-parallel -- Import writes must finish before flushing them and rebalancing from the worker repo.
   await importExpenseAtIndex(0);
+  await flushPartyDocuments();
+  await helpers.recalculateBalances();
+
+  async function flushPartyDocuments() {
+    const migratedParty = handle.doc();
+
+    if (!migratedParty) {
+      throw new Error("Party not found after migration, this should not happen");
+    }
+
+    await repo.flush([
+      partyId,
+      ...migratedParty.chunkRefs.flatMap((chunkRef) => [chunkRef.chunkId, chunkRef.balancesId]),
+    ]);
+  }
 
   async function importExpenseAtIndex(index: number): Promise<void> {
     const expense = data.expenses[index];

--- a/packages/pwa/src/models/migration.ts
+++ b/packages/pwa/src/models/migration.ts
@@ -92,23 +92,7 @@ export async function createPartyFromMigrationData({
     });
   }
 
-  // eslint-disable-next-line react-doctor/async-parallel -- Import writes must finish before flushing them and rebalancing from the worker repo.
   await importExpenseAtIndex(0);
-  await flushPartyDocuments();
-  await helpers.recalculateBalances();
-
-  async function flushPartyDocuments() {
-    const migratedParty = handle.doc();
-
-    if (!migratedParty) {
-      throw new Error("Party not found after migration, this should not happen");
-    }
-
-    await repo.flush([
-      partyId,
-      ...migratedParty.chunkRefs.flatMap((chunkRef) => [chunkRef.chunkId, chunkRef.balancesId]),
-    ]);
-  }
 
   async function importExpenseAtIndex(index: number): Promise<void> {
     const expense = data.expenses[index];

--- a/packages/pwa/src/routes/migrate_.tricount/-components/FinishedStates.tsx
+++ b/packages/pwa/src/routes/migrate_.tricount/-components/FinishedStates.tsx
@@ -1,9 +1,12 @@
 import { Trans } from "@lingui/react/macro";
 import { useNavigate } from "@tanstack/react-router";
+import { appWorker } from "#src/lib/appWorker/client.ts";
 import { Button } from "#src/ui/Button.tsx";
+import type { Party } from "#src/models/party.ts";
 
-export function SuccessState({ partyId }: { partyId: string }) {
+export function SuccessState({ partyId }: { partyId: Party["id"] }) {
   const navigate = useNavigate();
+
   return (
     <div className="flex min-h-full flex-col items-center justify-center">
       <div className="w-full max-w-sm p-4 text-center">
@@ -13,8 +16,9 @@ export function SuccessState({ partyId }: { partyId: string }) {
 
         <Button
           color="input-like"
-          onClick={() => {
-            void navigate({ to: `/party/${partyId}`, replace: true });
+          pressAction={async () => {
+            await appWorker.recalculateBalances(partyId);
+            await navigate({ to: `/party/${partyId}`, replace: true });
           }}
           className="font-bold"
         >

--- a/packages/pwa/src/routes/migrate_.tricount/route.tsx
+++ b/packages/pwa/src/routes/migrate_.tricount/route.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRepo } from "#src/lib/automerge/useRepo.ts";
 import { createPartyFromMigrationData, type MigrationData } from "#src/models/migration.ts";
 import { getAppLink } from "#src/lib/link.ts";
+import type { Party } from "#src/models/party.ts";
 import { ErrorState, SuccessState } from "./-components/FinishedStates.js";
 import { IdleState } from "./-components/IdleState.js";
 import { InProgressState } from "./-components/InProgressState.js";
@@ -39,7 +40,7 @@ type MigrationState =
     }
   | {
       type: "success";
-      partyId: string;
+      partyId: Party["id"];
     }
   | {
       type: "error";


### PR DESCRIPTION
## Description

Make Tricount imports deterministic before creating migration data. Tricount response ordering can vary between requests, and the importer previously preserved that order when creating expense shares. Since rounding remainders are order-sensitive, repeated imports of the same Tricount could assign one-cent differences to different participants.

This PR normalizes memberships, registry entries, and allocations before building party data, and uses stable temporary IDs for imported participants/photos so migration output is easier to compare.

## Related Issues

Related to #328

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

Extracted from the Dinero v2 migration branch so `main` can be made deterministic before comparing money-calculation behavior in #328.
