### PR TITLE
fix(pwa): pin QR scanner dependency

### DIFF
--- a/.changeset/quiet-qr-scanner.md
+++ b/.changeset/quiet-qr-scanner.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Pin `barcode-detector` to 3.0.8 to keep QR scanning on the ZXing WASM version used by the last stable release.

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -47,6 +47,10 @@ instead of being buried in the broad non-major dependency group.
 React Doctor dependencies are grouped together so the CLI and matching Oxlint
 plugin stay in sync.
 
+`barcode-detector` updates are disabled because newer ZXing WASM releases have
+regressed QR scanning on affected Android Chrome devices. Keep the catalog pin
+and Renovate package rule in sync when this is revisited.
+
 Most major updates stay independent, but tightly coupled dependency families
 still have major grouping rules so packages that need to move together are
 reviewed together. `react` and `react-dom` updates are disabled because the app

--- a/packages/pwa/src/lib/qr.test.ts
+++ b/packages/pwa/src/lib/qr.test.ts
@@ -1,6 +1,127 @@
-import { describe, test, expect, beforeAll } from "vite-plus/test";
-import { parseQRCodeForPartyId } from "./qr";
 import { generateAutomergeUrl, parseAutomergeUrl } from "@automerge/automerge-repo/slim";
+import { prepareZXingModule } from "barcode-detector/ponyfill";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vite-plus/test";
+import { BarcodeDetector, parseQRCodeForPartyId } from "./qr";
+
+const QR_SCANNER_TEST_VALUE = "TRIZUM QR SCANNER TEST";
+
+const QR_SCANNER_TEST_MODULES = [
+  "1111111011100001101111111",
+  "1000001011001011001000001",
+  "1011101000010111001011101",
+  "1011101010110000001011101",
+  "1011101000010100001011101",
+  "1000001000100010101000001",
+  "1111111010101010101111111",
+  "0000000010101110000000000",
+  "1011011101100110101001011",
+  "0101110100011001100101111",
+  "0110111100110010000101111",
+  "1101010000000111101001101",
+  "0000111011110001001000011",
+  "0001100111110100110011010",
+  "0100011010001010011011010",
+  "1001110010101100101111010",
+  "0000101111010001111111110",
+  "0000000011001100100010110",
+  "1111111010111001101010111",
+  "1000001010001001100011001",
+  "1011101000111100111111001",
+  "1011101011101111110100001",
+  "1011101011011100110000010",
+  "1000001000000001011011001",
+  "1111111010101011000001101",
+] as const;
+
+class TestImageData {
+  constructor(
+    public data: Uint8ClampedArray,
+    public width: number,
+    public height: number,
+  ) {}
+}
+
+class TestDOMRectReadOnly {
+  public readonly top: number;
+  public readonly right: number;
+  public readonly bottom: number;
+  public readonly left: number;
+
+  constructor(
+    public readonly x = 0,
+    public readonly y = 0,
+    public readonly width = 0,
+    public readonly height = 0,
+  ) {
+    this.top = y;
+    this.right = x + width;
+    this.bottom = y + height;
+    this.left = x;
+  }
+}
+
+function createQRCodeImageData(rows: readonly string[]): ImageData {
+  const moduleScale = 8;
+  const quietZoneModules = 4;
+  const moduleCount = rows.length;
+  const width = (moduleCount + quietZoneModules * 2) * moduleScale;
+  const data = new Uint8ClampedArray(width * width * 4);
+
+  data.fill(255);
+
+  rows.forEach((row, moduleY) => {
+    row.split("").forEach((module, moduleX) => {
+      if (module !== "1") {
+        return;
+      }
+
+      const startX = (moduleX + quietZoneModules) * moduleScale;
+      const startY = (moduleY + quietZoneModules) * moduleScale;
+
+      for (let y = startY; y < startY + moduleScale; y += 1) {
+        for (let x = startX; x < startX + moduleScale; x += 1) {
+          const pixel = (y * width + x) * 4;
+          data[pixel] = 0;
+          data[pixel + 1] = 0;
+          data[pixel + 2] = 0;
+        }
+      }
+    });
+  });
+
+  return new TestImageData(data, width, width) as ImageData;
+}
+
+describe("BarcodeDetector", () => {
+  beforeAll(() => {
+    vi.stubGlobal("ImageData", TestImageData);
+    vi.stubGlobal("DOMRectReadOnly", TestDOMRectReadOnly);
+    prepareZXingModule({
+      overrides: {
+        wasmBinary: new Uint8Array(
+          readFileSync(fileURLToPath(new URL("../../public/zxing_reader.wasm", import.meta.url))),
+        ),
+      },
+    });
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("detects a QR code from image data", async () => {
+    const detector = new BarcodeDetector({ formats: ["qr_code"] });
+
+    await expect(detector.detect(createQRCodeImageData(QR_SCANNER_TEST_MODULES))).resolves.toEqual([
+      expect.objectContaining({
+        format: "qr_code",
+        rawValue: QR_SCANNER_TEST_VALUE,
+      }),
+    ]);
+  });
+});
 
 describe("parseQRCodeForPartyId", () => {
   // Generate a valid Automerge document ID for testing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ catalogs:
       specifier: 1.0.0
       version: 1.0.0
     barcode-detector:
-      specifier: ^3.0.8
-      version: 3.2.0
+      specifier: 3.0.8
+      version: 3.0.8
     better-auth:
       specifier: 1.6.23
       version: 1.6.23
@@ -525,7 +525,7 @@ importers:
         version: link:../logging
       '@trizum/pwa':
         specifier: workspace:*
-        version: file:packages/pwa(@libsql/client@0.17.4)(@logtape/logtape@2.2.3)(@opentelemetry/api@1.9.1)(@sentry/core@10.63.0)(@types/pg@8.15.6)(babel-plugin-macros@3.1.0)(drizzle-kit@0.31.10)(kysely@0.29.2)(vitest@4.1.9)
+        version: file:packages/pwa(@libsql/client@0.17.4)(@logtape/logtape@2.2.3)(@opentelemetry/api@1.9.1)(@sentry/core@10.63.0)(@types/emscripten@1.41.5)(@types/pg@8.15.6)(babel-plugin-macros@3.1.0)(drizzle-kit@0.31.10)(kysely@0.29.2)(vitest@4.1.9)
       capacitor-plugin-safe-area:
         specifier: 'catalog:'
         version: 5.0.0(@capacitor/core@8.4.1)
@@ -646,7 +646,7 @@ importers:
         version: 10.3.1(react@0.0.0-experimental-d025ddd3-20240722)
       barcode-detector:
         specifier: 'catalog:'
-        version: 3.2.0(@types/emscripten@1.41.5)
+        version: 3.0.8(@types/emscripten@1.41.5)
       better-auth:
         specifier: 'catalog:'
         version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2))(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)(vitest@4.1.9)
@@ -5143,8 +5143,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  barcode-detector@3.2.0:
-    resolution: {integrity: sha512-MrT5TT058ptG5YB157pHLfXKVpp0BKEfQBOb8QvzTbatzmLDu85JJ0Gd/sCYwbwdwStJvxsYflrSN6D6E4Ndyw==}
+  barcode-detector@3.0.8:
+    resolution: {integrity: sha512-Z9jzzE8ngEDyN9EU7lWdGgV07mcnEQnrX8W9WecXDqD2v+5CcVjt9+a134a5zb+kICvpsrDx6NYA6ay4LGFs8A==}
 
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
@@ -9135,8 +9135,8 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
-  zxing-wasm@3.1.0:
-    resolution: {integrity: sha512-5+3V1wPRx4gvbeLH2jB7n2cKrYJ1q4i3QgjnBUtrDPeqxJSi6BdzKJg4y6aF6bgW8zfntnYJyrkqFMevDhL2NA==}
+  zxing-wasm@2.2.4:
+    resolution: {integrity: sha512-1gq5zs4wuNTs5umWLypzNNeuJoluFvwmvjiiT3L9z/TMlVveeJRWy7h90xyUqCe+Qq0zL0w7o5zkdDMWDr9aZA==}
     peerDependencies:
       '@types/emscripten': '>=1.39.6'
 
@@ -12460,7 +12460,7 @@ snapshots:
     dependencies:
       '@logtape/logtape': 2.2.3
 
-  '@trizum/pwa@file:packages/pwa(@libsql/client@0.17.4)(@logtape/logtape@2.2.3)(@opentelemetry/api@1.9.1)(@sentry/core@10.63.0)(@types/pg@8.15.6)(babel-plugin-macros@3.1.0)(drizzle-kit@0.31.10)(kysely@0.29.2)(vitest@4.1.9)':
+  '@trizum/pwa@file:packages/pwa(@libsql/client@0.17.4)(@logtape/logtape@2.2.3)(@opentelemetry/api@1.9.1)(@sentry/core@10.63.0)(@types/emscripten@1.41.5)(@types/pg@8.15.6)(babel-plugin-macros@3.1.0)(drizzle-kit@0.31.10)(kysely@0.29.2)(vitest@4.1.9)':
     dependencies:
       '@automerge/automerge': 3.2.6
       '@automerge/automerge-repo': 2.5.6
@@ -12491,7 +12491,7 @@ snapshots:
       '@trizum/logging': file:packages/logging
       '@trizum/tw-dynamic-themes': file:packages/tw-dynamic-themes
       '@use-gesture/react': 10.3.1(react@0.0.0-experimental-d025ddd3-20240722)
-      barcode-detector: 3.2.0(@types/emscripten@1.41.5)
+      barcode-detector: 3.0.8(@types/emscripten@1.41.5)
       better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2))(react-dom@0.0.0-experimental-d025ddd3-20240722(react@0.0.0-experimental-d025ddd3-20240722))(react@0.0.0-experimental-d025ddd3-20240722)(vitest@4.1.9)
       browser-image-compression: 2.0.2
       capacitor-plugin-safe-area: 5.0.0(@capacitor/core@8.4.1)
