### PR TITLE
chore(deps): update dependency culori to v4

### DIFF
--- a/packages/tw-dynamic-themes/src/runtime.ts
+++ b/packages/tw-dynamic-themes/src/runtime.ts
@@ -1,5 +1,4 @@
 import {
-  // @ts-expect-error Old typings for this module
   toGamut as _toGamut,
   type Color,
   type Oklch,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,8 @@ catalogs:
       specifier: 1.168.19
       version: 1.168.19
     '@types/culori':
-      specifier: 2.0.4
-      version: 2.0.4
+      specifier: 4.0.1
+      version: 4.0.1
     '@types/node':
       specifier: 24.13.2
       version: 24.13.2
@@ -209,8 +209,8 @@ catalogs:
       specifier: 1.7.5
       version: 1.7.5
     culori:
-      specifier: 3.3.0
-      version: 3.3.0
+      specifier: 4.0.2
+      version: 4.0.2
     dinero.js:
       specifier: 2.0.2
       version: 2.0.2
@@ -402,7 +402,7 @@ importers:
         version: 0.7.1
       react-doctor:
         specifier: 'catalog:'
-        version: 0.7.1(@emnapi/core@1.11.0)(eslint@10.6.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0)
+        version: 0.7.1(eslint@10.6.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0)
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.2
         version: '@voidzero-dev/vite-plus-core@0.2.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)'
@@ -958,14 +958,14 @@ importers:
     dependencies:
       culori:
         specifier: 'catalog:'
-        version: 3.3.0
+        version: 4.0.2
     devDependencies:
       '@trizum/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       '@types/culori':
         specifier: 'catalog:'
-        version: 2.0.4
+        version: 4.0.1
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -4625,8 +4625,8 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
-  '@types/culori@2.0.4':
-    resolution: {integrity: sha512-GeLW8+KBRkwqIgeGrU8EnNbBE2D7waYbQHkx2xnI5exlzSGTMpjWtDaHzLWK1PTYmyJN9u6dPvMYumFevDe+VA==}
+  '@types/culori@4.0.1':
+    resolution: {integrity: sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -5671,8 +5671,8 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
-  culori@3.3.0:
-    resolution: {integrity: sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==}
+  culori@4.0.2:
+    resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   dargs@7.0.0:
@@ -8359,9 +8359,6 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
-
-  tailwind-merge@2.6.1:
-    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -11515,12 +11512,11 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.21.3':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.21.3(@emnapi/core@1.11.0)':
+  '@oxc-resolver/binding-wasm32-wasi@11.21.3':
     dependencies:
+      '@emnapi/core': 1.11.0
       '@emnapi/runtime': 1.11.0
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
     optional: true
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.21.3':
@@ -12517,7 +12513,7 @@ snapshots:
       react-window: 2.2.7(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       sonner: 2.0.7(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
       suspense: 0.1.0(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)
-      tailwind-merge: 2.6.1
+      tailwind-merge: 3.6.0
       ulidx: 2.4.1
       workbox-build: 7.4.1(@types/babel__core@7.20.5)
       workbox-window: 7.4.1
@@ -12576,7 +12572,7 @@ snapshots:
 
   '@trizum/tw-dynamic-themes@file:packages/tw-dynamic-themes':
     dependencies:
-      culori: 3.3.0
+      culori: 4.0.2
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -12622,7 +12618,7 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
-  '@types/culori@2.0.4': {}
+  '@types/culori@4.0.1': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -13706,7 +13702,7 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  culori@3.3.0: {}
+  culori@4.0.2: {}
 
   dargs@7.0.0: {}
 
@@ -13813,16 +13809,14 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.7.1(@emnapi/core@1.11.0):
+  deslop-js@0.7.1:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
       minimatch: 10.2.5
       oxc-parser: 0.132.0
-      oxc-resolver: 11.21.3(@emnapi/core@1.11.0)
+      oxc-resolver: 11.21.3
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
 
   detect-indent@6.1.0: {}
 
@@ -15415,7 +15409,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.135.0
       '@oxc-parser/binding-win32-x64-msvc': 0.135.0
 
-  oxc-resolver@11.21.3(@emnapi/core@1.11.0):
+  oxc-resolver@11.21.3:
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.21.3
       '@oxc-resolver/binding-android-arm64': 11.21.3
@@ -15433,11 +15427,9 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.21.3
       '@oxc-resolver/binding-linux-x64-musl': 11.21.3
       '@oxc-resolver/binding-openharmony-arm64': 11.21.3
-      '@oxc-resolver/binding-wasm32-wasi': 11.21.3(@emnapi/core@1.11.0)
+      '@oxc-resolver/binding-wasm32-wasi': 11.21.3
       '@oxc-resolver/binding-win32-arm64-msvc': 11.21.3
       '@oxc-resolver/binding-win32-x64-msvc': 11.21.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
 
   oxfmt@0.57.0(vite-plus@0.2.2(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)):
     dependencies:
@@ -15864,14 +15856,14 @@ snapshots:
       react-stately: 3.48.0(react@0.0.0-experimental-d025ddd3-20240722)
       use-sync-external-store: 1.6.0(react@0.0.0-experimental-d025ddd3-20240722)
 
-  react-doctor@0.7.1(@emnapi/core@1.11.0)(eslint@10.6.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0):
+  react-doctor@0.7.1(eslint@10.6.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.7.1(@emnapi/core@1.11.0)
+      deslop-js: 0.7.1
       eslint-plugin-react-hooks: 7.1.1(eslint@10.6.0(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
@@ -15884,7 +15876,6 @@ snapshots:
       vscode-uri: 3.1.0
       yaml: 2.9.0
     transitivePeerDependencies:
-      - '@emnapi/core'
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
       - eslint
@@ -16702,8 +16693,6 @@ snapshots:
   systeminformation@5.31.3: {}
 
   tagged-tag@1.0.0: {}
-
-  tailwind-merge@2.6.1: {}
 
   tailwind-merge@3.6.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,7 +87,7 @@ catalog:
   "@tanstack/react-router": 1.170.17
   "@tanstack/router-plugin": 1.168.19
   "@tailwindcss/vite": 4.3.2
-  "@types/culori": 2.0.4
+  "@types/culori": 4.0.1
   "@types/node": 24.13.2
   "@types/react": npm:types-react@rc
   "@types/react-dom": npm:types-react-dom@rc
@@ -104,7 +104,7 @@ catalog:
   capacitor-plugin-safe-area: 5.0.0
   clsx: 2.1.1
   comctx: 1.7.5
-  culori: 3.3.0
+  culori: 4.0.2
   dinero.js: 2.0.2
   drizzle-kit: 0.31.10
   drizzle-orm: 0.45.2


### PR DESCRIPTION
Supersedes #359.
## Why
Reviewed chore(deps): update dependency culori to v4 (#359); affected areas: workspace; updates: @types/culori 2.0.4 -> 4.0.1, culori 3.3.0 -> 4.0.2.
The catalog and lockfile update is not mergeable as-is. @types/culori 4 now exposes the toGamut import, making the existing @ts-expect-error in tw-dynamic-themes unused, and CI is red in the production TypeScript build and downstream mobile sync jobs.
- [blocker] PR checks are failing: Mobile Sync (ios), Mobile Sync (android), Check (check), Check (test), Autofix & Extract Messages, Check (build), Deploy Preview
- [blocker] CI fails because the culori type update makes an existing @ts-expect-error unused (packages/tw-dynamic-themes/src/runtime.ts): The failed Check (test), Mobile Sync (android), and Mobile Sync (ios) logs all stop in packages/tw-dynamic-themes with TS2578: Unused '@ts-expect-error' directive. The PR updates @types/culori from 2.0.4 to 4.0.1, and the new definitions export toGamut, so the suppression above the toGamut import in runtime.ts i
[truncated 300 bytes]
## What
- Updates: @types/culori 2.0.4 -> 4.0.1, culori 3.3.0 -> 4.0.2.
- Fix: Applied the agent-generated fix for the review findings.
- Files: `packages/tw-dynamic-themes/src/runtime.ts`
## How
- Local validation: failed.
- [pass] `vp install --frozen-lockfile`
- [pass] `vp run --no-cache check`
- [fail] `vp run --no-cache test` (exit 1)
- Failed command: `vp run --no-cache test` (exit 1).
- Failure output:
```text
Test Files  1 failed (1)
::error file=/tmp/trizum-renovate-6W0jMu/packages/tw-dynamic-themes/src/css.test.ts,title=[tw-dynamic-themes] src/css.test.ts,line=5,column=1::TypeError: Cannot read properties of undefined (reading 'config')%0A ❯ src/css.test.ts:5:1%0A ❯ VitestModuleRunner.directRequest ../../../../home/runner/work/trizum/trizum/node_modules/.pnpm/@voidzero-dev+vite-plus-core@0.2.2_@types+node@24.13.2_esbuild@0.28.1_jiti@2.7.0_terser_aad3288f51ce4c9ff9b6ef215b3fbe36/node_modules/@voidzero-dev/vite-plus-core/dis
[truncated 641 bytes]
 Test Files  2 failed (2)
::error file=/tmp/trizum-renovate-6W0jMu/packages/logging/src/github-actions.test.ts,title=[logging] src/github-actions.test.ts,line=45,column=1::Error: Vitest failed to find the current suite. One of the following is possible:%0A- "vitest" is imported directly without running "vitest" command%0A- "vitest" is imported insid
[truncated 807 bytes]
```
- CI on this PR is the source of truth for merge readiness.