### PR TITLE
chore(renovate): group tailwind-merge updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,9 +82,9 @@
       "groupName": "TanStack major updates"
     },
     {
-      "description": "Keep Tailwind CSS major updates with plugins that require the same Tailwind major.",
+      "description": "Keep Tailwind CSS major updates with companion packages that require the same Tailwind major.",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["tailwindcss", "tailwindcss-react-aria-components"],
+      "matchPackageNames": ["tailwind-merge", "tailwindcss", "tailwindcss-react-aria-components"],
       "matchUpdateTypes": ["major"],
       "groupName": "Tailwind CSS major updates"
     },


### PR DESCRIPTION
## Description

Updates the Tailwind CSS major Renovate grouping so `tailwind-merge` is included with `tailwindcss` and `tailwindcss-react-aria-components`.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (describe below)

Dependency automation configuration.

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable.

## Additional Notes

- `jq empty renovate.json` passed.
- No changeset is included because this is internal dependency automation configuration.
- Initial `vp run check` failed before dependencies were installed; `vp install` resolved the local setup, and the rerun passed.