@@ -13176,9 +13176,9 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  barcode-detector@3.2.0(@types/emscripten@1.41.5):
+  barcode-detector@3.0.8(@types/emscripten@1.41.5):
     dependencies:
-      zxing-wasm: 3.1.0(@types/emscripten@1.41.5)
+      zxing-wasm: 2.2.4(@types/emscripten@1.41.5)
     transitivePeerDependencies:
       - '@types/emscripten'
 
@@ -17652,7 +17652,7 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zxing-wasm@3.1.0(@types/emscripten@1.41.5):
+  zxing-wasm@2.2.4(@types/emscripten@1.41.5):
     dependencies:
       '@types/emscripten': 1.41.5
       type-fest: 5.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -98,7 +98,7 @@ catalog:
   agent-browser: 0.31.1
   all-contributors-cli: 6.26.1
   babel-plugin-react-compiler: 1.0.0
-  barcode-detector: ^3.0.8
+  barcode-detector: 3.0.8
   better-auth: 1.6.23
   browser-image-compression: 2.0.2
   capacitor-plugin-safe-area: 5.0.0

--- a/renovate.json
+++ b/renovate.json
@@ -81,6 +81,12 @@
       "enabled": false
     },
     {
+      "description": "Do not update barcode-detector; newer ZXing WASM releases break QR scanning on affected Android Chrome devices.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["barcode-detector"],
+      "enabled": false
+    },
+    {
       "description": "Keep tightly coupled React support major updates together.",
       "matchManagers": ["npm"],
       "matchPackageNames": [


### PR DESCRIPTION
## Description

Fixes the `/join` QR scanner regression by returning `@trizum/pwa` to the scanner dependency stack used by the last stable release.

- Pins the workspace catalog entry for `barcode-detector` to `3.0.8`.
- Regenerates `pnpm-lock.yaml` so both the PWA and mobile workspace dependency resolve `barcode-detector@3.0.8` with `zxing-wasm@2.2.4`.
- Removes the custom app-owned ZXing scanner fallback changes from this PR and keeps the original scanner behavior.
- Disables Renovate updates for `barcode-detector` with an explicit package rule.
- Documents why the dependency is managed manually in the Renovate docs.
- Adds a PWA QR scanner test that renders a known QR fixture to `ImageData` and verifies the exported `BarcodeDetector` decodes it.

## Related Issues

Related to Sentry issue 7594985724.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable. There are no UI changes.

## Additional Notes

Confirmed with `pnpm why` that PWA and mobile resolve only `barcode-detector@3.0.8` and `zxing-wasm@2.2.4`.

`vp run build` passed with existing chunk-size/plugin timing warnings. Sentry sourcemap upload was skipped locally because `SENTRY_AUTH_TOKEN` is not set.
