### PR TITLE
chore(renovate): group React Doctor updates

### DIFF
--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -44,6 +44,9 @@ Vite core package, Vitest, Vite/Vitest plugins, and adjacent toolchain packages
 such as Rolldown, tsdown, Oxlint, Oxfmt, and Vite Task are reviewed together
 instead of being buried in the broad non-major dependency group.
 
+React Doctor dependencies are grouped together so the CLI and matching Oxlint
+plugin stay in sync.
+
 Most major updates stay independent, but tightly coupled dependency families
 still have major grouping rules so packages that need to move together are
 reviewed together. `react` and `react-dom` updates are disabled because the app

--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,13 @@
       "groupSlug": "vite-plus-toolchain"
     },
     {
+      "description": "Keep React Doctor package updates together.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["react-doctor", "oxlint-plugin-react-doctor"],
+      "groupName": "React Doctor updates",
+      "groupSlug": "react-doctor"
+    },
+    {
       "description": "Do not update experimental React runtime packages; they are managed manually.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["react", "react-dom"],


### PR DESCRIPTION
## Description

Adds a dedicated Renovate package rule that groups `react-doctor` and `oxlint-plugin-react-doctor` updates together. Updates the Renovate docs so the dependency automation behavior remains documented.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [x] Other (describe below)

Renovate configuration maintenance.

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; no UI changes.

## Additional Notes

Also validated `renovate.json` with `vp dlx -p renovate renovate-config-validator renovate.json`.
No changeset is needed because this is internal dependency automation maintenance.
