### PR TITLE
chore(renovate): group Vite+ toolchain updates

### DIFF
--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -39,6 +39,11 @@ keep update volume manageable. TypeScript and current 0.x patch/minor updates
 are grouped separately for manual review so they do not block automerge for
 unrelated dependencies.
 
+Vite+ toolchain updates have their own group so changes to Vite+, the aliased
+Vite core package, Vitest, Vite/Vitest plugins, and adjacent toolchain packages
+such as Rolldown, tsdown, Oxlint, Oxfmt, and Vite Task are reviewed together
+instead of being buried in the broad non-major dependency group.
+
 Most major updates stay independent, but tightly coupled dependency families
 still have major grouping rules so packages that need to move together are
 reviewed together. `react` and `react-dom` updates are disabled because the app

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,32 @@
       "groupSlug": "manual-non-major-dependencies"
     },
     {
+      "description": "Keep Vite+ toolchain and Vite/Vitest ecosystem updates together.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@cloudflare/vite-plugin",
+        "@lingui/vite-plugin",
+        "@rolldown/*",
+        "@sentry/vite-plugin",
+        "@vite-pwa/*",
+        "@vitejs/*",
+        "@vitest/*",
+        "@voidzero-dev/vite-plus-core",
+        "oxfmt",
+        "oxlint",
+        "oxlint-*",
+        "rolldown",
+        "tsdown",
+        "vite",
+        "vite-*",
+        "vite-plus",
+        "vite-task",
+        "vitest"
+      ],
+      "groupName": "Vite+ toolchain updates",
+      "groupSlug": "vite-plus-toolchain"
+    },
+    {
       "description": "Do not update experimental React runtime packages; they are managed manually.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["react", "react-dom"],


### PR DESCRIPTION
## Description

Adds a dedicated Renovate package rule for the Vite+ toolchain so Vite+, the aliased Vite core package, Vitest, Vite/Vitest plugins, and adjacent tooling update together instead of landing in the broad dependency groups.

Updates the Renovate documentation to describe the new grouping behavior.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [x] Other: Renovate configuration

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] Tests for new functionality are not applicable for this config-only change
- [x] `vp run lingui:extract` ran in the pre-commit hook; no user-facing strings were added
- [x] Changeset is not needed for internal Renovate config/docs changes

## Screenshots

No UI changes.

## Additional Notes

Additional validation:

- `node -e 'JSON.parse(require("node:fs").readFileSync("renovate.json", "utf8"))'`
- `vp dlx -p renovate renovate-config-validator renovate.json`
