### PR TITLE
fix(pwa): preserve saved settings before returning

### DIFF
--- a/.changeset/saved-settings-stay-put.md
+++ b/.changeset/saved-settings-stay-put.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Fix Party Settings reverting fields after saving while keeping settings forms' post-save navigation.

--- a/packages/pwa/e2e/settings.spec.ts
+++ b/packages/pwa/e2e/settings.spec.ts
@@ -1,0 +1,48 @@
+import { defaultParticipants, createPartyFixture } from "./harness/scenarios";
+import { expect, test } from "./harness/trizum.fixture";
+
+test.describe("Settings forms", () => {
+  test("returns from party settings after saving", async ({ harness, page }) => {
+    const seededParty = await harness.seedJoinedParty({
+      fixture: createPartyFixture(),
+      memberParticipantId: defaultParticipants.blair.id,
+    });
+    const updatedPartyName = "Updated weekend trip";
+
+    await harness.navigate(`/party/${seededParty.partyId}/settings`);
+    await expect(page.getByRole("heading", { name: "Party Settings" })).toBeVisible();
+
+    const nameField = page.getByLabel("Name", { exact: true });
+
+    await nameField.fill(updatedPartyName);
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByText("Party settings saved!")).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/party/${seededParty.partyId}(?:\\?.*)?$`));
+
+    await harness.navigate(`/party/${seededParty.partyId}/settings`);
+    await expect(page.getByLabel("Name", { exact: true })).toHaveValue(updatedPartyName);
+  });
+
+  test("returns from user settings after saving", async ({ harness, page }) => {
+    const updatedUsername = "Saved Harness User";
+
+    await harness.seedPartyList({
+      username: "Harness User",
+      phone: "",
+    });
+    await harness.navigate("/settings");
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+
+    const usernameField = page.getByLabel("Username");
+
+    await usernameField.fill(updatedUsername);
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByText("Settings saved")).toBeVisible();
+    await expect(page).toHaveURL(/\/(?:\?.*)?$/);
+
+    await harness.navigate("/settings");
+    await expect(page.getByLabel("Username")).toHaveValue(updatedUsername);
+  });
+});

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -71,7 +71,7 @@ msgstr "About"
 msgid "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 msgstr "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 
-#: src/routes/settings.tsx:443
+#: src/routes/settings.tsx:441
 msgid "Accent color"
 msgstr "Accent color"
 
@@ -91,7 +91,7 @@ msgstr "Across the selected timeframe"
 msgid "Active"
 msgstr "Active"
 
-#: src/routes/settings.tsx:494
+#: src/routes/settings.tsx:492
 msgid "Active on this device"
 msgstr "Active on this device"
 
@@ -275,15 +275,15 @@ msgid "Authentication failed"
 msgstr "Authentication failed"
 
 #: src/components/ExpenseEditor.tsx:356
-#: src/routes/settings.tsx:430
+#: src/routes/settings.tsx:428
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
 
-#: src/routes/settings.tsx:432
+#: src/routes/settings.tsx:430
 msgid "Automatically open the calculator when focusing amount fields"
 msgstr "Automatically open the calculator when focusing amount fields"
 
-#: src/routes/settings.tsx:419
+#: src/routes/settings.tsx:417
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Automatically open the last visited party when you open the app"
 
@@ -493,7 +493,7 @@ msgstr "Check your email for the sign-in link"
 msgid "Checking for updates..."
 msgstr "Checking for updates..."
 
-#: src/routes/settings.tsx:482
+#: src/routes/settings.tsx:480
 msgid "Checking..."
 msgstr "Checking..."
 
@@ -700,7 +700,7 @@ msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
 #: src/hooks/useCloudSyncAccountState.ts:220
-#: src/routes/settings.tsx:486
+#: src/routes/settings.tsx:484
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
 
@@ -1101,7 +1101,7 @@ msgstr "Filter totals and rankings"
 msgid "Finishing sign in"
 msgstr "Finishing sign in"
 
-#: src/routes/settings.tsx:381
+#: src/routes/settings.tsx:379
 msgid "For payments through Bizum or similar services"
 msgstr "For payments through Bizum or similar services"
 
@@ -1402,7 +1402,7 @@ msgstr "Kuwaiti Dinar"
 msgid "Kyrgystani Som"
 msgstr "Kyrgystani Som"
 
-#: src/routes/settings.tsx:396
+#: src/routes/settings.tsx:394
 msgid "Language"
 msgstr "Language"
 
@@ -1734,11 +1734,11 @@ msgstr "Not a valid trizum party code"
 msgid "Not connected"
 msgstr "Not connected"
 
-#: src/routes/settings.tsx:490
+#: src/routes/settings.tsx:488
 msgid "Not set up"
 msgstr "Not set up"
 
-#: src/routes/settings.tsx:478
+#: src/routes/settings.tsx:476
 msgid "Not signed in"
 msgstr "Not signed in"
 
@@ -1782,7 +1782,7 @@ msgstr "Open calculator when focusing amount fields"
 msgid "Open GitHub Issues"
 msgstr "Open GitHub Issues"
 
-#: src/routes/settings.tsx:417
+#: src/routes/settings.tsx:415
 msgid "Open last party on launch"
 msgstr "Open last party on launch"
 
@@ -1911,7 +1911,7 @@ msgstr "Party restored to home"
 msgid "Party Settings"
 msgstr "Party Settings"
 
-#: src/routes/party_.$partyId.settings/route.tsx:55
+#: src/routes/party_.$partyId.settings/route.tsx:63
 msgid "Party settings saved!"
 msgstr "Party settings saved!"
 
@@ -1993,7 +1993,7 @@ msgstr "Peruvian Sol"
 msgid "Philippine Peso"
 msgstr "Philippine Peso"
 
-#: src/routes/settings.tsx:380
+#: src/routes/settings.tsx:378
 msgid "Phone number"
 msgstr "Phone number"
 
@@ -2081,7 +2081,7 @@ msgstr "QR code frame capture"
 msgid "Ranking based on how much each participant paid in the selected timeframe."
 msgstr "Ranking based on how much each participant paid in the selected timeframe."
 
-#: src/routes/settings.tsx:497
+#: src/routes/settings.tsx:495
 msgid "Ready on another device"
 msgstr "Ready on another device"
 
@@ -2182,7 +2182,7 @@ msgstr "Saudi Riyal"
 #: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
-#: src/routes/party_.$partyId.settings/route.tsx:111
+#: src/routes/party_.$partyId.settings/route.tsx:120
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
 #: src/routes/settings.tsx:232
@@ -2451,7 +2451,7 @@ msgstr "Submit a Request"
 #: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
-#: src/routes/party_.$partyId.settings/route.tsx:111
+#: src/routes/party_.$partyId.settings/route.tsx:120
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
 #: src/routes/settings.tsx:232
@@ -2906,7 +2906,7 @@ msgstr "Use trizum cloud on this device?"
 msgid "Use your camera to scan a trizum invite"
 msgstr "Use your camera to scan a trizum invite"
 
-#: src/routes/settings.tsx:358
+#: src/routes/settings.tsx:356
 msgid "Username"
 msgstr "Username"
 
@@ -2992,7 +2992,7 @@ msgstr "Welcome to trizum"
 msgid "What is this party about?"
 msgstr "What is this party about?"
 
-#: src/routes/settings.tsx:359
+#: src/routes/settings.tsx:357
 msgid "What's your preferred way to be addressed?"
 msgstr "What's your preferred way to be addressed?"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -67,7 +67,7 @@ msgstr "Acerca de"
 msgid "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 msgstr "¡Por supuesto! trizum funciona sin necesidad de crear una cuenta o registrarte. Solo crea un grupo y empieza a registrar gastos."
 
-#: src/routes/settings.tsx:443
+#: src/routes/settings.tsx:441
 msgid "Accent color"
 msgstr "Color de acento"
 
@@ -87,7 +87,7 @@ msgstr "En el período seleccionado"
 msgid "Active"
 msgstr "Activos"
 
-#: src/routes/settings.tsx:494
+#: src/routes/settings.tsx:492
 msgid "Active on this device"
 msgstr "Activo en este dispositivo"
 
@@ -263,15 +263,15 @@ msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
 #: src/components/ExpenseEditor.tsx:356
-#: src/routes/settings.tsx:430
+#: src/routes/settings.tsx:428
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
 
-#: src/routes/settings.tsx:432
+#: src/routes/settings.tsx:430
 msgid "Automatically open the calculator when focusing amount fields"
 msgstr "Abrir automáticamente la calculadora al enfocar campos de importe"
 
-#: src/routes/settings.tsx:419
+#: src/routes/settings.tsx:417
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Abrir automáticamente el último grupo visitado cuando abras la app"
 
@@ -469,7 +469,7 @@ msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
-#: src/routes/settings.tsx:482
+#: src/routes/settings.tsx:480
 msgid "Checking..."
 msgstr "Comprobando..."
 
@@ -676,7 +676,7 @@ msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
 #: src/hooks/useCloudSyncAccountState.ts:220
-#: src/routes/settings.tsx:486
+#: src/routes/settings.tsx:484
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
 
@@ -1057,7 +1057,7 @@ msgstr "Filtra totales y rankings"
 msgid "Finishing sign in"
 msgstr "Terminando el inicio de sesión"
 
-#: src/routes/settings.tsx:381
+#: src/routes/settings.tsx:379
 msgid "For payments through Bizum or similar services"
 msgstr "Para pagos mediante Bizum o servicios similares"
 
@@ -1350,7 +1350,7 @@ msgstr "Dinar Kuwaití"
 msgid "Kyrgystani Som"
 msgstr "Som Kirguís"
 
-#: src/routes/settings.tsx:396
+#: src/routes/settings.tsx:394
 msgid "Language"
 msgstr "Idioma"
 
@@ -1678,11 +1678,11 @@ msgstr "No es un código de grupo de trizum válido"
 msgid "Not connected"
 msgstr "No conectado"
 
-#: src/routes/settings.tsx:490
+#: src/routes/settings.tsx:488
 msgid "Not set up"
 msgstr "No configurada"
 
-#: src/routes/settings.tsx:478
+#: src/routes/settings.tsx:476
 msgid "Not signed in"
 msgstr "No has iniciado sesión"
 
@@ -1726,7 +1726,7 @@ msgstr "Abrir calculadora al enfocar campos de importe"
 msgid "Open GitHub Issues"
 msgstr "Abrir GitHub Issues"
 
-#: src/routes/settings.tsx:417
+#: src/routes/settings.tsx:415
 msgid "Open last party on launch"
 msgstr "Abrir el último grupo al abrir la app"
 
@@ -1843,7 +1843,7 @@ msgstr "Grupo restaurado al inicio"
 msgid "Party Settings"
 msgstr "Configuración del Grupo"
 
-#: src/routes/party_.$partyId.settings/route.tsx:55
+#: src/routes/party_.$partyId.settings/route.tsx:63
 msgid "Party settings saved!"
 msgstr "¡Configuración del grupo guardada!"
 
@@ -1925,7 +1925,7 @@ msgstr "Sol Peruano"
 msgid "Philippine Peso"
 msgstr "Peso Filipino"
 
-#: src/routes/settings.tsx:380
+#: src/routes/settings.tsx:378
 msgid "Phone number"
 msgstr "Número de teléfono"
 
@@ -2013,7 +2013,7 @@ msgstr "Captura de fotograma del código QR"
 msgid "Ranking based on how much each participant paid in the selected timeframe."
 msgstr "Clasificación según cuánto ha pagado cada participante en el período seleccionado."
 
-#: src/routes/settings.tsx:497
+#: src/routes/settings.tsx:495
 msgid "Ready on another device"
 msgstr "Listo en otro dispositivo"
 
@@ -2110,7 +2110,7 @@ msgstr "Riyal Saudí"
 #: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
-#: src/routes/party_.$partyId.settings/route.tsx:111
+#: src/routes/party_.$partyId.settings/route.tsx:120
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
 #: src/routes/settings.tsx:232
@@ -2375,7 +2375,7 @@ msgstr "Enviar sugerencia"
 #: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
-#: src/routes/party_.$partyId.settings/route.tsx:111
+#: src/routes/party_.$partyId.settings/route.tsx:120
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
 #: src/routes/settings.tsx:232
@@ -2809,7 +2809,7 @@ msgstr "¿Usar trizum cloud en este dispositivo?"
 msgid "Use your camera to scan a trizum invite"
 msgstr "Usa tu cámara para escanear una invitación de trizum"
 
-#: src/routes/settings.tsx:358
+#: src/routes/settings.tsx:356
 msgid "Username"
 msgstr "Nombre de usuario"
 
@@ -2891,7 +2891,7 @@ msgstr "Bienvenid@ a trizum"
 msgid "What is this party about?"
 msgstr "¿De qué trata este grupo?"
 
-#: src/routes/settings.tsx:359
+#: src/routes/settings.tsx:357
 msgid "What's your preferred way to be addressed?"
 msgstr "¿Cuál es tu forma preferida de que te llamen?"
 

--- a/packages/pwa/src/routes/party_.$partyId.settings/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.settings/route.tsx
@@ -4,7 +4,7 @@ import { guardParticipatingInParty } from "#src/lib/guards.js";
 import { DEFAULT_PARTY_SYMBOL, type Party, type PartyParticipant } from "#src/models/party.js";
 import { IconButton } from "#src/ui/IconButton.js";
 import { useForm } from "@tanstack/react-form";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { PartyPendingComponent } from "#src/components/PartyPendingComponent.tsx";
 import { Suspense, useId } from "react";
 import { toast } from "sonner";
@@ -27,6 +27,7 @@ export const Route = createFileRoute("/party_/$partyId/settings")({
 function PartySettings() {
   const params = Route.useParams();
   const { party, updateSettings } = useParty(params.partyId);
+  const navigate = useNavigate();
 
   function onSaveSettings(values: PartySettingsFormValues) {
     const participants = values.participants
@@ -44,15 +45,23 @@ function PartySettings() {
         result[next.id] = next;
         return result;
       }, {});
-
-    updateSettings({
+    const savedValues = {
       name: values.name,
       symbol: values.symbol,
       description: values.description,
+      participants: Object.values(participants),
+    } as PartySettingsFormValues;
+
+    updateSettings({
+      name: savedValues.name,
+      symbol: savedValues.symbol,
+      description: savedValues.description,
       participants,
     });
 
+    form.reset(savedValues);
     toast.success(t`Party settings saved!`);
+    void navigate({ to: "..", replace: true });
   }
 
   const form = useForm({
@@ -120,9 +129,12 @@ function PartySettings() {
         }
       />
 
+      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form to stale defaults after saving settings. */}
       <form
         id={formId}
-        action={() => {
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
           void form.handleSubmit();
         }}
         className="container mt-4 flex flex-col gap-6 px-4"

--- a/packages/pwa/src/routes/settings.tsx
+++ b/packages/pwa/src/routes/settings.tsx
@@ -186,7 +186,7 @@ export function Settings() {
       autoOpenCalculator: values.autoOpenCalculator,
       hue: values.hue,
     });
-    form.reset();
+    form.reset(values);
     toast.success(t`Settings saved`);
     void navigate({ to: "..", replace: true });
   }
@@ -328,9 +328,7 @@ function SettingsFormFields({
   return (
     <form
       id={formId}
-      action={() => {
-        void form.handleSubmit();
-      }}
+      action={() => form.handleSubmit()}
       className="container mt-6 flex flex-col gap-6 px-4 pb-8 pb-safe"
     >
       <form.Field name="avatarId">


### PR DESCRIPTION
## Description

Fixes settings save behavior so saved values are committed before the app returns to the previous screen. Party Settings no longer flashes or reverts to the old form state after saving, and both Party Settings and User Settings keep their expected post-save navigation.

Adds E2E regression coverage for saving both settings forms and reopening them to confirm the saved values persisted.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; behavior is covered by the settings E2E regression.

## Additional Notes

Validation also included `vp exec playwright test e2e/settings.spec.ts` in Chromium and WebKit.
