### PR TITLE
fix(pwa): preserve form drafts on validation failure

### DIFF
--- a/.changeset/quiet-forms-keep-drafts.md
+++ b/.changeset/quiet-forms-keep-drafts.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Preserve form draft values when validation blocks submission.

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://react.doctor/schema/config.json",
+  "rules": {
+    "react-doctor/no-prevent-default": "off"
+  }
+}

--- a/packages/pwa/e2e/expense-log.spec.ts
+++ b/packages/pwa/e2e/expense-log.spec.ts
@@ -100,4 +100,27 @@ test.describe("Expense log", () => {
       await partyPage.expectExpenseInLog(expenseLogJourney.newExpenseTitle, expectedAmountText);
     });
   });
+
+  test("keeps expense draft values when validation fails", async ({ harness, page }) => {
+    const partyPage = new PartyPage(page);
+    const expenseEditorPage = new ExpenseEditorPage(page);
+    const draftAmount = 12.34;
+
+    const seededParty = await harness.seedJoinedParty({
+      fixture: createExpenseLogFixture(1),
+      memberParticipantId: defaultParticipants.blair.id,
+    });
+
+    await harness.navigate(`/party/${seededParty.partyId}?tab=expenses`);
+    await partyPage.expectLoaded(seededParty.partyId, "Weekend trip");
+    await partyPage.openAddExpense();
+
+    await expenseEditorPage.expectLoaded();
+    await expenseEditorPage.fillAmount(draftAmount);
+    await expenseEditorPage.save();
+
+    await expect(page).toHaveURL(new RegExp(`/party/${seededParty.partyId}/add(?:\\?.*)?$`));
+    await expect(expenseEditorPage.amountField).toHaveValue(draftAmount.toFixed(2));
+    await expect(page.getByText("Title is required")).toBeVisible();
+  });
 });

--- a/packages/pwa/e2e/join-trizum.spec.ts
+++ b/packages/pwa/e2e/join-trizum.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "./harness/trizum.fixture";
+import { JoinTrizumPage } from "./pages/join-trizum.page";
+
+test.describe("Join trizum form", () => {
+  test("keeps the entered invite when validation fails", async ({ harness, page }) => {
+    const joinPage = new JoinTrizumPage(page);
+    const invalidInvite = "not-a-party-code";
+
+    await harness.goto("/join");
+    await joinPage.expectLoaded();
+    await joinPage.codeField.fill(invalidInvite);
+    await joinPage.codeField.evaluate((input: HTMLInputElement) => input.form?.requestSubmit());
+
+    await expect(page).toHaveURL(/\/join(?:\?.*)?$/);
+    await expect(joinPage.codeField).toHaveValue(invalidInvite);
+    await expect(page.getByText("Invalid trizum party code")).toBeVisible();
+  });
+});

--- a/packages/pwa/e2e/migrate-tricount.spec.ts
+++ b/packages/pwa/e2e/migrate-tricount.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "./harness/trizum.fixture";
+
+test.describe("Migrate from Tricount form", () => {
+  test("keeps import options when validation fails", async ({ harness, page }) => {
+    const invalidKey = "not a tricount invite";
+
+    await harness.goto("/migrate/tricount");
+    await expect(page.getByRole("heading", { name: "Migrate from Tricount" })).toBeVisible();
+
+    const keyField = page.getByLabel("Tricount URL or key");
+    const importAttachments = page.getByRole("checkbox", { name: "Import attachments" });
+
+    await keyField.fill(invalidKey);
+    await page.getByText("Import attachments", { exact: true }).click();
+    await expect(importAttachments).not.toBeChecked();
+    await keyField.evaluate((input: HTMLInputElement) => input.form?.requestSubmit());
+
+    await expect(page).toHaveURL(/\/migrate\/tricount(?:\?.*)?$/);
+    await expect(keyField).toHaveValue(invalidKey);
+    await expect(importAttachments).not.toBeChecked();
+    await expect(page.getByText(/Please paste the Tricount sharing message/)).toBeVisible();
+  });
+});

--- a/packages/pwa/e2e/new-trizum.spec.ts
+++ b/packages/pwa/e2e/new-trizum.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "./harness/trizum.fixture";
+import { NewTrizumPage } from "./pages/new-trizum.page";
+
+test.describe("New trizum form", () => {
+  test("keeps draft values when validation fails", async ({ harness, page }) => {
+    const newTrizumPage = new NewTrizumPage(page);
+    const description = "Only the description has been filled";
+
+    await harness.goto("/new");
+    await newTrizumPage.expectLoaded();
+    await newTrizumPage.descriptionField.fill(description);
+    await newTrizumPage.save();
+
+    await expect(page).toHaveURL(/\/new(?:\?.*)?$/);
+    await expect(newTrizumPage.descriptionField).toHaveValue(description);
+    await expect(page.getByText("Title is required")).toBeVisible();
+  });
+});

--- a/packages/pwa/e2e/pages/new-trizum.page.ts
+++ b/packages/pwa/e2e/pages/new-trizum.page.ts
@@ -9,6 +9,7 @@ export class NewTrizumPage {
   readonly page: Page;
   readonly heading: Locator;
   readonly nameField: Locator;
+  readonly descriptionField: Locator;
   readonly participantNames: Locator;
   readonly newParticipantNameField: Locator;
   readonly addParticipantButton: Locator;
@@ -18,6 +19,7 @@ export class NewTrizumPage {
     this.page = page;
     this.heading = page.getByRole("heading", { name: "New trizum" });
     this.nameField = page.getByRole("textbox", { name: /^Name$/ });
+    this.descriptionField = page.getByRole("textbox", { name: /^Description$/ });
     this.participantNames = page.getByRole("textbox", {
       name: /^Participant name$/,
     });
@@ -49,6 +51,10 @@ export class NewTrizumPage {
       await expect(this.participantNames).toHaveCount(participantCount + 1);
     }
 
+    await this.saveButton.click();
+  }
+
+  async save() {
     await this.saveButton.click();
   }
 }

--- a/packages/pwa/e2e/reset-password.spec.ts
+++ b/packages/pwa/e2e/reset-password.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "./harness/trizum.fixture";
+
+test.describe("Reset password form", () => {
+  test("keeps the entered password when validation fails", async ({ harness, page }) => {
+    const invalidPassword = "short";
+
+    await harness.goto("/reset-password?token=test-token");
+    await expect(page.getByRole("heading", { name: "Reset password" })).toBeVisible();
+
+    const passwordField = page.getByLabel("New password");
+
+    await passwordField.fill(invalidPassword);
+    await page.getByRole("button", { name: "Update password" }).click();
+
+    await expect(page).toHaveURL(/\/reset-password\?(?:.*&)?token=test-token(?:&.*)?$/);
+    await expect(passwordField).toHaveValue(invalidPassword);
+    await expect(page.getByText("Password must be at least 8 characters")).toBeVisible();
+  });
+});

--- a/packages/pwa/e2e/settings.spec.ts
+++ b/packages/pwa/e2e/settings.spec.ts
@@ -24,6 +24,28 @@ test.describe("Settings forms", () => {
     await expect(page.getByLabel("Name", { exact: true })).toHaveValue(updatedPartyName);
   });
 
+  test("keeps party settings draft values when validation fails", async ({ harness, page }) => {
+    const seededParty = await harness.seedJoinedParty({
+      fixture: createPartyFixture(),
+      memberParticipantId: defaultParticipants.blair.id,
+    });
+    const draftDescription = "Keep this description after a failed save";
+
+    await harness.navigate(`/party/${seededParty.partyId}/settings`);
+    await expect(page.getByRole("heading", { name: "Party Settings" })).toBeVisible();
+
+    const nameField = page.getByLabel("Name", { exact: true });
+    const descriptionField = page.getByLabel("Description");
+
+    await descriptionField.fill(draftDescription);
+    await nameField.fill("");
+    await nameField.evaluate((input: HTMLInputElement) => input.form?.requestSubmit());
+
+    await expect(page).toHaveURL(new RegExp(`/party/${seededParty.partyId}/settings(?:\\?.*)?$`));
+    await expect(descriptionField).toHaveValue(draftDescription);
+    await expect(page.getByText("Title is required")).toBeVisible();
+  });
+
   test("returns from user settings after saving", async ({ harness, page }) => {
     const updatedUsername = "Saved Harness User";
 
@@ -44,5 +66,27 @@ test.describe("Settings forms", () => {
 
     await harness.navigate("/settings");
     await expect(page.getByLabel("Username")).toHaveValue(updatedUsername);
+  });
+
+  test("keeps user settings draft values when validation fails", async ({ harness, page }) => {
+    const draftPhoneNumber = "612345678";
+
+    await harness.seedPartyList({
+      username: "Harness User",
+      phone: "",
+    });
+    await harness.navigate("/settings");
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+
+    const usernameField = page.getByLabel("Username");
+    const phoneField = page.getByLabel("Phone number");
+
+    await phoneField.fill(draftPhoneNumber);
+    await usernameField.fill("");
+    await usernameField.evaluate((input: HTMLInputElement) => input.form?.requestSubmit());
+
+    await expect(page).toHaveURL(/\/settings(?:\?.*)?$/);
+    await expect(phoneField).toHaveValue(draftPhoneNumber);
+    await expect(page.getByText("A name for the participant is required")).toBeVisible();
   });
 });

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -71,7 +71,7 @@ msgstr "About"
 msgid "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 msgstr "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 
-#: src/routes/settings.tsx:441
+#: src/routes/settings.tsx:446
 msgid "Accent color"
 msgstr "Accent color"
 
@@ -91,11 +91,11 @@ msgstr "Across the selected timeframe"
 msgid "Active"
 msgstr "Active"
 
-#: src/routes/settings.tsx:492
+#: src/routes/settings.tsx:497
 msgid "Active on this device"
 msgstr "Active on this device"
 
-#: src/routes/new/route.tsx:336
+#: src/routes/new/route.tsx:339
 msgid "ADB Unit of Account"
 msgstr "ADB Unit of Account"
 
@@ -146,15 +146,15 @@ msgstr "Adding expense..."
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/routes/new/route.tsx:193
+#: src/routes/new/route.tsx:196
 msgid "Afghan Afghani"
 msgstr "Afghan Afghani"
 
-#: src/routes/new/route.tsx:194
+#: src/routes/new/route.tsx:197
 msgid "Albanian Lek"
 msgstr "Albanian Lek"
 
-#: src/routes/new/route.tsx:228
+#: src/routes/new/route.tsx:231
 msgid "Algerian Dinar"
 msgstr "Algerian Dinar"
 
@@ -166,7 +166,7 @@ msgstr "Align QR code here"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:445
+#: src/components/ExpenseEditor.tsx:449
 msgid "Amount"
 msgstr "Amount"
 
@@ -174,15 +174,15 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:763
+#: src/components/ExpenseEditor.tsx:767
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:435
+#: src/components/ExpenseEditor.tsx:439
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
-#: src/routes/new/route.tsx:197
+#: src/routes/new/route.tsx:200
 msgid "Angolan Kwanza"
 msgstr "Angolan Kwanza"
 
@@ -234,15 +234,15 @@ msgstr "Archived Parties"
 msgid "Archived parties live here until you restore them to the home screen."
 msgstr "Archived parties live here until you restore them to the home screen."
 
-#: src/routes/new/route.tsx:198
+#: src/routes/new/route.tsx:201
 msgid "Argentine Peso"
 msgstr "Argentine Peso"
 
-#: src/routes/new/route.tsx:195
+#: src/routes/new/route.tsx:198
 msgid "Armenian Dram"
 msgstr "Armenian Dram"
 
-#: src/routes/new/route.tsx:199
+#: src/routes/new/route.tsx:202
 msgid "Aruban Florin"
 msgstr "Aruban Florin"
 
@@ -259,7 +259,7 @@ msgstr "Attach photos of receipts to your expenses"
 msgid "Attachments"
 msgstr "Attachments"
 
-#: src/routes/new/route.tsx:167
+#: src/routes/new/route.tsx:170
 msgid "Australian Dollar"
 msgstr "Australian Dollar"
 
@@ -274,16 +274,16 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:352
-#: src/routes/settings.tsx:428
+#: src/components/ExpenseEditor.tsx:356
+#: src/routes/settings.tsx:433
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
 
-#: src/routes/settings.tsx:430
+#: src/routes/settings.tsx:435
 msgid "Automatically open the calculator when focusing amount fields"
 msgstr "Automatically open the calculator when focusing amount fields"
 
-#: src/routes/settings.tsx:417
+#: src/routes/settings.tsx:422
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Automatically open the last visited party when you open the app"
 
@@ -295,7 +295,7 @@ msgstr "Avatar removed"
 msgid "Avatar updated successfully"
 msgstr "Avatar updated successfully"
 
-#: src/routes/new/route.tsx:200
+#: src/routes/new/route.tsx:203
 msgid "Azerbaijani Manat"
 msgstr "Azerbaijani Manat"
 
@@ -316,11 +316,11 @@ msgstr "Back to sign in"
 msgid "Backspace"
 msgstr "Backspace"
 
-#: src/routes/new/route.tsx:210
+#: src/routes/new/route.tsx:213
 msgid "Bahamian Dollar"
 msgstr "Bahamian Dollar"
 
-#: src/routes/new/route.tsx:204
+#: src/routes/new/route.tsx:207
 msgid "Bahraini Dinar"
 msgstr "Bahraini Dinar"
 
@@ -336,27 +336,27 @@ msgstr "Balance, Lowest First"
 msgid "Balances"
 msgstr "Balances"
 
-#: src/routes/new/route.tsx:203
+#: src/routes/new/route.tsx:206
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
-#: src/routes/new/route.tsx:202
+#: src/routes/new/route.tsx:205
 msgid "Barbadian Dollar"
 msgstr "Barbadian Dollar"
 
-#: src/routes/new/route.tsx:213
+#: src/routes/new/route.tsx:216
 msgid "Belarusian Ruble"
 msgstr "Belarusian Ruble"
 
-#: src/routes/new/route.tsx:214
+#: src/routes/new/route.tsx:217
 msgid "Belize Dollar"
 msgstr "Belize Dollar"
 
-#: src/routes/new/route.tsx:206
+#: src/routes/new/route.tsx:209
 msgid "Bermudan Dollar"
 msgstr "Bermudan Dollar"
 
-#: src/routes/new/route.tsx:211
+#: src/routes/new/route.tsx:214
 msgid "Bhutanese Ngultrum"
 msgstr "Bhutanese Ngultrum"
 
@@ -364,31 +364,31 @@ msgstr "Bhutanese Ngultrum"
 msgid "Biggest spenders"
 msgstr "Biggest spenders"
 
-#: src/routes/new/route.tsx:208
+#: src/routes/new/route.tsx:211
 msgid "Bolivian Boliviano"
 msgstr "Bolivian Boliviano"
 
-#: src/routes/new/route.tsx:209
+#: src/routes/new/route.tsx:212
 msgid "Bolivian Mvdol"
 msgstr "Bolivian Mvdol"
 
-#: src/routes/new/route.tsx:201
+#: src/routes/new/route.tsx:204
 msgid "Bosnia-Herzegovina Convertible Mark"
 msgstr "Bosnia-Herzegovina Convertible Mark"
 
-#: src/routes/new/route.tsx:212
+#: src/routes/new/route.tsx:215
 msgid "Botswanan Pula"
 msgstr "Botswanan Pula"
 
-#: src/routes/new/route.tsx:171
+#: src/routes/new/route.tsx:174
 msgid "Brazilian Real"
 msgstr "Brazilian Real"
 
-#: src/routes/new/route.tsx:163
+#: src/routes/new/route.tsx:166
 msgid "British Pound"
 msgstr "British Pound"
 
-#: src/routes/new/route.tsx:207
+#: src/routes/new/route.tsx:210
 msgid "Brunei Dollar"
 msgstr "Brunei Dollar"
 
@@ -400,11 +400,11 @@ msgstr "Bug Reports"
 msgid "Built With"
 msgstr "Built With"
 
-#: src/routes/new/route.tsx:180
+#: src/routes/new/route.tsx:183
 msgid "Bulgarian Lev"
 msgstr "Bulgarian Lev"
 
-#: src/routes/new/route.tsx:205
+#: src/routes/new/route.tsx:208
 msgid "Burundian Franc"
 msgstr "Burundian Franc"
 
@@ -420,7 +420,7 @@ msgstr "Calculator"
 msgid "Calculator expression"
 msgstr "Calculator expression"
 
-#: src/routes/new/route.tsx:251
+#: src/routes/new/route.tsx:254
 msgid "Cambodian Riel"
 msgstr "Cambodian Riel"
 
@@ -440,7 +440,7 @@ msgstr "Can I use trizum without an account?"
 msgid "Can't add an expense to a party that doesn't exist"
 msgstr "Can't add an expense to a party that doesn't exist"
 
-#: src/routes/new/route.tsx:166
+#: src/routes/new/route.tsx:169
 msgid "Canadian Dollar"
 msgstr "Canadian Dollar"
 
@@ -449,7 +449,7 @@ msgstr "Canadian Dollar"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/routes/new/route.tsx:225
+#: src/routes/new/route.tsx:228
 msgid "Cape Verdean Escudo"
 msgstr "Cape Verdean Escudo"
 
@@ -457,19 +457,19 @@ msgstr "Cape Verdean Escudo"
 msgid "Cash or other ways"
 msgstr "Cash or other ways"
 
-#: src/routes/new/route.tsx:255
+#: src/routes/new/route.tsx:258
 msgid "Cayman Islands Dollar"
 msgstr "Cayman Islands Dollar"
 
-#: src/routes/new/route.tsx:330
+#: src/routes/new/route.tsx:333
 msgid "CFA Franc BCEAO"
 msgstr "CFA Franc BCEAO"
 
-#: src/routes/new/route.tsx:321
+#: src/routes/new/route.tsx:324
 msgid "CFA Franc BEAC"
 msgstr "CFA Franc BEAC"
 
-#: src/routes/new/route.tsx:332
+#: src/routes/new/route.tsx:335
 msgid "CFP Franc"
 msgstr "CFP Franc"
 
@@ -493,19 +493,19 @@ msgstr "Check your email for the sign-in link"
 msgid "Checking for updates..."
 msgstr "Checking for updates..."
 
-#: src/routes/settings.tsx:480
+#: src/routes/settings.tsx:485
 msgid "Checking..."
 msgstr "Checking..."
 
-#: src/routes/new/route.tsx:219
+#: src/routes/new/route.tsx:222
 msgid "Chilean Peso"
 msgstr "Chilean Peso"
 
-#: src/routes/new/route.tsx:218
+#: src/routes/new/route.tsx:221
 msgid "Chilean Unit of Account (UF)"
 msgstr "Chilean Unit of Account (UF)"
 
-#: src/routes/new/route.tsx:168
+#: src/routes/new/route.tsx:171
 msgid "Chinese Yuan"
 msgstr "Chinese Yuan"
 
@@ -554,15 +554,15 @@ msgstr "Cloud settings applied"
 msgid "Cloud settings saved"
 msgstr "Cloud settings saved"
 
-#: src/routes/new/route.tsx:335
+#: src/routes/new/route.tsx:338
 msgid "Code for testing"
 msgstr "Code for testing"
 
-#: src/routes/new/route.tsx:220
+#: src/routes/new/route.tsx:223
 msgid "Colombian Peso"
 msgstr "Colombian Peso"
 
-#: src/routes/new/route.tsx:221
+#: src/routes/new/route.tsx:224
 msgid "Colombian Real Value Unit"
 msgstr "Colombian Real Value Unit"
 
@@ -570,7 +570,7 @@ msgstr "Colombian Real Value Unit"
 msgid "Color"
 msgstr "Color"
 
-#: src/routes/new/route.tsx:252
+#: src/routes/new/route.tsx:255
 msgid "Comorian Franc"
 msgstr "Comorian Franc"
 
@@ -604,7 +604,7 @@ msgstr "Confirmation"
 msgid "Confirming..."
 msgstr "Confirming..."
 
-#: src/routes/new/route.tsx:215
+#: src/routes/new/route.tsx:218
 msgid "Congolese Franc"
 msgstr "Congolese Franc"
 
@@ -675,7 +675,7 @@ msgstr "Copy party link"
 msgid "Copy the phone number and pay through Bizum using your bank app."
 msgstr "Copy the phone number and pay through Bizum using your bank app."
 
-#: src/routes/new/route.tsx:222
+#: src/routes/new/route.tsx:225
 msgid "Costa Rican Colón"
 msgstr "Costa Rican Colón"
 
@@ -700,7 +700,7 @@ msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
 #: src/hooks/useCloudSyncAccountState.ts:220
-#: src/routes/settings.tsx:484
+#: src/routes/settings.tsx:489
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
 
@@ -750,15 +750,15 @@ msgstr "Creditor"
 msgid "Credits"
 msgstr "Credits"
 
-#: src/routes/new/route.tsx:181
+#: src/routes/new/route.tsx:184
 msgid "Croatian Kuna"
 msgstr "Croatian Kuna"
 
-#: src/routes/new/route.tsx:223
+#: src/routes/new/route.tsx:226
 msgid "Cuban Convertible Peso"
 msgstr "Cuban Convertible Peso"
 
-#: src/routes/new/route.tsx:224
+#: src/routes/new/route.tsx:227
 msgid "Cuban Peso"
 msgstr "Cuban Peso"
 
@@ -781,15 +781,15 @@ msgstr "Current year"
 msgid "Custom range"
 msgstr "Custom range"
 
-#: src/routes/new/route.tsx:177
+#: src/routes/new/route.tsx:180
 msgid "Czech Koruna"
 msgstr "Czech Koruna"
 
-#: src/routes/new/route.tsx:175
+#: src/routes/new/route.tsx:178
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:495
+#: src/components/ExpenseEditor.tsx:499
 msgid "Date"
 msgstr "Date"
 
@@ -861,15 +861,15 @@ msgstr "Did you know?"
 msgid "Divide"
 msgstr "Divide"
 
-#: src/routes/new/route.tsx:226
+#: src/routes/new/route.tsx:229
 msgid "Djiboutian Franc"
 msgstr "Djiboutian Franc"
 
-#: src/routes/new/route.tsx:227
+#: src/routes/new/route.tsx:230
 msgid "Dominican Peso"
 msgstr "Dominican Peso"
 
-#: src/routes/new/route.tsx:328
+#: src/routes/new/route.tsx:331
 msgid "East Caribbean Dollar"
 msgstr "East Caribbean Dollar"
 
@@ -885,7 +885,7 @@ msgstr "Editing {0}"
 msgid "Editing {expenseName}"
 msgstr "Editing {expenseName}"
 
-#: src/routes/new/route.tsx:229
+#: src/routes/new/route.tsx:232
 msgid "Egyptian Pound"
 msgstr "Egyptian Pound"
 
@@ -958,11 +958,11 @@ msgstr "Enter a party link or code to join"
 msgid "Enter the key of the Tricount account you want to migrate from"
 msgstr "Enter the key of the Tricount account you want to migrate from"
 
-#: src/routes/join.tsx:172
+#: src/routes/join.tsx:175
 msgid "Enter the link or code of the trizum party you want to join"
 msgstr "Enter the link or code of the trizum party you want to join"
 
-#: src/routes/new/route.tsx:230
+#: src/routes/new/route.tsx:233
 msgid "Eritrean Nakfa"
 msgstr "Eritrean Nakfa"
 
@@ -970,27 +970,27 @@ msgstr "Eritrean Nakfa"
 msgid "Español"
 msgstr "Español"
 
-#: src/routes/new/route.tsx:231
+#: src/routes/new/route.tsx:234
 msgid "Ethiopian Birr"
 msgstr "Ethiopian Birr"
 
-#: src/routes/new/route.tsx:161
+#: src/routes/new/route.tsx:164
 msgid "Euro"
 msgstr "Euro"
 
-#: src/routes/new/route.tsx:324
+#: src/routes/new/route.tsx:327
 msgid "European Composite Unit"
 msgstr "European Composite Unit"
 
-#: src/routes/new/route.tsx:325
+#: src/routes/new/route.tsx:328
 msgid "European Monetary Unit"
 msgstr "European Monetary Unit"
 
-#: src/routes/new/route.tsx:327
+#: src/routes/new/route.tsx:330
 msgid "European Unit of Account 17"
 msgstr "European Unit of Account 17"
 
-#: src/routes/new/route.tsx:326
+#: src/routes/new/route.tsx:329
 msgid "European Unit of Account 9"
 msgstr "European Unit of Account 9"
 
@@ -1027,7 +1027,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:974
+#: src/components/ExpenseEditor.tsx:978
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1072,11 +1072,11 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:949
+#: src/components/ExpenseEditor.tsx:953
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
-#: src/routes/new/route.tsx:233
+#: src/routes/new/route.tsx:236
 msgid "Falkland Islands Pound"
 msgstr "Falkland Islands Pound"
 
@@ -1088,7 +1088,7 @@ msgstr "Feature Requests"
 msgid "Features"
 msgstr "Features"
 
-#: src/routes/new/route.tsx:232
+#: src/routes/new/route.tsx:235
 msgid "Fijian Dollar"
 msgstr "Fijian Dollar"
 
@@ -1101,7 +1101,7 @@ msgstr "Filter totals and rankings"
 msgid "Finishing sign in"
 msgstr "Finishing sign in"
 
-#: src/routes/settings.tsx:379
+#: src/routes/settings.tsx:384
 msgid "For payments through Bizum or similar services"
 msgstr "For payments through Bizum or similar services"
 
@@ -1117,11 +1117,11 @@ msgstr "Found a bug? Let us know on GitHub and we'll fix it."
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: src/routes/new/route.tsx:237
+#: src/routes/new/route.tsx:240
 msgid "Gambian Dalasi"
 msgstr "Gambian Dalasi"
 
-#: src/routes/new/route.tsx:234
+#: src/routes/new/route.tsx:237
 msgid "Georgian Lari"
 msgstr "Georgian Lari"
 
@@ -1129,11 +1129,11 @@ msgstr "Georgian Lari"
 msgid "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 msgstr "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 
-#: src/routes/new/route.tsx:235
+#: src/routes/new/route.tsx:238
 msgid "Ghanaian Cedi"
 msgstr "Ghanaian Cedi"
 
-#: src/routes/new/route.tsx:236
+#: src/routes/new/route.tsx:239
 msgid "Gibraltar Pound"
 msgstr "Gibraltar Pound"
 
@@ -1154,7 +1154,7 @@ msgstr "Go back and try again from the balances list."
 msgid "Go back to home"
 msgstr "Go back to home"
 
-#: src/routes/new/route.tsx:323
+#: src/routes/new/route.tsx:326
 msgid "Gold (troy ounce)"
 msgstr "Gold (troy ounce)"
 
@@ -1178,19 +1178,19 @@ msgstr "Got it"
 msgid "Group expense sharing made simple. Track, split and settle shared costs effortlessly."
 msgstr "Group expense sharing made simple. Track, split and settle shared costs effortlessly."
 
-#: src/routes/new/route.tsx:239
+#: src/routes/new/route.tsx:242
 msgid "Guatemalan Quetzal"
 msgstr "Guatemalan Quetzal"
 
-#: src/routes/new/route.tsx:238
+#: src/routes/new/route.tsx:241
 msgid "Guinean Franc"
 msgstr "Guinean Franc"
 
-#: src/routes/new/route.tsx:240
+#: src/routes/new/route.tsx:243
 msgid "Guyanaese Dollar"
 msgstr "Guyanaese Dollar"
 
-#: src/routes/new/route.tsx:242
+#: src/routes/new/route.tsx:245
 msgid "Haitian Gourde"
 msgstr "Haitian Gourde"
 
@@ -1198,7 +1198,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:851
+#: src/components/ExpenseEditor.tsx:855
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -1218,11 +1218,11 @@ msgstr "Hide password sign in"
 msgid "Home"
 msgstr "Home"
 
-#: src/routes/new/route.tsx:241
+#: src/routes/new/route.tsx:244
 msgid "Honduran Lempira"
 msgstr "Honduran Lempira"
 
-#: src/routes/new/route.tsx:186
+#: src/routes/new/route.tsx:189
 msgid "Hong Kong Dollar"
 msgstr "Hong Kong Dollar"
 
@@ -1247,11 +1247,11 @@ msgstr "How should I balance?"
 msgid "How to pay?"
 msgstr "How to pay?"
 
-#: src/routes/new/route.tsx:178
+#: src/routes/new/route.tsx:181
 msgid "Hungarian Forint"
 msgstr "Hungarian Forint"
 
-#: src/routes/new/route.tsx:246
+#: src/routes/new/route.tsx:249
 msgid "Icelandic Króna"
 msgstr "Icelandic Króna"
 
@@ -1267,7 +1267,7 @@ msgstr "Image must be smaller than 10MB"
 msgid "Impact on my balance: <0/>"
 msgstr "Impact on my balance: <0/>"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:94
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:97
 msgid "Import attachments"
 msgstr "Import attachments"
 
@@ -1287,11 +1287,11 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:539
+#: src/components/ExpenseEditor.tsx:543
 msgid "Include all"
 msgstr "Include all"
 
-#: src/routes/new/route.tsx:169
+#: src/routes/new/route.tsx:172
 msgid "Indian Rupee"
 msgstr "Indian Rupee"
 
@@ -1299,7 +1299,7 @@ msgstr "Indian Rupee"
 msgid "Individual totals"
 msgstr "Individual totals"
 
-#: src/routes/new/route.tsx:243
+#: src/routes/new/route.tsx:246
 msgid "Indonesian Rupiah"
 msgstr "Indonesian Rupiah"
 
@@ -1321,11 +1321,11 @@ msgstr "Invalid trizum party code"
 msgid "Invalid trizum party link"
 msgstr "Invalid trizum party link"
 
-#: src/routes/new/route.tsx:245
+#: src/routes/new/route.tsx:248
 msgid "Iranian Rial"
 msgstr "Iranian Rial"
 
-#: src/routes/new/route.tsx:244
+#: src/routes/new/route.tsx:247
 msgid "Iraqi Dinar"
 msgstr "Iraqi Dinar"
 
@@ -1333,19 +1333,19 @@ msgstr "Iraqi Dinar"
 msgid "Is my data secure?"
 msgstr "Is my data secure?"
 
-#: src/routes/new/route.tsx:189
+#: src/routes/new/route.tsx:192
 msgid "Israeli Shekel"
 msgstr "Israeli Shekel"
 
-#: src/routes/new/route.tsx:247
+#: src/routes/new/route.tsx:250
 msgid "Jamaican Dollar"
 msgstr "Jamaican Dollar"
 
-#: src/routes/new/route.tsx:164
+#: src/routes/new/route.tsx:167
 msgid "Japanese Yen"
 msgstr "Japanese Yen"
 
-#: src/routes/join.tsx:192
+#: src/routes/join.tsx:195
 msgid "Join"
 msgstr "Join"
 
@@ -1370,7 +1370,7 @@ msgstr "Join a trizum"
 msgid "Joined {0}!"
 msgstr "Joined {0}!"
 
-#: src/routes/new/route.tsx:248
+#: src/routes/new/route.tsx:251
 msgid "Jordanian Dinar"
 msgstr "Jordanian Dinar"
 
@@ -1378,7 +1378,7 @@ msgstr "Jordanian Dinar"
 msgid "Jump back into the groups you use most"
 msgstr "Jump back into the groups you use most"
 
-#: src/routes/new/route.tsx:256
+#: src/routes/new/route.tsx:259
 msgid "Kazakhstani Tenge"
 msgstr "Kazakhstani Tenge"
 
@@ -1390,23 +1390,23 @@ msgstr "Keep local data"
 msgid "Keep your profile settings available on your signed-in devices."
 msgstr "Keep your profile settings available on your signed-in devices."
 
-#: src/routes/new/route.tsx:249
+#: src/routes/new/route.tsx:252
 msgid "Kenyan Shilling"
 msgstr "Kenyan Shilling"
 
-#: src/routes/new/route.tsx:254
+#: src/routes/new/route.tsx:257
 msgid "Kuwaiti Dinar"
 msgstr "Kuwaiti Dinar"
 
-#: src/routes/new/route.tsx:250
+#: src/routes/new/route.tsx:253
 msgid "Kyrgystani Som"
 msgstr "Kyrgystani Som"
 
-#: src/routes/settings.tsx:394
+#: src/routes/settings.tsx:399
 msgid "Language"
 msgstr "Language"
 
-#: src/routes/new/route.tsx:257
+#: src/routes/new/route.tsx:260
 msgid "Laotian Kip"
 msgstr "Laotian Kip"
 
@@ -1426,19 +1426,19 @@ msgstr "Last year"
 msgid "Leave party"
 msgstr "Leave party"
 
-#: src/routes/new/route.tsx:258
+#: src/routes/new/route.tsx:261
 msgid "Lebanese Pound"
 msgstr "Lebanese Pound"
 
-#: src/routes/new/route.tsx:261
+#: src/routes/new/route.tsx:264
 msgid "Lesotho Loti"
 msgstr "Lesotho Loti"
 
-#: src/routes/new/route.tsx:260
+#: src/routes/new/route.tsx:263
 msgid "Liberian Dollar"
 msgstr "Liberian Dollar"
 
-#: src/routes/new/route.tsx:262
+#: src/routes/new/route.tsx:265
 msgid "Libyan Dinar"
 msgstr "Libyan Dinar"
 
@@ -1446,7 +1446,7 @@ msgstr "Libyan Dinar"
 msgid "License"
 msgstr "License"
 
-#: src/routes/join.tsx:171
+#: src/routes/join.tsx:174
 msgid "Link or code"
 msgstr "Link or code"
 
@@ -1462,27 +1462,27 @@ msgstr "Loading licenses..."
 msgid "Long press for party actions"
 msgstr "Long press for party actions"
 
-#: src/routes/new/route.tsx:269
+#: src/routes/new/route.tsx:272
 msgid "Macanese Pataca"
 msgstr "Macanese Pataca"
 
-#: src/routes/new/route.tsx:266
+#: src/routes/new/route.tsx:269
 msgid "Macedonian Denar"
 msgstr "Macedonian Denar"
 
-#: src/routes/new/route.tsx:265
+#: src/routes/new/route.tsx:268
 msgid "Malagasy Ariary"
 msgstr "Malagasy Ariary"
 
-#: src/routes/new/route.tsx:273
+#: src/routes/new/route.tsx:276
 msgid "Malawian Kwacha"
 msgstr "Malawian Kwacha"
 
-#: src/routes/new/route.tsx:275
+#: src/routes/new/route.tsx:278
 msgid "Malaysian Ringgit"
 msgstr "Malaysian Ringgit"
 
-#: src/routes/new/route.tsx:272
+#: src/routes/new/route.tsx:275
 msgid "Maldivian Rufiyaa"
 msgstr "Maldivian Rufiyaa"
 
@@ -1504,11 +1504,11 @@ msgstr "Mark as paid"
 msgid "Marking expense as paid..."
 msgstr "Marking expense as paid..."
 
-#: src/routes/new/route.tsx:270
+#: src/routes/new/route.tsx:273
 msgid "Mauritanian Ouguiya"
 msgstr "Mauritanian Ouguiya"
 
-#: src/routes/new/route.tsx:271
+#: src/routes/new/route.tsx:274
 msgid "Mauritian Rupee"
 msgstr "Mauritian Rupee"
 
@@ -1519,18 +1519,18 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:345
+#: src/components/ExpenseEditor.tsx:349
 #: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:86
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
 msgstr "Menu"
 
-#: src/routes/new/route.tsx:274
+#: src/routes/new/route.tsx:277
 msgid "Mexican Investment Unit"
 msgstr "Mexican Investment Unit"
 
-#: src/routes/new/route.tsx:170
+#: src/routes/new/route.tsx:173
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
@@ -1553,15 +1553,15 @@ msgstr "Migration successful"
 msgid "Missing search params"
 msgstr "Missing search params"
 
-#: src/routes/new/route.tsx:264
+#: src/routes/new/route.tsx:267
 msgid "Moldovan Leu"
 msgstr "Moldovan Leu"
 
-#: src/routes/new/route.tsx:268
+#: src/routes/new/route.tsx:271
 msgid "Mongolian Tugrik"
 msgstr "Mongolian Tugrik"
 
-#: src/routes/new/route.tsx:263
+#: src/routes/new/route.tsx:266
 msgid "Moroccan Dirham"
 msgstr "Moroccan Dirham"
 
@@ -1577,7 +1577,7 @@ msgstr "Move cursor right"
 msgid "Moved to"
 msgstr "Moved to"
 
-#: src/routes/new/route.tsx:276
+#: src/routes/new/route.tsx:279
 msgid "Mozambican Metical"
 msgstr "Mozambican Metical"
 
@@ -1589,7 +1589,7 @@ msgstr "Multi-Party Splitting"
 msgid "Multiply"
 msgstr "Multiply"
 
-#: src/routes/new/route.tsx:267
+#: src/routes/new/route.tsx:270
 msgid "Myanma Kyat"
 msgstr "Myanma Kyat"
 
@@ -1603,7 +1603,7 @@ msgstr "Name"
 msgid "Name must be less than 50 characters"
 msgstr "Name must be less than 50 characters"
 
-#: src/routes/new/route.tsx:277
+#: src/routes/new/route.tsx:280
 msgid "Namibian Dollar"
 msgstr "Namibian Dollar"
 
@@ -1611,11 +1611,11 @@ msgstr "Namibian Dollar"
 msgid "Need help with trizum? We're here to assist you."
 msgstr "Need help with trizum? We're here to assist you."
 
-#: src/routes/new/route.tsx:280
+#: src/routes/new/route.tsx:283
 msgid "Nepalese Rupee"
 msgstr "Nepalese Rupee"
 
-#: src/routes/new/route.tsx:196
+#: src/routes/new/route.tsx:199
 msgid "Netherlands Antillean Guilder"
 msgstr "Netherlands Antillean Guilder"
 
@@ -1628,11 +1628,11 @@ msgstr "New expense"
 msgid "New participant name"
 msgstr "New participant name"
 
-#: src/routes/reset-password.tsx:124
+#: src/routes/reset-password.tsx:127
 msgid "New password"
 msgstr "New password"
 
-#: src/routes/new/route.tsx:308
+#: src/routes/new/route.tsx:311
 msgid "New Taiwan Dollar"
 msgstr "New Taiwan Dollar"
 
@@ -1640,7 +1640,7 @@ msgstr "New Taiwan Dollar"
 msgid "New trizum"
 msgstr "New trizum"
 
-#: src/routes/new/route.tsx:184
+#: src/routes/new/route.tsx:187
 msgid "New Zealand Dollar"
 msgstr "New Zealand Dollar"
 
@@ -1648,11 +1648,11 @@ msgstr "New Zealand Dollar"
 msgid "Next"
 msgstr "Next"
 
-#: src/routes/new/route.tsx:279
+#: src/routes/new/route.tsx:282
 msgid "Nicaraguan Córdoba"
 msgstr "Nicaraguan Córdoba"
 
-#: src/routes/new/route.tsx:278
+#: src/routes/new/route.tsx:281
 msgid "Nigerian Naira"
 msgstr "Nigerian Naira"
 
@@ -1672,7 +1672,7 @@ msgstr "No camera found on this device"
 msgid "No cloud settings saved yet"
 msgstr "No cloud settings saved yet"
 
-#: src/routes/new/route.tsx:337
+#: src/routes/new/route.tsx:340
 msgid "No currency"
 msgstr "No currency"
 
@@ -1717,11 +1717,11 @@ msgstr "Nobody yet"
 msgid "Non-transfer expenses in this timeframe"
 msgstr "Non-transfer expenses in this timeframe"
 
-#: src/routes/new/route.tsx:253
+#: src/routes/new/route.tsx:256
 msgid "North Korean Won"
 msgstr "North Korean Won"
 
-#: src/routes/new/route.tsx:174
+#: src/routes/new/route.tsx:177
 msgid "Norwegian Krone"
 msgstr "Norwegian Krone"
 
@@ -1734,11 +1734,11 @@ msgstr "Not a valid trizum party code"
 msgid "Not connected"
 msgstr "Not connected"
 
-#: src/routes/settings.tsx:488
+#: src/routes/settings.tsx:493
 msgid "Not set up"
 msgstr "Not set up"
 
-#: src/routes/settings.tsx:476
+#: src/routes/settings.tsx:481
 msgid "Not signed in"
 msgstr "Not signed in"
 
@@ -1754,7 +1754,7 @@ msgstr "Offline-First"
 msgid "Older parties stay tucked away, not gone"
 msgstr "Older parties stay tucked away, not gone"
 
-#: src/routes/new/route.tsx:281
+#: src/routes/new/route.tsx:284
 msgid "Omani Rial"
 msgstr "Omani Rial"
 
@@ -1774,7 +1774,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:355
+#: src/components/ExpenseEditor.tsx:359
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1782,7 +1782,7 @@ msgstr "Open calculator when focusing amount fields"
 msgid "Open GitHub Issues"
 msgstr "Open GitHub Issues"
 
-#: src/routes/settings.tsx:415
+#: src/routes/settings.tsx:420
 msgid "Open last party on launch"
 msgstr "Open last party on launch"
 
@@ -1819,7 +1819,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:470
+#: src/components/ExpenseEditor.tsx:474
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -1832,23 +1832,23 @@ msgstr "Paid debt to {0}"
 msgid "Paid debt to {toName}"
 msgstr "Paid debt to {toName}"
 
-#: src/routes/new/route.tsx:286
+#: src/routes/new/route.tsx:289
 msgid "Pakistani Rupee"
 msgstr "Pakistani Rupee"
 
-#: src/routes/new/route.tsx:331
+#: src/routes/new/route.tsx:334
 msgid "Palladium (troy ounce)"
 msgstr "Palladium (troy ounce)"
 
-#: src/routes/new/route.tsx:282
+#: src/routes/new/route.tsx:285
 msgid "Panamanian Balboa"
 msgstr "Panamanian Balboa"
 
-#: src/routes/new/route.tsx:284
+#: src/routes/new/route.tsx:287
 msgid "Papua New Guinean Kina"
 msgstr "Papua New Guinean Kina"
 
-#: src/routes/new/route.tsx:287
+#: src/routes/new/route.tsx:290
 msgid "Paraguayan Guarani"
 msgstr "Paraguayan Guarani"
 
@@ -1940,7 +1940,7 @@ msgstr "Password email sent"
 msgid "Password enabled"
 msgstr "Password enabled"
 
-#: src/routes/reset-password.tsx:118
+#: src/routes/reset-password.tsx:121
 msgid "Password must be at least 8 characters"
 msgstr "Password must be at least 8 characters"
 
@@ -1964,7 +1964,7 @@ msgstr "Password sign-in is enabled"
 msgid "Password updated"
 msgstr "Password updated"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:74
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:77
 msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 msgstr "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 
@@ -1985,15 +1985,15 @@ msgstr "Permanently delete your trizum cloud account"
 msgid "Personal mode"
 msgstr "Personal mode"
 
-#: src/routes/new/route.tsx:283
+#: src/routes/new/route.tsx:286
 msgid "Peruvian Sol"
 msgstr "Peruvian Sol"
 
-#: src/routes/new/route.tsx:285
+#: src/routes/new/route.tsx:288
 msgid "Philippine Peso"
 msgstr "Philippine Peso"
 
-#: src/routes/settings.tsx:378
+#: src/routes/settings.tsx:383
 msgid "Phone number"
 msgstr "Phone number"
 
@@ -2025,7 +2025,7 @@ msgstr "Pinned parties stay close. Recent activity keeps the rest in order."
 msgid "Pinned parties stay on top, then the rest follow your latest activity."
 msgstr "Pinned parties stay on top, then the rest follow your latest activity."
 
-#: src/routes/new/route.tsx:333
+#: src/routes/new/route.tsx:336
 msgid "Platinum (troy ounce)"
 msgstr "Platinum (troy ounce)"
 
@@ -2033,7 +2033,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:869
+#: src/components/ExpenseEditor.tsx:873
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -2057,7 +2057,7 @@ msgstr "Please wait while we fetch the latest data"
 msgid "Point your camera at a trizum QR code"
 msgstr "Point your camera at a trizum QR code"
 
-#: src/routes/new/route.tsx:176
+#: src/routes/new/route.tsx:179
 msgid "Polish Zloty"
 msgstr "Polish Zloty"
 
@@ -2069,7 +2069,7 @@ msgstr "Previous"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: src/routes/new/route.tsx:288
+#: src/routes/new/route.tsx:291
 msgid "Qatari Rial"
 msgstr "Qatari Rial"
 
@@ -2081,7 +2081,7 @@ msgstr "QR code frame capture"
 msgid "Ranking based on how much each participant paid in the selected timeframe."
 msgstr "Ranking based on how much each participant paid in the selected timeframe."
 
-#: src/routes/settings.tsx:495
+#: src/routes/settings.tsx:500
 msgid "Ready on another device"
 msgstr "Ready on another device"
 
@@ -2110,7 +2110,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1066
+#: src/components/ExpenseEditor.tsx:1070
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2147,35 +2147,35 @@ msgstr "Restore to home"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/routes/new/route.tsx:179
+#: src/routes/new/route.tsx:182
 msgid "Romanian Leu"
 msgstr "Romanian Leu"
 
-#: src/routes/new/route.tsx:182
+#: src/routes/new/route.tsx:185
 msgid "Russian Ruble"
 msgstr "Russian Ruble"
 
-#: src/routes/new/route.tsx:290
+#: src/routes/new/route.tsx:293
 msgid "Rwandan Franc"
 msgstr "Rwandan Franc"
 
-#: src/routes/new/route.tsx:294
+#: src/routes/new/route.tsx:297
 msgid "Saint Helena Pound"
 msgstr "Saint Helena Pound"
 
-#: src/routes/new/route.tsx:300
+#: src/routes/new/route.tsx:303
 msgid "Salvadoran Colón"
 msgstr "Salvadoran Colón"
 
-#: src/routes/new/route.tsx:320
+#: src/routes/new/route.tsx:323
 msgid "Samoan Tala"
 msgstr "Samoan Tala"
 
-#: src/routes/new/route.tsx:299
+#: src/routes/new/route.tsx:302
 msgid "São Tomé and Príncipe Dobra"
 msgstr "São Tomé and Príncipe Dobra"
 
-#: src/routes/new/route.tsx:191
+#: src/routes/new/route.tsx:194
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
@@ -2226,7 +2226,7 @@ msgstr "Send password link"
 msgid "Send us an email and we'll get back to you as soon as possible."
 msgstr "Send us an email and we'll get back to you as soon as possible."
 
-#: src/routes/new/route.tsx:289
+#: src/routes/new/route.tsx:292
 msgid "Serbian Dinar"
 msgstr "Serbian Dinar"
 
@@ -2260,7 +2260,7 @@ msgstr "Settings saved"
 msgid "Settled in"
 msgstr "Settled in"
 
-#: src/routes/new/route.tsx:292
+#: src/routes/new/route.tsx:295
 msgid "Seychellois Rupee"
 msgstr "Seychellois Rupee"
 
@@ -2282,7 +2282,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:725
+#: src/components/ExpenseEditor.tsx:729
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -2290,11 +2290,11 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:855
+#: src/components/ExpenseEditor.tsx:859
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
-#: src/routes/new/route.tsx:295
+#: src/routes/new/route.tsx:298
 msgid "Sierra Leonean Leone"
 msgstr "Sierra Leonean Leone"
 
@@ -2363,7 +2363,7 @@ msgstr "Signed in"
 msgid "Signed out"
 msgstr "Signed out"
 
-#: src/routes/new/route.tsx:322
+#: src/routes/new/route.tsx:325
 msgid "Silver (troy ounce)"
 msgstr "Silver (troy ounce)"
 
@@ -2371,15 +2371,15 @@ msgstr "Silver (troy ounce)"
 msgid "Simple"
 msgstr "Simple"
 
-#: src/routes/new/route.tsx:185
+#: src/routes/new/route.tsx:188
 msgid "Singapore Dollar"
 msgstr "Singapore Dollar"
 
-#: src/routes/new/route.tsx:291
+#: src/routes/new/route.tsx:294
 msgid "Solomon Islands Dollar"
 msgstr "Solomon Islands Dollar"
 
-#: src/routes/new/route.tsx:296
+#: src/routes/new/route.tsx:299
 msgid "Somali Shilling"
 msgstr "Somali Shilling"
 
@@ -2395,19 +2395,19 @@ msgstr "Something went wrong"
 msgid "Sort balances"
 msgstr "Sort balances"
 
-#: src/routes/new/route.tsx:188
+#: src/routes/new/route.tsx:191
 msgid "South African Rand"
 msgstr "South African Rand"
 
-#: src/routes/new/route.tsx:172
+#: src/routes/new/route.tsx:175
 msgid "South Korean Won"
 msgstr "South Korean Won"
 
-#: src/routes/new/route.tsx:298
+#: src/routes/new/route.tsx:301
 msgid "South Sudanese Pound"
 msgstr "South Sudanese Pound"
 
-#: src/routes/new/route.tsx:329
+#: src/routes/new/route.tsx:332
 msgid "Special Drawing Rights"
 msgstr "Special Drawing Rights"
 
@@ -2423,7 +2423,7 @@ msgstr "Split bills with friends and family. Track, calculate, and settle expens
 msgid "Split expenses fairly among multiple participants"
 msgstr "Split expenses fairly among multiple participants"
 
-#: src/routes/new/route.tsx:259
+#: src/routes/new/route.tsx:262
 msgid "Sri Lankan Rupee"
 msgstr "Sri Lankan Rupee"
 
@@ -2462,11 +2462,11 @@ msgstr "Submitting..."
 msgid "Subtract"
 msgstr "Subtract"
 
-#: src/routes/new/route.tsx:334
+#: src/routes/new/route.tsx:337
 msgid "Sucre"
 msgstr "Sucre"
 
-#: src/routes/new/route.tsx:293
+#: src/routes/new/route.tsx:296
 msgid "Sudanese Pound"
 msgstr "Sudanese Pound"
 
@@ -2475,15 +2475,15 @@ msgstr "Sudanese Pound"
 msgid "Support"
 msgstr "Support"
 
-#: src/routes/new/route.tsx:297
+#: src/routes/new/route.tsx:300
 msgid "Surinamese Dollar"
 msgstr "Surinamese Dollar"
 
-#: src/routes/new/route.tsx:302
+#: src/routes/new/route.tsx:305
 msgid "Swazi Lilangeni"
 msgstr "Swazi Lilangeni"
 
-#: src/routes/new/route.tsx:173
+#: src/routes/new/route.tsx:176
 msgid "Swedish Krona"
 msgstr "Swedish Krona"
 
@@ -2491,15 +2491,15 @@ msgstr "Swedish Krona"
 msgid "Swipe between expenses and balances tabs."
 msgstr "Swipe between expenses and balances tabs."
 
-#: src/routes/new/route.tsx:165
+#: src/routes/new/route.tsx:168
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:749
+#: src/components/ExpenseEditor.tsx:753
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:750
+#: src/components/ExpenseEditor.tsx:754
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2524,7 +2524,7 @@ msgstr "Sync profile settings"
 msgid "Syncing party information..."
 msgstr "Syncing party information..."
 
-#: src/routes/new/route.tsx:301
+#: src/routes/new/route.tsx:304
 msgid "Syrian Pound"
 msgstr "Syrian Pound"
 
@@ -2532,18 +2532,18 @@ msgstr "Syrian Pound"
 msgid "System (fallbacks to {DEFAULT_LOCALE})"
 msgstr "System (fallbacks to {DEFAULT_LOCALE})"
 
-#: src/routes/new/route.tsx:303
+#: src/routes/new/route.tsx:306
 msgid "Tajikistani Somoni"
 msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:994
-#: src/components/ExpenseEditor.tsx:1008
+#: src/components/ExpenseEditor.tsx:998
+#: src/components/ExpenseEditor.tsx:1012
 msgid "Take photo"
 msgstr "Take photo"
 
-#: src/routes/new/route.tsx:309
+#: src/routes/new/route.tsx:312
 msgid "Tanzanian Shilling"
 msgstr "Tanzanian Shilling"
 
@@ -2551,7 +2551,7 @@ msgstr "Tanzanian Shilling"
 msgid "Tap to change"
 msgstr "Tap to change"
 
-#: src/routes/new/route.tsx:187
+#: src/routes/new/route.tsx:190
 msgid "Thai Baht"
 msgstr "Thai Baht"
 
@@ -2638,7 +2638,7 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:411
+#: src/components/ExpenseEditor.tsx:415
 msgid "Title"
 msgstr "Title"
 
@@ -2658,11 +2658,11 @@ msgstr "To connect Google or Apple, choose an account with the same email addres
 msgid "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 
-#: src/routes/party_.$partyId.who.tsx:129
+#: src/routes/party_.$partyId.who.tsx:132
 msgid "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 
-#: src/routes/new/route.tsx:306
+#: src/routes/new/route.tsx:309
 msgid "Tongan Paʻanga"
 msgstr "Tongan Paʻanga"
 
@@ -2704,11 +2704,11 @@ msgstr "Tricount key is required"
 msgid "Tricount key or URL is required"
 msgstr "Tricount key or URL is required"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:73
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:76
 msgid "Tricount URL or key"
 msgstr "Tricount URL or key"
 
-#: src/routes/new/route.tsx:307
+#: src/routes/new/route.tsx:310
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
@@ -2768,15 +2768,15 @@ msgstr "Try another timeframe to compare a different period of your party."
 msgid "Try scanning another code"
 msgstr "Try scanning another code"
 
-#: src/routes/new/route.tsx:305
+#: src/routes/new/route.tsx:308
 msgid "Tunisian Dinar"
 msgstr "Tunisian Dinar"
 
-#: src/routes/new/route.tsx:183
+#: src/routes/new/route.tsx:186
 msgid "Turkish Lira"
 msgstr "Turkish Lira"
 
-#: src/routes/new/route.tsx:304
+#: src/routes/new/route.tsx:307
 msgid "Turkmenistani Manat"
 msgstr "Turkmenistani Manat"
 
@@ -2784,19 +2784,19 @@ msgstr "Turkmenistani Manat"
 msgid "Type \"delete account\" to confirm."
 msgstr "Type \"delete account\" to confirm."
 
-#: src/routes/new/route.tsx:190
+#: src/routes/new/route.tsx:193
 msgid "UAE Dirham"
 msgstr "UAE Dirham"
 
-#: src/routes/new/route.tsx:311
+#: src/routes/new/route.tsx:314
 msgid "Ugandan Shilling"
 msgstr "Ugandan Shilling"
 
-#: src/routes/new/route.tsx:310
+#: src/routes/new/route.tsx:313
 msgid "Ukrainian Hryvnia"
 msgstr "Ukrainian Hryvnia"
 
-#: src/routes/new/route.tsx:315
+#: src/routes/new/route.tsx:318
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
@@ -2821,11 +2821,11 @@ msgstr "Update failed. Please try again."
 msgid "Update is no longer available."
 msgstr "Update is no longer available."
 
-#: src/routes/reset-password.tsx:139
+#: src/routes/reset-password.tsx:142
 msgid "Update password"
 msgstr "Update password"
 
-#: src/routes/party_.$partyId.who.tsx:134
+#: src/routes/party_.$partyId.who.tsx:137
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 msgstr "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 
@@ -2837,14 +2837,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:894
+#: src/components/ExpenseEditor.tsx:898
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1003
-#: src/components/ExpenseEditor.tsx:1020
+#: src/components/ExpenseEditor.tsx:1007
+#: src/components/ExpenseEditor.tsx:1024
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2857,7 +2857,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:934
+#: src/components/ExpenseEditor.tsx:938
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2865,19 +2865,19 @@ msgstr "Uploading..."
 msgid "URL or Party ID"
 msgstr "URL or Party ID"
 
-#: src/routes/new/route.tsx:313
+#: src/routes/new/route.tsx:316
 msgid "Uruguay Peso en Unidades Indexadas"
 msgstr "Uruguay Peso en Unidades Indexadas"
 
-#: src/routes/new/route.tsx:314
+#: src/routes/new/route.tsx:317
 msgid "Uruguayan Peso"
 msgstr "Uruguayan Peso"
 
-#: src/routes/new/route.tsx:162
+#: src/routes/new/route.tsx:165
 msgid "US Dollar"
 msgstr "US Dollar"
 
-#: src/routes/new/route.tsx:312
+#: src/routes/new/route.tsx:315
 msgid "US Dollar (Next day)"
 msgstr "US Dollar (Next day)"
 
@@ -2906,7 +2906,7 @@ msgstr "Use trizum cloud on this device?"
 msgid "Use your camera to scan a trizum invite"
 msgstr "Use your camera to scan a trizum invite"
 
-#: src/routes/settings.tsx:356
+#: src/routes/settings.tsx:361
 msgid "Username"
 msgstr "Username"
 
@@ -2914,15 +2914,15 @@ msgstr "Username"
 msgid "Username, phone, language, launch behavior, and accent color"
 msgstr "Username, phone, language, launch behavior, and accent color"
 
-#: src/routes/new/route.tsx:316
+#: src/routes/new/route.tsx:319
 msgid "Uzbekistan Som"
 msgstr "Uzbekistan Som"
 
-#: src/routes/new/route.tsx:319
+#: src/routes/new/route.tsx:322
 msgid "Vanuatu Vatu"
 msgstr "Vanuatu Vatu"
 
-#: src/routes/new/route.tsx:317
+#: src/routes/new/route.tsx:320
 msgid "Venezuelan Bolívar Soberano"
 msgstr "Venezuelan Bolívar Soberano"
 
@@ -2930,7 +2930,7 @@ msgstr "Venezuelan Bolívar Soberano"
 msgid "Version"
 msgstr "Version"
 
-#: src/routes/new/route.tsx:318
+#: src/routes/new/route.tsx:321
 msgid "Vietnamese Dong"
 msgstr "Vietnamese Dong"
 
@@ -2942,7 +2942,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1055
+#: src/components/ExpenseEditor.tsx:1059
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"
@@ -2992,7 +2992,7 @@ msgstr "Welcome to trizum"
 msgid "What is this party about?"
 msgstr "What is this party about?"
 
-#: src/routes/settings.tsx:357
+#: src/routes/settings.tsx:362
 msgid "What's your preferred way to be addressed?"
 msgstr "What's your preferred way to be addressed?"
 
@@ -3008,11 +3008,11 @@ msgstr "Who is invited to this party? You can add more participants later."
 msgid "Why is this taking so long?"
 msgstr "Why is this taking so long?"
 
-#: src/routes/new/route.tsx:216
+#: src/routes/new/route.tsx:219
 msgid "WIR Euro"
 msgstr "WIR Euro"
 
-#: src/routes/new/route.tsx:217
+#: src/routes/new/route.tsx:220
 msgid "WIR Franc"
 msgstr "WIR Franc"
 
@@ -3020,7 +3020,7 @@ msgstr "WIR Franc"
 msgid "Works seamlessly offline with automatic sync when online"
 msgstr "Works seamlessly offline with automatic sync when online"
 
-#: src/routes/new/route.tsx:338
+#: src/routes/new/route.tsx:341
 msgid "Yemeni Rial"
 msgstr "Yemeni Rial"
 
@@ -3076,10 +3076,10 @@ msgstr "Your parties"
 msgid "Your total"
 msgstr "Your total"
 
-#: src/routes/new/route.tsx:339
+#: src/routes/new/route.tsx:342
 msgid "Zambian Kwacha"
 msgstr "Zambian Kwacha"
 
-#: src/routes/new/route.tsx:340
+#: src/routes/new/route.tsx:343
 msgid "Zimbabwean Dollar"
 msgstr "Zimbabwean Dollar"

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -71,7 +71,7 @@ msgstr "About"
 msgid "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 msgstr "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 
-#: src/routes/settings.tsx:446
+#: src/routes/settings.tsx:444
 msgid "Accent color"
 msgstr "Accent color"
 
@@ -91,11 +91,11 @@ msgstr "Across the selected timeframe"
 msgid "Active"
 msgstr "Active"
 
-#: src/routes/settings.tsx:497
+#: src/routes/settings.tsx:495
 msgid "Active on this device"
 msgstr "Active on this device"
 
-#: src/routes/new/route.tsx:339
+#: src/routes/new/route.tsx:337
 msgid "ADB Unit of Account"
 msgstr "ADB Unit of Account"
 
@@ -146,15 +146,15 @@ msgstr "Adding expense..."
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/routes/new/route.tsx:196
+#: src/routes/new/route.tsx:194
 msgid "Afghan Afghani"
 msgstr "Afghan Afghani"
 
-#: src/routes/new/route.tsx:197
+#: src/routes/new/route.tsx:195
 msgid "Albanian Lek"
 msgstr "Albanian Lek"
 
-#: src/routes/new/route.tsx:231
+#: src/routes/new/route.tsx:229
 msgid "Algerian Dinar"
 msgstr "Algerian Dinar"
 
@@ -166,7 +166,7 @@ msgstr "Align QR code here"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:449
+#: src/components/ExpenseEditor.tsx:447
 msgid "Amount"
 msgstr "Amount"
 
@@ -174,15 +174,15 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:767
+#: src/components/ExpenseEditor.tsx:765
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:439
+#: src/components/ExpenseEditor.tsx:437
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
-#: src/routes/new/route.tsx:200
+#: src/routes/new/route.tsx:198
 msgid "Angolan Kwanza"
 msgstr "Angolan Kwanza"
 
@@ -234,15 +234,15 @@ msgstr "Archived Parties"
 msgid "Archived parties live here until you restore them to the home screen."
 msgstr "Archived parties live here until you restore them to the home screen."
 
-#: src/routes/new/route.tsx:201
+#: src/routes/new/route.tsx:199
 msgid "Argentine Peso"
 msgstr "Argentine Peso"
 
-#: src/routes/new/route.tsx:198
+#: src/routes/new/route.tsx:196
 msgid "Armenian Dram"
 msgstr "Armenian Dram"
 
-#: src/routes/new/route.tsx:202
+#: src/routes/new/route.tsx:200
 msgid "Aruban Florin"
 msgstr "Aruban Florin"
 
@@ -259,7 +259,7 @@ msgstr "Attach photos of receipts to your expenses"
 msgid "Attachments"
 msgstr "Attachments"
 
-#: src/routes/new/route.tsx:170
+#: src/routes/new/route.tsx:168
 msgid "Australian Dollar"
 msgstr "Australian Dollar"
 
@@ -274,16 +274,16 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:356
-#: src/routes/settings.tsx:433
+#: src/components/ExpenseEditor.tsx:354
+#: src/routes/settings.tsx:431
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
 
-#: src/routes/settings.tsx:435
+#: src/routes/settings.tsx:433
 msgid "Automatically open the calculator when focusing amount fields"
 msgstr "Automatically open the calculator when focusing amount fields"
 
-#: src/routes/settings.tsx:422
+#: src/routes/settings.tsx:420
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Automatically open the last visited party when you open the app"
 
@@ -295,7 +295,7 @@ msgstr "Avatar removed"
 msgid "Avatar updated successfully"
 msgstr "Avatar updated successfully"
 
-#: src/routes/new/route.tsx:203
+#: src/routes/new/route.tsx:201
 msgid "Azerbaijani Manat"
 msgstr "Azerbaijani Manat"
 
@@ -316,11 +316,11 @@ msgstr "Back to sign in"
 msgid "Backspace"
 msgstr "Backspace"
 
-#: src/routes/new/route.tsx:213
+#: src/routes/new/route.tsx:211
 msgid "Bahamian Dollar"
 msgstr "Bahamian Dollar"
 
-#: src/routes/new/route.tsx:207
+#: src/routes/new/route.tsx:205
 msgid "Bahraini Dinar"
 msgstr "Bahraini Dinar"
 
@@ -336,27 +336,27 @@ msgstr "Balance, Lowest First"
 msgid "Balances"
 msgstr "Balances"
 
-#: src/routes/new/route.tsx:206
+#: src/routes/new/route.tsx:204
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
-#: src/routes/new/route.tsx:205
+#: src/routes/new/route.tsx:203
 msgid "Barbadian Dollar"
 msgstr "Barbadian Dollar"
 
-#: src/routes/new/route.tsx:216
+#: src/routes/new/route.tsx:214
 msgid "Belarusian Ruble"
 msgstr "Belarusian Ruble"
 
-#: src/routes/new/route.tsx:217
+#: src/routes/new/route.tsx:215
 msgid "Belize Dollar"
 msgstr "Belize Dollar"
 
-#: src/routes/new/route.tsx:209
+#: src/routes/new/route.tsx:207
 msgid "Bermudan Dollar"
 msgstr "Bermudan Dollar"
 
-#: src/routes/new/route.tsx:214
+#: src/routes/new/route.tsx:212
 msgid "Bhutanese Ngultrum"
 msgstr "Bhutanese Ngultrum"
 
@@ -364,31 +364,31 @@ msgstr "Bhutanese Ngultrum"
 msgid "Biggest spenders"
 msgstr "Biggest spenders"
 
-#: src/routes/new/route.tsx:211
+#: src/routes/new/route.tsx:209
 msgid "Bolivian Boliviano"
 msgstr "Bolivian Boliviano"
 
-#: src/routes/new/route.tsx:212
+#: src/routes/new/route.tsx:210
 msgid "Bolivian Mvdol"
 msgstr "Bolivian Mvdol"
 
-#: src/routes/new/route.tsx:204
+#: src/routes/new/route.tsx:202
 msgid "Bosnia-Herzegovina Convertible Mark"
 msgstr "Bosnia-Herzegovina Convertible Mark"
 
-#: src/routes/new/route.tsx:215
+#: src/routes/new/route.tsx:213
 msgid "Botswanan Pula"
 msgstr "Botswanan Pula"
 
-#: src/routes/new/route.tsx:174
+#: src/routes/new/route.tsx:172
 msgid "Brazilian Real"
 msgstr "Brazilian Real"
 
-#: src/routes/new/route.tsx:166
+#: src/routes/new/route.tsx:164
 msgid "British Pound"
 msgstr "British Pound"
 
-#: src/routes/new/route.tsx:210
+#: src/routes/new/route.tsx:208
 msgid "Brunei Dollar"
 msgstr "Brunei Dollar"
 
@@ -400,11 +400,11 @@ msgstr "Bug Reports"
 msgid "Built With"
 msgstr "Built With"
 
-#: src/routes/new/route.tsx:183
+#: src/routes/new/route.tsx:181
 msgid "Bulgarian Lev"
 msgstr "Bulgarian Lev"
 
-#: src/routes/new/route.tsx:208
+#: src/routes/new/route.tsx:206
 msgid "Burundian Franc"
 msgstr "Burundian Franc"
 
@@ -420,7 +420,7 @@ msgstr "Calculator"
 msgid "Calculator expression"
 msgstr "Calculator expression"
 
-#: src/routes/new/route.tsx:254
+#: src/routes/new/route.tsx:252
 msgid "Cambodian Riel"
 msgstr "Cambodian Riel"
 
@@ -440,7 +440,7 @@ msgstr "Can I use trizum without an account?"
 msgid "Can't add an expense to a party that doesn't exist"
 msgstr "Can't add an expense to a party that doesn't exist"
 
-#: src/routes/new/route.tsx:169
+#: src/routes/new/route.tsx:167
 msgid "Canadian Dollar"
 msgstr "Canadian Dollar"
 
@@ -449,7 +449,7 @@ msgstr "Canadian Dollar"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/routes/new/route.tsx:228
+#: src/routes/new/route.tsx:226
 msgid "Cape Verdean Escudo"
 msgstr "Cape Verdean Escudo"
 
@@ -457,19 +457,19 @@ msgstr "Cape Verdean Escudo"
 msgid "Cash or other ways"
 msgstr "Cash or other ways"
 
-#: src/routes/new/route.tsx:258
+#: src/routes/new/route.tsx:256
 msgid "Cayman Islands Dollar"
 msgstr "Cayman Islands Dollar"
 
-#: src/routes/new/route.tsx:333
+#: src/routes/new/route.tsx:331
 msgid "CFA Franc BCEAO"
 msgstr "CFA Franc BCEAO"
 
-#: src/routes/new/route.tsx:324
+#: src/routes/new/route.tsx:322
 msgid "CFA Franc BEAC"
 msgstr "CFA Franc BEAC"
 
-#: src/routes/new/route.tsx:335
+#: src/routes/new/route.tsx:333
 msgid "CFP Franc"
 msgstr "CFP Franc"
 
@@ -493,19 +493,19 @@ msgstr "Check your email for the sign-in link"
 msgid "Checking for updates..."
 msgstr "Checking for updates..."
 
-#: src/routes/settings.tsx:485
+#: src/routes/settings.tsx:483
 msgid "Checking..."
 msgstr "Checking..."
 
-#: src/routes/new/route.tsx:222
+#: src/routes/new/route.tsx:220
 msgid "Chilean Peso"
 msgstr "Chilean Peso"
 
-#: src/routes/new/route.tsx:221
+#: src/routes/new/route.tsx:219
 msgid "Chilean Unit of Account (UF)"
 msgstr "Chilean Unit of Account (UF)"
 
-#: src/routes/new/route.tsx:171
+#: src/routes/new/route.tsx:169
 msgid "Chinese Yuan"
 msgstr "Chinese Yuan"
 
@@ -554,15 +554,15 @@ msgstr "Cloud settings applied"
 msgid "Cloud settings saved"
 msgstr "Cloud settings saved"
 
-#: src/routes/new/route.tsx:338
+#: src/routes/new/route.tsx:336
 msgid "Code for testing"
 msgstr "Code for testing"
 
-#: src/routes/new/route.tsx:223
+#: src/routes/new/route.tsx:221
 msgid "Colombian Peso"
 msgstr "Colombian Peso"
 
-#: src/routes/new/route.tsx:224
+#: src/routes/new/route.tsx:222
 msgid "Colombian Real Value Unit"
 msgstr "Colombian Real Value Unit"
 
@@ -570,7 +570,7 @@ msgstr "Colombian Real Value Unit"
 msgid "Color"
 msgstr "Color"
 
-#: src/routes/new/route.tsx:255
+#: src/routes/new/route.tsx:253
 msgid "Comorian Franc"
 msgstr "Comorian Franc"
 
@@ -604,7 +604,7 @@ msgstr "Confirmation"
 msgid "Confirming..."
 msgstr "Confirming..."
 
-#: src/routes/new/route.tsx:218
+#: src/routes/new/route.tsx:216
 msgid "Congolese Franc"
 msgstr "Congolese Franc"
 
@@ -675,7 +675,7 @@ msgstr "Copy party link"
 msgid "Copy the phone number and pay through Bizum using your bank app."
 msgstr "Copy the phone number and pay through Bizum using your bank app."
 
-#: src/routes/new/route.tsx:225
+#: src/routes/new/route.tsx:223
 msgid "Costa Rican Colón"
 msgstr "Costa Rican Colón"
 
@@ -700,7 +700,7 @@ msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
 #: src/hooks/useCloudSyncAccountState.ts:220
-#: src/routes/settings.tsx:489
+#: src/routes/settings.tsx:487
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
 
@@ -750,15 +750,15 @@ msgstr "Creditor"
 msgid "Credits"
 msgstr "Credits"
 
-#: src/routes/new/route.tsx:184
+#: src/routes/new/route.tsx:182
 msgid "Croatian Kuna"
 msgstr "Croatian Kuna"
 
-#: src/routes/new/route.tsx:226
+#: src/routes/new/route.tsx:224
 msgid "Cuban Convertible Peso"
 msgstr "Cuban Convertible Peso"
 
-#: src/routes/new/route.tsx:227
+#: src/routes/new/route.tsx:225
 msgid "Cuban Peso"
 msgstr "Cuban Peso"
 
@@ -781,15 +781,15 @@ msgstr "Current year"
 msgid "Custom range"
 msgstr "Custom range"
 
-#: src/routes/new/route.tsx:180
+#: src/routes/new/route.tsx:178
 msgid "Czech Koruna"
 msgstr "Czech Koruna"
 
-#: src/routes/new/route.tsx:178
+#: src/routes/new/route.tsx:176
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:499
+#: src/components/ExpenseEditor.tsx:497
 msgid "Date"
 msgstr "Date"
 
@@ -861,15 +861,15 @@ msgstr "Did you know?"
 msgid "Divide"
 msgstr "Divide"
 
-#: src/routes/new/route.tsx:229
+#: src/routes/new/route.tsx:227
 msgid "Djiboutian Franc"
 msgstr "Djiboutian Franc"
 
-#: src/routes/new/route.tsx:230
+#: src/routes/new/route.tsx:228
 msgid "Dominican Peso"
 msgstr "Dominican Peso"
 
-#: src/routes/new/route.tsx:331
+#: src/routes/new/route.tsx:329
 msgid "East Caribbean Dollar"
 msgstr "East Caribbean Dollar"
 
@@ -885,7 +885,7 @@ msgstr "Editing {0}"
 msgid "Editing {expenseName}"
 msgstr "Editing {expenseName}"
 
-#: src/routes/new/route.tsx:232
+#: src/routes/new/route.tsx:230
 msgid "Egyptian Pound"
 msgstr "Egyptian Pound"
 
@@ -958,11 +958,11 @@ msgstr "Enter a party link or code to join"
 msgid "Enter the key of the Tricount account you want to migrate from"
 msgstr "Enter the key of the Tricount account you want to migrate from"
 
-#: src/routes/join.tsx:175
+#: src/routes/join.tsx:173
 msgid "Enter the link or code of the trizum party you want to join"
 msgstr "Enter the link or code of the trizum party you want to join"
 
-#: src/routes/new/route.tsx:233
+#: src/routes/new/route.tsx:231
 msgid "Eritrean Nakfa"
 msgstr "Eritrean Nakfa"
 
@@ -970,27 +970,27 @@ msgstr "Eritrean Nakfa"
 msgid "Español"
 msgstr "Español"
 
-#: src/routes/new/route.tsx:234
+#: src/routes/new/route.tsx:232
 msgid "Ethiopian Birr"
 msgstr "Ethiopian Birr"
 
-#: src/routes/new/route.tsx:164
+#: src/routes/new/route.tsx:162
 msgid "Euro"
 msgstr "Euro"
 
-#: src/routes/new/route.tsx:327
+#: src/routes/new/route.tsx:325
 msgid "European Composite Unit"
 msgstr "European Composite Unit"
 
-#: src/routes/new/route.tsx:328
+#: src/routes/new/route.tsx:326
 msgid "European Monetary Unit"
 msgstr "European Monetary Unit"
 
-#: src/routes/new/route.tsx:330
+#: src/routes/new/route.tsx:328
 msgid "European Unit of Account 17"
 msgstr "European Unit of Account 17"
 
-#: src/routes/new/route.tsx:329
+#: src/routes/new/route.tsx:327
 msgid "European Unit of Account 9"
 msgstr "European Unit of Account 9"
 
@@ -1027,7 +1027,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:978
+#: src/components/ExpenseEditor.tsx:976
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1072,11 +1072,11 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:953
+#: src/components/ExpenseEditor.tsx:951
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
-#: src/routes/new/route.tsx:236
+#: src/routes/new/route.tsx:234
 msgid "Falkland Islands Pound"
 msgstr "Falkland Islands Pound"
 
@@ -1088,7 +1088,7 @@ msgstr "Feature Requests"
 msgid "Features"
 msgstr "Features"
 
-#: src/routes/new/route.tsx:235
+#: src/routes/new/route.tsx:233
 msgid "Fijian Dollar"
 msgstr "Fijian Dollar"
 
@@ -1101,7 +1101,7 @@ msgstr "Filter totals and rankings"
 msgid "Finishing sign in"
 msgstr "Finishing sign in"
 
-#: src/routes/settings.tsx:384
+#: src/routes/settings.tsx:382
 msgid "For payments through Bizum or similar services"
 msgstr "For payments through Bizum or similar services"
 
@@ -1117,11 +1117,11 @@ msgstr "Found a bug? Let us know on GitHub and we'll fix it."
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: src/routes/new/route.tsx:240
+#: src/routes/new/route.tsx:238
 msgid "Gambian Dalasi"
 msgstr "Gambian Dalasi"
 
-#: src/routes/new/route.tsx:237
+#: src/routes/new/route.tsx:235
 msgid "Georgian Lari"
 msgstr "Georgian Lari"
 
@@ -1129,11 +1129,11 @@ msgstr "Georgian Lari"
 msgid "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 msgstr "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 
-#: src/routes/new/route.tsx:238
+#: src/routes/new/route.tsx:236
 msgid "Ghanaian Cedi"
 msgstr "Ghanaian Cedi"
 
-#: src/routes/new/route.tsx:239
+#: src/routes/new/route.tsx:237
 msgid "Gibraltar Pound"
 msgstr "Gibraltar Pound"
 
@@ -1154,7 +1154,7 @@ msgstr "Go back and try again from the balances list."
 msgid "Go back to home"
 msgstr "Go back to home"
 
-#: src/routes/new/route.tsx:326
+#: src/routes/new/route.tsx:324
 msgid "Gold (troy ounce)"
 msgstr "Gold (troy ounce)"
 
@@ -1178,19 +1178,19 @@ msgstr "Got it"
 msgid "Group expense sharing made simple. Track, split and settle shared costs effortlessly."
 msgstr "Group expense sharing made simple. Track, split and settle shared costs effortlessly."
 
-#: src/routes/new/route.tsx:242
+#: src/routes/new/route.tsx:240
 msgid "Guatemalan Quetzal"
 msgstr "Guatemalan Quetzal"
 
-#: src/routes/new/route.tsx:241
+#: src/routes/new/route.tsx:239
 msgid "Guinean Franc"
 msgstr "Guinean Franc"
 
-#: src/routes/new/route.tsx:243
+#: src/routes/new/route.tsx:241
 msgid "Guyanaese Dollar"
 msgstr "Guyanaese Dollar"
 
-#: src/routes/new/route.tsx:245
+#: src/routes/new/route.tsx:243
 msgid "Haitian Gourde"
 msgstr "Haitian Gourde"
 
@@ -1198,7 +1198,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:855
+#: src/components/ExpenseEditor.tsx:853
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -1218,11 +1218,11 @@ msgstr "Hide password sign in"
 msgid "Home"
 msgstr "Home"
 
-#: src/routes/new/route.tsx:244
+#: src/routes/new/route.tsx:242
 msgid "Honduran Lempira"
 msgstr "Honduran Lempira"
 
-#: src/routes/new/route.tsx:189
+#: src/routes/new/route.tsx:187
 msgid "Hong Kong Dollar"
 msgstr "Hong Kong Dollar"
 
@@ -1247,11 +1247,11 @@ msgstr "How should I balance?"
 msgid "How to pay?"
 msgstr "How to pay?"
 
-#: src/routes/new/route.tsx:181
+#: src/routes/new/route.tsx:179
 msgid "Hungarian Forint"
 msgstr "Hungarian Forint"
 
-#: src/routes/new/route.tsx:249
+#: src/routes/new/route.tsx:247
 msgid "Icelandic Króna"
 msgstr "Icelandic Króna"
 
@@ -1267,7 +1267,7 @@ msgstr "Image must be smaller than 10MB"
 msgid "Impact on my balance: <0/>"
 msgstr "Impact on my balance: <0/>"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:97
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:95
 msgid "Import attachments"
 msgstr "Import attachments"
 
@@ -1287,11 +1287,11 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:543
+#: src/components/ExpenseEditor.tsx:541
 msgid "Include all"
 msgstr "Include all"
 
-#: src/routes/new/route.tsx:172
+#: src/routes/new/route.tsx:170
 msgid "Indian Rupee"
 msgstr "Indian Rupee"
 
@@ -1299,7 +1299,7 @@ msgstr "Indian Rupee"
 msgid "Individual totals"
 msgstr "Individual totals"
 
-#: src/routes/new/route.tsx:246
+#: src/routes/new/route.tsx:244
 msgid "Indonesian Rupiah"
 msgstr "Indonesian Rupiah"
 
@@ -1321,11 +1321,11 @@ msgstr "Invalid trizum party code"
 msgid "Invalid trizum party link"
 msgstr "Invalid trizum party link"
 
-#: src/routes/new/route.tsx:248
+#: src/routes/new/route.tsx:246
 msgid "Iranian Rial"
 msgstr "Iranian Rial"
 
-#: src/routes/new/route.tsx:247
+#: src/routes/new/route.tsx:245
 msgid "Iraqi Dinar"
 msgstr "Iraqi Dinar"
 
@@ -1333,19 +1333,19 @@ msgstr "Iraqi Dinar"
 msgid "Is my data secure?"
 msgstr "Is my data secure?"
 
-#: src/routes/new/route.tsx:192
+#: src/routes/new/route.tsx:190
 msgid "Israeli Shekel"
 msgstr "Israeli Shekel"
 
-#: src/routes/new/route.tsx:250
+#: src/routes/new/route.tsx:248
 msgid "Jamaican Dollar"
 msgstr "Jamaican Dollar"
 
-#: src/routes/new/route.tsx:167
+#: src/routes/new/route.tsx:165
 msgid "Japanese Yen"
 msgstr "Japanese Yen"
 
-#: src/routes/join.tsx:195
+#: src/routes/join.tsx:193
 msgid "Join"
 msgstr "Join"
 
@@ -1370,7 +1370,7 @@ msgstr "Join a trizum"
 msgid "Joined {0}!"
 msgstr "Joined {0}!"
 
-#: src/routes/new/route.tsx:251
+#: src/routes/new/route.tsx:249
 msgid "Jordanian Dinar"
 msgstr "Jordanian Dinar"
 
@@ -1378,7 +1378,7 @@ msgstr "Jordanian Dinar"
 msgid "Jump back into the groups you use most"
 msgstr "Jump back into the groups you use most"
 
-#: src/routes/new/route.tsx:259
+#: src/routes/new/route.tsx:257
 msgid "Kazakhstani Tenge"
 msgstr "Kazakhstani Tenge"
 
@@ -1390,23 +1390,23 @@ msgstr "Keep local data"
 msgid "Keep your profile settings available on your signed-in devices."
 msgstr "Keep your profile settings available on your signed-in devices."
 
-#: src/routes/new/route.tsx:252
+#: src/routes/new/route.tsx:250
 msgid "Kenyan Shilling"
 msgstr "Kenyan Shilling"
 
-#: src/routes/new/route.tsx:257
+#: src/routes/new/route.tsx:255
 msgid "Kuwaiti Dinar"
 msgstr "Kuwaiti Dinar"
 
-#: src/routes/new/route.tsx:253
+#: src/routes/new/route.tsx:251
 msgid "Kyrgystani Som"
 msgstr "Kyrgystani Som"
 
-#: src/routes/settings.tsx:399
+#: src/routes/settings.tsx:397
 msgid "Language"
 msgstr "Language"
 
-#: src/routes/new/route.tsx:260
+#: src/routes/new/route.tsx:258
 msgid "Laotian Kip"
 msgstr "Laotian Kip"
 
@@ -1426,19 +1426,19 @@ msgstr "Last year"
 msgid "Leave party"
 msgstr "Leave party"
 
-#: src/routes/new/route.tsx:261
+#: src/routes/new/route.tsx:259
 msgid "Lebanese Pound"
 msgstr "Lebanese Pound"
 
-#: src/routes/new/route.tsx:264
+#: src/routes/new/route.tsx:262
 msgid "Lesotho Loti"
 msgstr "Lesotho Loti"
 
-#: src/routes/new/route.tsx:263
+#: src/routes/new/route.tsx:261
 msgid "Liberian Dollar"
 msgstr "Liberian Dollar"
 
-#: src/routes/new/route.tsx:265
+#: src/routes/new/route.tsx:263
 msgid "Libyan Dinar"
 msgstr "Libyan Dinar"
 
@@ -1446,7 +1446,7 @@ msgstr "Libyan Dinar"
 msgid "License"
 msgstr "License"
 
-#: src/routes/join.tsx:174
+#: src/routes/join.tsx:172
 msgid "Link or code"
 msgstr "Link or code"
 
@@ -1462,27 +1462,27 @@ msgstr "Loading licenses..."
 msgid "Long press for party actions"
 msgstr "Long press for party actions"
 
-#: src/routes/new/route.tsx:272
+#: src/routes/new/route.tsx:270
 msgid "Macanese Pataca"
 msgstr "Macanese Pataca"
 
-#: src/routes/new/route.tsx:269
+#: src/routes/new/route.tsx:267
 msgid "Macedonian Denar"
 msgstr "Macedonian Denar"
 
-#: src/routes/new/route.tsx:268
+#: src/routes/new/route.tsx:266
 msgid "Malagasy Ariary"
 msgstr "Malagasy Ariary"
 
-#: src/routes/new/route.tsx:276
+#: src/routes/new/route.tsx:274
 msgid "Malawian Kwacha"
 msgstr "Malawian Kwacha"
 
-#: src/routes/new/route.tsx:278
+#: src/routes/new/route.tsx:276
 msgid "Malaysian Ringgit"
 msgstr "Malaysian Ringgit"
 
-#: src/routes/new/route.tsx:275
+#: src/routes/new/route.tsx:273
 msgid "Maldivian Rufiyaa"
 msgstr "Maldivian Rufiyaa"
 
@@ -1504,11 +1504,11 @@ msgstr "Mark as paid"
 msgid "Marking expense as paid..."
 msgstr "Marking expense as paid..."
 
-#: src/routes/new/route.tsx:273
+#: src/routes/new/route.tsx:271
 msgid "Mauritanian Ouguiya"
 msgstr "Mauritanian Ouguiya"
 
-#: src/routes/new/route.tsx:274
+#: src/routes/new/route.tsx:272
 msgid "Mauritian Rupee"
 msgstr "Mauritian Rupee"
 
@@ -1519,18 +1519,18 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:349
+#: src/components/ExpenseEditor.tsx:347
 #: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:86
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
 msgstr "Menu"
 
-#: src/routes/new/route.tsx:277
+#: src/routes/new/route.tsx:275
 msgid "Mexican Investment Unit"
 msgstr "Mexican Investment Unit"
 
-#: src/routes/new/route.tsx:173
+#: src/routes/new/route.tsx:171
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
@@ -1553,15 +1553,15 @@ msgstr "Migration successful"
 msgid "Missing search params"
 msgstr "Missing search params"
 
-#: src/routes/new/route.tsx:267
+#: src/routes/new/route.tsx:265
 msgid "Moldovan Leu"
 msgstr "Moldovan Leu"
 
-#: src/routes/new/route.tsx:271
+#: src/routes/new/route.tsx:269
 msgid "Mongolian Tugrik"
 msgstr "Mongolian Tugrik"
 
-#: src/routes/new/route.tsx:266
+#: src/routes/new/route.tsx:264
 msgid "Moroccan Dirham"
 msgstr "Moroccan Dirham"
 
@@ -1577,7 +1577,7 @@ msgstr "Move cursor right"
 msgid "Moved to"
 msgstr "Moved to"
 
-#: src/routes/new/route.tsx:279
+#: src/routes/new/route.tsx:277
 msgid "Mozambican Metical"
 msgstr "Mozambican Metical"
 
@@ -1589,7 +1589,7 @@ msgstr "Multi-Party Splitting"
 msgid "Multiply"
 msgstr "Multiply"
 
-#: src/routes/new/route.tsx:270
+#: src/routes/new/route.tsx:268
 msgid "Myanma Kyat"
 msgstr "Myanma Kyat"
 
@@ -1603,7 +1603,7 @@ msgstr "Name"
 msgid "Name must be less than 50 characters"
 msgstr "Name must be less than 50 characters"
 
-#: src/routes/new/route.tsx:280
+#: src/routes/new/route.tsx:278
 msgid "Namibian Dollar"
 msgstr "Namibian Dollar"
 
@@ -1611,11 +1611,11 @@ msgstr "Namibian Dollar"
 msgid "Need help with trizum? We're here to assist you."
 msgstr "Need help with trizum? We're here to assist you."
 
-#: src/routes/new/route.tsx:283
+#: src/routes/new/route.tsx:281
 msgid "Nepalese Rupee"
 msgstr "Nepalese Rupee"
 
-#: src/routes/new/route.tsx:199
+#: src/routes/new/route.tsx:197
 msgid "Netherlands Antillean Guilder"
 msgstr "Netherlands Antillean Guilder"
 
@@ -1628,11 +1628,11 @@ msgstr "New expense"
 msgid "New participant name"
 msgstr "New participant name"
 
-#: src/routes/reset-password.tsx:127
+#: src/routes/reset-password.tsx:125
 msgid "New password"
 msgstr "New password"
 
-#: src/routes/new/route.tsx:311
+#: src/routes/new/route.tsx:309
 msgid "New Taiwan Dollar"
 msgstr "New Taiwan Dollar"
 
@@ -1640,7 +1640,7 @@ msgstr "New Taiwan Dollar"
 msgid "New trizum"
 msgstr "New trizum"
 
-#: src/routes/new/route.tsx:187
+#: src/routes/new/route.tsx:185
 msgid "New Zealand Dollar"
 msgstr "New Zealand Dollar"
 
@@ -1648,11 +1648,11 @@ msgstr "New Zealand Dollar"
 msgid "Next"
 msgstr "Next"
 
-#: src/routes/new/route.tsx:282
+#: src/routes/new/route.tsx:280
 msgid "Nicaraguan Córdoba"
 msgstr "Nicaraguan Córdoba"
 
-#: src/routes/new/route.tsx:281
+#: src/routes/new/route.tsx:279
 msgid "Nigerian Naira"
 msgstr "Nigerian Naira"
 
@@ -1672,7 +1672,7 @@ msgstr "No camera found on this device"
 msgid "No cloud settings saved yet"
 msgstr "No cloud settings saved yet"
 
-#: src/routes/new/route.tsx:340
+#: src/routes/new/route.tsx:338
 msgid "No currency"
 msgstr "No currency"
 
@@ -1717,11 +1717,11 @@ msgstr "Nobody yet"
 msgid "Non-transfer expenses in this timeframe"
 msgstr "Non-transfer expenses in this timeframe"
 
-#: src/routes/new/route.tsx:256
+#: src/routes/new/route.tsx:254
 msgid "North Korean Won"
 msgstr "North Korean Won"
 
-#: src/routes/new/route.tsx:177
+#: src/routes/new/route.tsx:175
 msgid "Norwegian Krone"
 msgstr "Norwegian Krone"
 
@@ -1734,11 +1734,11 @@ msgstr "Not a valid trizum party code"
 msgid "Not connected"
 msgstr "Not connected"
 
-#: src/routes/settings.tsx:493
+#: src/routes/settings.tsx:491
 msgid "Not set up"
 msgstr "Not set up"
 
-#: src/routes/settings.tsx:481
+#: src/routes/settings.tsx:479
 msgid "Not signed in"
 msgstr "Not signed in"
 
@@ -1754,7 +1754,7 @@ msgstr "Offline-First"
 msgid "Older parties stay tucked away, not gone"
 msgstr "Older parties stay tucked away, not gone"
 
-#: src/routes/new/route.tsx:284
+#: src/routes/new/route.tsx:282
 msgid "Omani Rial"
 msgstr "Omani Rial"
 
@@ -1774,7 +1774,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:359
+#: src/components/ExpenseEditor.tsx:357
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1782,7 +1782,7 @@ msgstr "Open calculator when focusing amount fields"
 msgid "Open GitHub Issues"
 msgstr "Open GitHub Issues"
 
-#: src/routes/settings.tsx:420
+#: src/routes/settings.tsx:418
 msgid "Open last party on launch"
 msgstr "Open last party on launch"
 
@@ -1819,7 +1819,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:474
+#: src/components/ExpenseEditor.tsx:472
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -1832,23 +1832,23 @@ msgstr "Paid debt to {0}"
 msgid "Paid debt to {toName}"
 msgstr "Paid debt to {toName}"
 
-#: src/routes/new/route.tsx:289
+#: src/routes/new/route.tsx:287
 msgid "Pakistani Rupee"
 msgstr "Pakistani Rupee"
 
-#: src/routes/new/route.tsx:334
+#: src/routes/new/route.tsx:332
 msgid "Palladium (troy ounce)"
 msgstr "Palladium (troy ounce)"
 
-#: src/routes/new/route.tsx:285
+#: src/routes/new/route.tsx:283
 msgid "Panamanian Balboa"
 msgstr "Panamanian Balboa"
 
-#: src/routes/new/route.tsx:287
+#: src/routes/new/route.tsx:285
 msgid "Papua New Guinean Kina"
 msgstr "Papua New Guinean Kina"
 
-#: src/routes/new/route.tsx:290
+#: src/routes/new/route.tsx:288
 msgid "Paraguayan Guarani"
 msgstr "Paraguayan Guarani"
 
@@ -1940,7 +1940,7 @@ msgstr "Password email sent"
 msgid "Password enabled"
 msgstr "Password enabled"
 
-#: src/routes/reset-password.tsx:121
+#: src/routes/reset-password.tsx:119
 msgid "Password must be at least 8 characters"
 msgstr "Password must be at least 8 characters"
 
@@ -1964,7 +1964,7 @@ msgstr "Password sign-in is enabled"
 msgid "Password updated"
 msgstr "Password updated"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:77
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:75
 msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 msgstr "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 
@@ -1985,15 +1985,15 @@ msgstr "Permanently delete your trizum cloud account"
 msgid "Personal mode"
 msgstr "Personal mode"
 
-#: src/routes/new/route.tsx:286
+#: src/routes/new/route.tsx:284
 msgid "Peruvian Sol"
 msgstr "Peruvian Sol"
 
-#: src/routes/new/route.tsx:288
+#: src/routes/new/route.tsx:286
 msgid "Philippine Peso"
 msgstr "Philippine Peso"
 
-#: src/routes/settings.tsx:383
+#: src/routes/settings.tsx:381
 msgid "Phone number"
 msgstr "Phone number"
 
@@ -2025,7 +2025,7 @@ msgstr "Pinned parties stay close. Recent activity keeps the rest in order."
 msgid "Pinned parties stay on top, then the rest follow your latest activity."
 msgstr "Pinned parties stay on top, then the rest follow your latest activity."
 
-#: src/routes/new/route.tsx:336
+#: src/routes/new/route.tsx:334
 msgid "Platinum (troy ounce)"
 msgstr "Platinum (troy ounce)"
 
@@ -2033,7 +2033,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:873
+#: src/components/ExpenseEditor.tsx:871
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -2057,7 +2057,7 @@ msgstr "Please wait while we fetch the latest data"
 msgid "Point your camera at a trizum QR code"
 msgstr "Point your camera at a trizum QR code"
 
-#: src/routes/new/route.tsx:179
+#: src/routes/new/route.tsx:177
 msgid "Polish Zloty"
 msgstr "Polish Zloty"
 
@@ -2069,7 +2069,7 @@ msgstr "Previous"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: src/routes/new/route.tsx:291
+#: src/routes/new/route.tsx:289
 msgid "Qatari Rial"
 msgstr "Qatari Rial"
 
@@ -2081,7 +2081,7 @@ msgstr "QR code frame capture"
 msgid "Ranking based on how much each participant paid in the selected timeframe."
 msgstr "Ranking based on how much each participant paid in the selected timeframe."
 
-#: src/routes/settings.tsx:500
+#: src/routes/settings.tsx:498
 msgid "Ready on another device"
 msgstr "Ready on another device"
 
@@ -2110,7 +2110,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1070
+#: src/components/ExpenseEditor.tsx:1068
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2147,35 +2147,35 @@ msgstr "Restore to home"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/routes/new/route.tsx:182
+#: src/routes/new/route.tsx:180
 msgid "Romanian Leu"
 msgstr "Romanian Leu"
 
-#: src/routes/new/route.tsx:185
+#: src/routes/new/route.tsx:183
 msgid "Russian Ruble"
 msgstr "Russian Ruble"
 
-#: src/routes/new/route.tsx:293
+#: src/routes/new/route.tsx:291
 msgid "Rwandan Franc"
 msgstr "Rwandan Franc"
 
-#: src/routes/new/route.tsx:297
+#: src/routes/new/route.tsx:295
 msgid "Saint Helena Pound"
 msgstr "Saint Helena Pound"
 
-#: src/routes/new/route.tsx:303
+#: src/routes/new/route.tsx:301
 msgid "Salvadoran Colón"
 msgstr "Salvadoran Colón"
 
-#: src/routes/new/route.tsx:323
+#: src/routes/new/route.tsx:321
 msgid "Samoan Tala"
 msgstr "Samoan Tala"
 
-#: src/routes/new/route.tsx:302
+#: src/routes/new/route.tsx:300
 msgid "São Tomé and Príncipe Dobra"
 msgstr "São Tomé and Príncipe Dobra"
 
-#: src/routes/new/route.tsx:194
+#: src/routes/new/route.tsx:192
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
@@ -2226,7 +2226,7 @@ msgstr "Send password link"
 msgid "Send us an email and we'll get back to you as soon as possible."
 msgstr "Send us an email and we'll get back to you as soon as possible."
 
-#: src/routes/new/route.tsx:292
+#: src/routes/new/route.tsx:290
 msgid "Serbian Dinar"
 msgstr "Serbian Dinar"
 
@@ -2260,7 +2260,7 @@ msgstr "Settings saved"
 msgid "Settled in"
 msgstr "Settled in"
 
-#: src/routes/new/route.tsx:295
+#: src/routes/new/route.tsx:293
 msgid "Seychellois Rupee"
 msgstr "Seychellois Rupee"
 
@@ -2282,7 +2282,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:729
+#: src/components/ExpenseEditor.tsx:727
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -2290,11 +2290,11 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:859
+#: src/components/ExpenseEditor.tsx:857
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
-#: src/routes/new/route.tsx:298
+#: src/routes/new/route.tsx:296
 msgid "Sierra Leonean Leone"
 msgstr "Sierra Leonean Leone"
 
@@ -2363,7 +2363,7 @@ msgstr "Signed in"
 msgid "Signed out"
 msgstr "Signed out"
 
-#: src/routes/new/route.tsx:325
+#: src/routes/new/route.tsx:323
 msgid "Silver (troy ounce)"
 msgstr "Silver (troy ounce)"
 
@@ -2371,15 +2371,15 @@ msgstr "Silver (troy ounce)"
 msgid "Simple"
 msgstr "Simple"
 
-#: src/routes/new/route.tsx:188
+#: src/routes/new/route.tsx:186
 msgid "Singapore Dollar"
 msgstr "Singapore Dollar"
 
-#: src/routes/new/route.tsx:294
+#: src/routes/new/route.tsx:292
 msgid "Solomon Islands Dollar"
 msgstr "Solomon Islands Dollar"
 
-#: src/routes/new/route.tsx:299
+#: src/routes/new/route.tsx:297
 msgid "Somali Shilling"
 msgstr "Somali Shilling"
 
@@ -2395,19 +2395,19 @@ msgstr "Something went wrong"
 msgid "Sort balances"
 msgstr "Sort balances"
 
-#: src/routes/new/route.tsx:191
+#: src/routes/new/route.tsx:189
 msgid "South African Rand"
 msgstr "South African Rand"
 
-#: src/routes/new/route.tsx:175
+#: src/routes/new/route.tsx:173
 msgid "South Korean Won"
 msgstr "South Korean Won"
 
-#: src/routes/new/route.tsx:301
+#: src/routes/new/route.tsx:299
 msgid "South Sudanese Pound"
 msgstr "South Sudanese Pound"
 
-#: src/routes/new/route.tsx:332
+#: src/routes/new/route.tsx:330
 msgid "Special Drawing Rights"
 msgstr "Special Drawing Rights"
 
@@ -2423,7 +2423,7 @@ msgstr "Split bills with friends and family. Track, calculate, and settle expens
 msgid "Split expenses fairly among multiple participants"
 msgstr "Split expenses fairly among multiple participants"
 
-#: src/routes/new/route.tsx:262
+#: src/routes/new/route.tsx:260
 msgid "Sri Lankan Rupee"
 msgstr "Sri Lankan Rupee"
 
@@ -2462,11 +2462,11 @@ msgstr "Submitting..."
 msgid "Subtract"
 msgstr "Subtract"
 
-#: src/routes/new/route.tsx:337
+#: src/routes/new/route.tsx:335
 msgid "Sucre"
 msgstr "Sucre"
 
-#: src/routes/new/route.tsx:296
+#: src/routes/new/route.tsx:294
 msgid "Sudanese Pound"
 msgstr "Sudanese Pound"
 
@@ -2475,15 +2475,15 @@ msgstr "Sudanese Pound"
 msgid "Support"
 msgstr "Support"
 
-#: src/routes/new/route.tsx:300
+#: src/routes/new/route.tsx:298
 msgid "Surinamese Dollar"
 msgstr "Surinamese Dollar"
 
-#: src/routes/new/route.tsx:305
+#: src/routes/new/route.tsx:303
 msgid "Swazi Lilangeni"
 msgstr "Swazi Lilangeni"
 
-#: src/routes/new/route.tsx:176
+#: src/routes/new/route.tsx:174
 msgid "Swedish Krona"
 msgstr "Swedish Krona"
 
@@ -2491,15 +2491,15 @@ msgstr "Swedish Krona"
 msgid "Swipe between expenses and balances tabs."
 msgstr "Swipe between expenses and balances tabs."
 
-#: src/routes/new/route.tsx:168
+#: src/routes/new/route.tsx:166
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:753
+#: src/components/ExpenseEditor.tsx:751
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:754
+#: src/components/ExpenseEditor.tsx:752
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2524,7 +2524,7 @@ msgstr "Sync profile settings"
 msgid "Syncing party information..."
 msgstr "Syncing party information..."
 
-#: src/routes/new/route.tsx:304
+#: src/routes/new/route.tsx:302
 msgid "Syrian Pound"
 msgstr "Syrian Pound"
 
@@ -2532,18 +2532,18 @@ msgstr "Syrian Pound"
 msgid "System (fallbacks to {DEFAULT_LOCALE})"
 msgstr "System (fallbacks to {DEFAULT_LOCALE})"
 
-#: src/routes/new/route.tsx:306
+#: src/routes/new/route.tsx:304
 msgid "Tajikistani Somoni"
 msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:998
-#: src/components/ExpenseEditor.tsx:1012
+#: src/components/ExpenseEditor.tsx:996
+#: src/components/ExpenseEditor.tsx:1010
 msgid "Take photo"
 msgstr "Take photo"
 
-#: src/routes/new/route.tsx:312
+#: src/routes/new/route.tsx:310
 msgid "Tanzanian Shilling"
 msgstr "Tanzanian Shilling"
 
@@ -2551,7 +2551,7 @@ msgstr "Tanzanian Shilling"
 msgid "Tap to change"
 msgstr "Tap to change"
 
-#: src/routes/new/route.tsx:190
+#: src/routes/new/route.tsx:188
 msgid "Thai Baht"
 msgstr "Thai Baht"
 
@@ -2638,7 +2638,7 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:415
+#: src/components/ExpenseEditor.tsx:413
 msgid "Title"
 msgstr "Title"
 
@@ -2658,11 +2658,11 @@ msgstr "To connect Google or Apple, choose an account with the same email addres
 msgid "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 
-#: src/routes/party_.$partyId.who.tsx:132
+#: src/routes/party_.$partyId.who.tsx:130
 msgid "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 
-#: src/routes/new/route.tsx:309
+#: src/routes/new/route.tsx:307
 msgid "Tongan Paʻanga"
 msgstr "Tongan Paʻanga"
 
@@ -2704,11 +2704,11 @@ msgstr "Tricount key is required"
 msgid "Tricount key or URL is required"
 msgstr "Tricount key or URL is required"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:76
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:74
 msgid "Tricount URL or key"
 msgstr "Tricount URL or key"
 
-#: src/routes/new/route.tsx:310
+#: src/routes/new/route.tsx:308
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
@@ -2768,15 +2768,15 @@ msgstr "Try another timeframe to compare a different period of your party."
 msgid "Try scanning another code"
 msgstr "Try scanning another code"
 
-#: src/routes/new/route.tsx:308
+#: src/routes/new/route.tsx:306
 msgid "Tunisian Dinar"
 msgstr "Tunisian Dinar"
 
-#: src/routes/new/route.tsx:186
+#: src/routes/new/route.tsx:184
 msgid "Turkish Lira"
 msgstr "Turkish Lira"
 
-#: src/routes/new/route.tsx:307
+#: src/routes/new/route.tsx:305
 msgid "Turkmenistani Manat"
 msgstr "Turkmenistani Manat"
 
@@ -2784,19 +2784,19 @@ msgstr "Turkmenistani Manat"
 msgid "Type \"delete account\" to confirm."
 msgstr "Type \"delete account\" to confirm."
 
-#: src/routes/new/route.tsx:193
+#: src/routes/new/route.tsx:191
 msgid "UAE Dirham"
 msgstr "UAE Dirham"
 
-#: src/routes/new/route.tsx:314
+#: src/routes/new/route.tsx:312
 msgid "Ugandan Shilling"
 msgstr "Ugandan Shilling"
 
-#: src/routes/new/route.tsx:313
+#: src/routes/new/route.tsx:311
 msgid "Ukrainian Hryvnia"
 msgstr "Ukrainian Hryvnia"
 
-#: src/routes/new/route.tsx:318
+#: src/routes/new/route.tsx:316
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
@@ -2821,11 +2821,11 @@ msgstr "Update failed. Please try again."
 msgid "Update is no longer available."
 msgstr "Update is no longer available."
 
-#: src/routes/reset-password.tsx:142
+#: src/routes/reset-password.tsx:140
 msgid "Update password"
 msgstr "Update password"
 
-#: src/routes/party_.$partyId.who.tsx:137
+#: src/routes/party_.$partyId.who.tsx:135
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 msgstr "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 
@@ -2837,14 +2837,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:898
+#: src/components/ExpenseEditor.tsx:896
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1007
-#: src/components/ExpenseEditor.tsx:1024
+#: src/components/ExpenseEditor.tsx:1005
+#: src/components/ExpenseEditor.tsx:1022
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2857,7 +2857,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:938
+#: src/components/ExpenseEditor.tsx:936
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2865,19 +2865,19 @@ msgstr "Uploading..."
 msgid "URL or Party ID"
 msgstr "URL or Party ID"
 
-#: src/routes/new/route.tsx:316
+#: src/routes/new/route.tsx:314
 msgid "Uruguay Peso en Unidades Indexadas"
 msgstr "Uruguay Peso en Unidades Indexadas"
 
-#: src/routes/new/route.tsx:317
+#: src/routes/new/route.tsx:315
 msgid "Uruguayan Peso"
 msgstr "Uruguayan Peso"
 
-#: src/routes/new/route.tsx:165
+#: src/routes/new/route.tsx:163
 msgid "US Dollar"
 msgstr "US Dollar"
 
-#: src/routes/new/route.tsx:315
+#: src/routes/new/route.tsx:313
 msgid "US Dollar (Next day)"
 msgstr "US Dollar (Next day)"
 
@@ -2906,7 +2906,7 @@ msgstr "Use trizum cloud on this device?"
 msgid "Use your camera to scan a trizum invite"
 msgstr "Use your camera to scan a trizum invite"
 
-#: src/routes/settings.tsx:361
+#: src/routes/settings.tsx:359
 msgid "Username"
 msgstr "Username"
 
@@ -2914,15 +2914,15 @@ msgstr "Username"
 msgid "Username, phone, language, launch behavior, and accent color"
 msgstr "Username, phone, language, launch behavior, and accent color"
 
-#: src/routes/new/route.tsx:319
+#: src/routes/new/route.tsx:317
 msgid "Uzbekistan Som"
 msgstr "Uzbekistan Som"
 
-#: src/routes/new/route.tsx:322
+#: src/routes/new/route.tsx:320
 msgid "Vanuatu Vatu"
 msgstr "Vanuatu Vatu"
 
-#: src/routes/new/route.tsx:320
+#: src/routes/new/route.tsx:318
 msgid "Venezuelan Bolívar Soberano"
 msgstr "Venezuelan Bolívar Soberano"
 
@@ -2930,7 +2930,7 @@ msgstr "Venezuelan Bolívar Soberano"
 msgid "Version"
 msgstr "Version"
 
-#: src/routes/new/route.tsx:321
+#: src/routes/new/route.tsx:319
 msgid "Vietnamese Dong"
 msgstr "Vietnamese Dong"
 
@@ -2942,7 +2942,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1059
+#: src/components/ExpenseEditor.tsx:1057
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"
@@ -2992,7 +2992,7 @@ msgstr "Welcome to trizum"
 msgid "What is this party about?"
 msgstr "What is this party about?"
 
-#: src/routes/settings.tsx:362
+#: src/routes/settings.tsx:360
 msgid "What's your preferred way to be addressed?"
 msgstr "What's your preferred way to be addressed?"
 
@@ -3008,11 +3008,11 @@ msgstr "Who is invited to this party? You can add more participants later."
 msgid "Why is this taking so long?"
 msgstr "Why is this taking so long?"
 
-#: src/routes/new/route.tsx:219
+#: src/routes/new/route.tsx:217
 msgid "WIR Euro"
 msgstr "WIR Euro"
 
-#: src/routes/new/route.tsx:220
+#: src/routes/new/route.tsx:218
 msgid "WIR Franc"
 msgstr "WIR Franc"
 
@@ -3020,7 +3020,7 @@ msgstr "WIR Franc"
 msgid "Works seamlessly offline with automatic sync when online"
 msgstr "Works seamlessly offline with automatic sync when online"
 
-#: src/routes/new/route.tsx:341
+#: src/routes/new/route.tsx:339
 msgid "Yemeni Rial"
 msgstr "Yemeni Rial"
 
@@ -3076,10 +3076,10 @@ msgstr "Your parties"
 msgid "Your total"
 msgstr "Your total"
 
-#: src/routes/new/route.tsx:342
+#: src/routes/new/route.tsx:340
 msgid "Zambian Kwacha"
 msgstr "Zambian Kwacha"
 
-#: src/routes/new/route.tsx:343
+#: src/routes/new/route.tsx:341
 msgid "Zimbabwean Dollar"
 msgstr "Zimbabwean Dollar"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -67,7 +67,7 @@ msgstr "Acerca de"
 msgid "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 msgstr "¡Por supuesto! trizum funciona sin necesidad de crear una cuenta o registrarte. Solo crea un grupo y empieza a registrar gastos."
 
-#: src/routes/settings.tsx:441
+#: src/routes/settings.tsx:446
 msgid "Accent color"
 msgstr "Color de acento"
 
@@ -87,11 +87,11 @@ msgstr "En el período seleccionado"
 msgid "Active"
 msgstr "Activos"
 
-#: src/routes/settings.tsx:492
+#: src/routes/settings.tsx:497
 msgid "Active on this device"
 msgstr "Activo en este dispositivo"
 
-#: src/routes/new/route.tsx:336
+#: src/routes/new/route.tsx:339
 msgid "ADB Unit of Account"
 msgstr "Unidad de Cuenta del BAsD"
 
@@ -138,15 +138,15 @@ msgstr "Añade tu nombre para que otros sepan quién eres y cómo pagarte"
 msgid "Adding expense..."
 msgstr "Añadiendo gasto..."
 
-#: src/routes/new/route.tsx:193
+#: src/routes/new/route.tsx:196
 msgid "Afghan Afghani"
 msgstr "Afgani Afgano"
 
-#: src/routes/new/route.tsx:194
+#: src/routes/new/route.tsx:197
 msgid "Albanian Lek"
 msgstr "Lek Albanés"
 
-#: src/routes/new/route.tsx:228
+#: src/routes/new/route.tsx:231
 msgid "Algerian Dinar"
 msgstr "Dinar Argelino"
 
@@ -158,7 +158,7 @@ msgstr "Alinea el código QR aquí"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:445
+#: src/components/ExpenseEditor.tsx:449
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -166,15 +166,15 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:763
+#: src/components/ExpenseEditor.tsx:767
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:435
+#: src/components/ExpenseEditor.tsx:439
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
-#: src/routes/new/route.tsx:197
+#: src/routes/new/route.tsx:200
 msgid "Angolan Kwanza"
 msgstr "Kwanza Angoleño"
 
@@ -226,15 +226,15 @@ msgstr "Grupos archivados"
 msgid "Archived parties live here until you restore them to the home screen."
 msgstr "Los grupos archivados se quedan aquí hasta que los restaures al inicio."
 
-#: src/routes/new/route.tsx:198
+#: src/routes/new/route.tsx:201
 msgid "Argentine Peso"
 msgstr "Peso Argentino"
 
-#: src/routes/new/route.tsx:195
+#: src/routes/new/route.tsx:198
 msgid "Armenian Dram"
 msgstr "Dram Armenio"
 
-#: src/routes/new/route.tsx:199
+#: src/routes/new/route.tsx:202
 msgid "Aruban Florin"
 msgstr "Florín Arubeño"
 
@@ -247,7 +247,7 @@ msgstr "Se requiere al menos un participante"
 msgid "Attachments"
 msgstr "Adjuntos"
 
-#: src/routes/new/route.tsx:167
+#: src/routes/new/route.tsx:170
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
@@ -262,16 +262,16 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:352
-#: src/routes/settings.tsx:428
+#: src/components/ExpenseEditor.tsx:356
+#: src/routes/settings.tsx:433
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
 
-#: src/routes/settings.tsx:430
+#: src/routes/settings.tsx:435
 msgid "Automatically open the calculator when focusing amount fields"
 msgstr "Abrir automáticamente la calculadora al enfocar campos de importe"
 
-#: src/routes/settings.tsx:417
+#: src/routes/settings.tsx:422
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Abrir automáticamente el último grupo visitado cuando abras la app"
 
@@ -283,7 +283,7 @@ msgstr "Avatar eliminado"
 msgid "Avatar updated successfully"
 msgstr "Avatar actualizado correctamente"
 
-#: src/routes/new/route.tsx:200
+#: src/routes/new/route.tsx:203
 msgid "Azerbaijani Manat"
 msgstr "Manat Azerbaiyano"
 
@@ -304,11 +304,11 @@ msgstr "Volver a iniciar sesión"
 msgid "Backspace"
 msgstr "Retroceso"
 
-#: src/routes/new/route.tsx:210
+#: src/routes/new/route.tsx:213
 msgid "Bahamian Dollar"
 msgstr "Dólar Bahameño"
 
-#: src/routes/new/route.tsx:204
+#: src/routes/new/route.tsx:207
 msgid "Bahraini Dinar"
 msgstr "Dinar Bareiní"
 
@@ -324,27 +324,27 @@ msgstr "Balance, Menor Primero"
 msgid "Balances"
 msgstr "Balance"
 
-#: src/routes/new/route.tsx:203
+#: src/routes/new/route.tsx:206
 msgid "Bangladeshi Taka"
 msgstr "Taka Bangladesí"
 
-#: src/routes/new/route.tsx:202
+#: src/routes/new/route.tsx:205
 msgid "Barbadian Dollar"
 msgstr "Dólar de Barbados"
 
-#: src/routes/new/route.tsx:213
+#: src/routes/new/route.tsx:216
 msgid "Belarusian Ruble"
 msgstr "Rublo Bielorruso"
 
-#: src/routes/new/route.tsx:214
+#: src/routes/new/route.tsx:217
 msgid "Belize Dollar"
 msgstr "Dólar Beliceño"
 
-#: src/routes/new/route.tsx:206
+#: src/routes/new/route.tsx:209
 msgid "Bermudan Dollar"
 msgstr "Dólar Bermudeño"
 
-#: src/routes/new/route.tsx:211
+#: src/routes/new/route.tsx:214
 msgid "Bhutanese Ngultrum"
 msgstr "Ngultrum Butanés"
 
@@ -352,31 +352,31 @@ msgstr "Ngultrum Butanés"
 msgid "Biggest spenders"
 msgstr "Quiénes más han pagado"
 
-#: src/routes/new/route.tsx:208
+#: src/routes/new/route.tsx:211
 msgid "Bolivian Boliviano"
 msgstr "Boliviano"
 
-#: src/routes/new/route.tsx:209
+#: src/routes/new/route.tsx:212
 msgid "Bolivian Mvdol"
 msgstr "Mvdol Boliviano"
 
-#: src/routes/new/route.tsx:201
+#: src/routes/new/route.tsx:204
 msgid "Bosnia-Herzegovina Convertible Mark"
 msgstr "Marco Convertible de Bosnia-Herzegovina"
 
-#: src/routes/new/route.tsx:212
+#: src/routes/new/route.tsx:215
 msgid "Botswanan Pula"
 msgstr "Pula Botsuano"
 
-#: src/routes/new/route.tsx:171
+#: src/routes/new/route.tsx:174
 msgid "Brazilian Real"
 msgstr "Real Brasileño"
 
-#: src/routes/new/route.tsx:163
+#: src/routes/new/route.tsx:166
 msgid "British Pound"
 msgstr "Libra Esterlina"
 
-#: src/routes/new/route.tsx:207
+#: src/routes/new/route.tsx:210
 msgid "Brunei Dollar"
 msgstr "Dólar de Brunéi"
 
@@ -384,11 +384,11 @@ msgstr "Dólar de Brunéi"
 msgid "Bug Reports"
 msgstr "Reportar errores"
 
-#: src/routes/new/route.tsx:180
+#: src/routes/new/route.tsx:183
 msgid "Bulgarian Lev"
 msgstr "Lev Búlgaro"
 
-#: src/routes/new/route.tsx:205
+#: src/routes/new/route.tsx:208
 msgid "Burundian Franc"
 msgstr "Franco Burundés"
 
@@ -404,7 +404,7 @@ msgstr "Calculadora"
 msgid "Calculator expression"
 msgstr "Expresión de calculadora"
 
-#: src/routes/new/route.tsx:251
+#: src/routes/new/route.tsx:254
 msgid "Cambodian Riel"
 msgstr "Riel Camboyano"
 
@@ -420,7 +420,7 @@ msgstr "Vista previa de la cámara"
 msgid "Can I use trizum without an account?"
 msgstr "¿Puedo usar trizum sin una cuenta?"
 
-#: src/routes/new/route.tsx:166
+#: src/routes/new/route.tsx:169
 msgid "Canadian Dollar"
 msgstr "Dólar Canadiense"
 
@@ -429,7 +429,7 @@ msgstr "Dólar Canadiense"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/routes/new/route.tsx:225
+#: src/routes/new/route.tsx:228
 msgid "Cape Verdean Escudo"
 msgstr "Escudo Caboverdiano"
 
@@ -437,19 +437,19 @@ msgstr "Escudo Caboverdiano"
 msgid "Cash or other ways"
 msgstr "Efectivo u otras formas"
 
-#: src/routes/new/route.tsx:255
+#: src/routes/new/route.tsx:258
 msgid "Cayman Islands Dollar"
 msgstr "Dólar de las Islas Caimán"
 
-#: src/routes/new/route.tsx:330
+#: src/routes/new/route.tsx:333
 msgid "CFA Franc BCEAO"
 msgstr "Franco CFA BCEAO"
 
-#: src/routes/new/route.tsx:321
+#: src/routes/new/route.tsx:324
 msgid "CFA Franc BEAC"
 msgstr "Franco CFA BEAC"
 
-#: src/routes/new/route.tsx:332
+#: src/routes/new/route.tsx:335
 msgid "CFP Franc"
 msgstr "Franco CFP"
 
@@ -469,19 +469,19 @@ msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
-#: src/routes/settings.tsx:480
+#: src/routes/settings.tsx:485
 msgid "Checking..."
 msgstr "Comprobando..."
 
-#: src/routes/new/route.tsx:219
+#: src/routes/new/route.tsx:222
 msgid "Chilean Peso"
 msgstr "Peso Chileno"
 
-#: src/routes/new/route.tsx:218
+#: src/routes/new/route.tsx:221
 msgid "Chilean Unit of Account (UF)"
 msgstr "Unidad de Fomento Chilena (UF)"
 
-#: src/routes/new/route.tsx:168
+#: src/routes/new/route.tsx:171
 msgid "Chinese Yuan"
 msgstr "Yuan Chino"
 
@@ -530,15 +530,15 @@ msgstr "Configuración en la nube aplicada"
 msgid "Cloud settings saved"
 msgstr "Configuración en la nube guardada"
 
-#: src/routes/new/route.tsx:335
+#: src/routes/new/route.tsx:338
 msgid "Code for testing"
 msgstr "Código para pruebas"
 
-#: src/routes/new/route.tsx:220
+#: src/routes/new/route.tsx:223
 msgid "Colombian Peso"
 msgstr "Peso Colombiano"
 
-#: src/routes/new/route.tsx:221
+#: src/routes/new/route.tsx:224
 msgid "Colombian Real Value Unit"
 msgstr "Unidad de Valor Real Colombiana"
 
@@ -546,7 +546,7 @@ msgstr "Unidad de Valor Real Colombiana"
 msgid "Color"
 msgstr "Color"
 
-#: src/routes/new/route.tsx:252
+#: src/routes/new/route.tsx:255
 msgid "Comorian Franc"
 msgstr "Franco Comorense"
 
@@ -580,7 +580,7 @@ msgstr "Confirmación"
 msgid "Confirming..."
 msgstr "Confirmando..."
 
-#: src/routes/new/route.tsx:215
+#: src/routes/new/route.tsx:218
 msgid "Congolese Franc"
 msgstr "Franco Congoleño"
 
@@ -651,7 +651,7 @@ msgstr "Copiar enlace del grupo"
 msgid "Copy the phone number and pay through Bizum using your bank app."
 msgstr "Copia el número de teléfono y paga mediante Bizum usando la aplicación de tu banco."
 
-#: src/routes/new/route.tsx:222
+#: src/routes/new/route.tsx:225
 msgid "Costa Rican Colón"
 msgstr "Colón Costarricense"
 
@@ -676,7 +676,7 @@ msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
 #: src/hooks/useCloudSyncAccountState.ts:220
-#: src/routes/settings.tsx:484
+#: src/routes/settings.tsx:489
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
 
@@ -722,15 +722,15 @@ msgstr "Acreedor"
 msgid "Credits"
 msgstr "Créditos"
 
-#: src/routes/new/route.tsx:181
+#: src/routes/new/route.tsx:184
 msgid "Croatian Kuna"
 msgstr "Kuna Croata"
 
-#: src/routes/new/route.tsx:223
+#: src/routes/new/route.tsx:226
 msgid "Cuban Convertible Peso"
 msgstr "Peso Cubano Convertible"
 
-#: src/routes/new/route.tsx:224
+#: src/routes/new/route.tsx:227
 msgid "Cuban Peso"
 msgstr "Peso Cubano"
 
@@ -753,15 +753,15 @@ msgstr "Año actual"
 msgid "Custom range"
 msgstr "Rango personalizado"
 
-#: src/routes/new/route.tsx:177
+#: src/routes/new/route.tsx:180
 msgid "Czech Koruna"
 msgstr "Corona Checa"
 
-#: src/routes/new/route.tsx:175
+#: src/routes/new/route.tsx:178
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:495
+#: src/components/ExpenseEditor.tsx:499
 msgid "Date"
 msgstr "Fecha"
 
@@ -833,15 +833,15 @@ msgstr "¿Sabías que?"
 msgid "Divide"
 msgstr "Dividir"
 
-#: src/routes/new/route.tsx:226
+#: src/routes/new/route.tsx:229
 msgid "Djiboutian Franc"
 msgstr "Franco Yibutiano"
 
-#: src/routes/new/route.tsx:227
+#: src/routes/new/route.tsx:230
 msgid "Dominican Peso"
 msgstr "Peso Dominicano"
 
-#: src/routes/new/route.tsx:328
+#: src/routes/new/route.tsx:331
 msgid "East Caribbean Dollar"
 msgstr "Dólar del Caribe Oriental"
 
@@ -857,7 +857,7 @@ msgstr "Editando {0}"
 msgid "Editing {expenseName}"
 msgstr "Editando {expenseName}"
 
-#: src/routes/new/route.tsx:229
+#: src/routes/new/route.tsx:232
 msgid "Egyptian Pound"
 msgstr "Libra Egipcia"
 
@@ -926,11 +926,11 @@ msgstr "Inglés"
 msgid "Enter a party link or code to join"
 msgstr "Introduce un enlace o código de grupo para unirte"
 
-#: src/routes/join.tsx:172
+#: src/routes/join.tsx:175
 msgid "Enter the link or code of the trizum party you want to join"
 msgstr "Introduce el enlace o código del grupo de trizum al que quieres unirte"
 
-#: src/routes/new/route.tsx:230
+#: src/routes/new/route.tsx:233
 msgid "Eritrean Nakfa"
 msgstr "Nakfa Eritreo"
 
@@ -938,27 +938,27 @@ msgstr "Nakfa Eritreo"
 msgid "Español"
 msgstr "Español"
 
-#: src/routes/new/route.tsx:231
+#: src/routes/new/route.tsx:234
 msgid "Ethiopian Birr"
 msgstr "Birr Etíope"
 
-#: src/routes/new/route.tsx:161
+#: src/routes/new/route.tsx:164
 msgid "Euro"
 msgstr "Euro"
 
-#: src/routes/new/route.tsx:324
+#: src/routes/new/route.tsx:327
 msgid "European Composite Unit"
 msgstr "Unidad Compuesta Europea"
 
-#: src/routes/new/route.tsx:325
+#: src/routes/new/route.tsx:328
 msgid "European Monetary Unit"
 msgstr "Unidad Monetaria Europea"
 
-#: src/routes/new/route.tsx:327
+#: src/routes/new/route.tsx:330
 msgid "European Unit of Account 17"
 msgstr "Unidad de Cuenta Europea 17"
 
-#: src/routes/new/route.tsx:326
+#: src/routes/new/route.tsx:329
 msgid "European Unit of Account 9"
 msgstr "Unidad de Cuenta Europea 9"
 
@@ -987,7 +987,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:974
+#: src/components/ExpenseEditor.tsx:978
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1028,11 +1028,11 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:949
+#: src/components/ExpenseEditor.tsx:953
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
-#: src/routes/new/route.tsx:233
+#: src/routes/new/route.tsx:236
 msgid "Falkland Islands Pound"
 msgstr "Libra Malvinense"
 
@@ -1044,7 +1044,7 @@ msgstr "Sugerencias"
 msgid "Features"
 msgstr "Características"
 
-#: src/routes/new/route.tsx:232
+#: src/routes/new/route.tsx:235
 msgid "Fijian Dollar"
 msgstr "Dólar Fiyiano"
 
@@ -1057,7 +1057,7 @@ msgstr "Filtra totales y rankings"
 msgid "Finishing sign in"
 msgstr "Terminando el inicio de sesión"
 
-#: src/routes/settings.tsx:379
+#: src/routes/settings.tsx:384
 msgid "For payments through Bizum or similar services"
 msgstr "Para pagos mediante Bizum o servicios similares"
 
@@ -1073,11 +1073,11 @@ msgstr "¿Encontraste un error? Avísanos en GitHub y lo solucionaremos."
 msgid "Frequently Asked Questions"
 msgstr "Preguntas frecuentes"
 
-#: src/routes/new/route.tsx:237
+#: src/routes/new/route.tsx:240
 msgid "Gambian Dalasi"
 msgstr "Dalasi Gambiano"
 
-#: src/routes/new/route.tsx:234
+#: src/routes/new/route.tsx:237
 msgid "Georgian Lari"
 msgstr "Lari Georgiano"
 
@@ -1085,11 +1085,11 @@ msgstr "Lari Georgiano"
 msgid "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 msgstr "Ponte en contacto con la persona para hacer el pago en efectivo o de otra forma diferente a las descritas anteriormente."
 
-#: src/routes/new/route.tsx:235
+#: src/routes/new/route.tsx:238
 msgid "Ghanaian Cedi"
 msgstr "Cedi Ghanés"
 
-#: src/routes/new/route.tsx:236
+#: src/routes/new/route.tsx:239
 msgid "Gibraltar Pound"
 msgstr "Libra de Gibraltar"
 
@@ -1110,7 +1110,7 @@ msgstr "Vuelve atrás e inténtalo de nuevo desde la lista de saldos."
 msgid "Go back to home"
 msgstr "Volver al inicio"
 
-#: src/routes/new/route.tsx:323
+#: src/routes/new/route.tsx:326
 msgid "Gold (troy ounce)"
 msgstr "Oro (onza troy)"
 
@@ -1130,19 +1130,19 @@ msgstr "Google está conectado a esta cuenta"
 msgid "Got it"
 msgstr "Entendido"
 
-#: src/routes/new/route.tsx:239
+#: src/routes/new/route.tsx:242
 msgid "Guatemalan Quetzal"
 msgstr "Quetzal Guatemalteco"
 
-#: src/routes/new/route.tsx:238
+#: src/routes/new/route.tsx:241
 msgid "Guinean Franc"
 msgstr "Franco Guineano"
 
-#: src/routes/new/route.tsx:240
+#: src/routes/new/route.tsx:243
 msgid "Guyanaese Dollar"
 msgstr "Dólar Guyanés"
 
-#: src/routes/new/route.tsx:242
+#: src/routes/new/route.tsx:245
 msgid "Haitian Gourde"
 msgstr "Gourde Haitiano"
 
@@ -1150,7 +1150,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:851
+#: src/components/ExpenseEditor.tsx:855
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -1170,11 +1170,11 @@ msgstr "Ocultar inicio de sesión con contraseña"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/routes/new/route.tsx:241
+#: src/routes/new/route.tsx:244
 msgid "Honduran Lempira"
 msgstr "Lempira Hondureño"
 
-#: src/routes/new/route.tsx:186
+#: src/routes/new/route.tsx:189
 msgid "Hong Kong Dollar"
 msgstr "Dólar de Hong Kong"
 
@@ -1195,11 +1195,11 @@ msgstr "¿Cómo debería equilibrar?"
 msgid "How to pay?"
 msgstr "¿Cómo pagar?"
 
-#: src/routes/new/route.tsx:178
+#: src/routes/new/route.tsx:181
 msgid "Hungarian Forint"
 msgstr "Forinto Húngaro"
 
-#: src/routes/new/route.tsx:246
+#: src/routes/new/route.tsx:249
 msgid "Icelandic Króna"
 msgstr "Corona Islandesa"
 
@@ -1219,7 +1219,7 @@ msgstr "Impacto en mi balance: <0/>"
 msgid "Impact on my balance: <0/>"
 msgstr "Impacto en mi balance: <0/>"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:94
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:97
 msgid "Import attachments"
 msgstr "Importar adjuntos"
 
@@ -1239,11 +1239,11 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:539
+#: src/components/ExpenseEditor.tsx:543
 msgid "Include all"
 msgstr "Incluir todos"
 
-#: src/routes/new/route.tsx:169
+#: src/routes/new/route.tsx:172
 msgid "Indian Rupee"
 msgstr "Rupia India"
 
@@ -1251,7 +1251,7 @@ msgstr "Rupia India"
 msgid "Individual totals"
 msgstr "Totales individuales"
 
-#: src/routes/new/route.tsx:243
+#: src/routes/new/route.tsx:246
 msgid "Indonesian Rupiah"
 msgstr "Rupia Indonesia"
 
@@ -1273,11 +1273,11 @@ msgstr "Código de grupo de trizum no válido"
 msgid "Invalid trizum party link"
 msgstr "Enlace de grupo de trizum no válido"
 
-#: src/routes/new/route.tsx:245
+#: src/routes/new/route.tsx:248
 msgid "Iranian Rial"
 msgstr "Rial Iraní"
 
-#: src/routes/new/route.tsx:244
+#: src/routes/new/route.tsx:247
 msgid "Iraqi Dinar"
 msgstr "Dinar Iraquí"
 
@@ -1285,19 +1285,19 @@ msgstr "Dinar Iraquí"
 msgid "Is my data secure?"
 msgstr "¿Mis datos están seguros?"
 
-#: src/routes/new/route.tsx:189
+#: src/routes/new/route.tsx:192
 msgid "Israeli Shekel"
 msgstr "Shekel Israelí"
 
-#: src/routes/new/route.tsx:247
+#: src/routes/new/route.tsx:250
 msgid "Jamaican Dollar"
 msgstr "Dólar Jamaicano"
 
-#: src/routes/new/route.tsx:164
+#: src/routes/new/route.tsx:167
 msgid "Japanese Yen"
 msgstr "Yen Japonés"
 
-#: src/routes/join.tsx:192
+#: src/routes/join.tsx:195
 msgid "Join"
 msgstr "Unirse"
 
@@ -1318,7 +1318,7 @@ msgstr "Unirse a un Grupo"
 msgid "Join a trizum"
 msgstr "Unirse a un trizum"
 
-#: src/routes/new/route.tsx:248
+#: src/routes/new/route.tsx:251
 msgid "Jordanian Dinar"
 msgstr "Dinar Jordano"
 
@@ -1326,7 +1326,7 @@ msgstr "Dinar Jordano"
 msgid "Jump back into the groups you use most"
 msgstr "Vuelve a los grupos que más usas"
 
-#: src/routes/new/route.tsx:256
+#: src/routes/new/route.tsx:259
 msgid "Kazakhstani Tenge"
 msgstr "Tenge Kazajo"
 
@@ -1338,23 +1338,23 @@ msgstr "Mantener datos locales"
 msgid "Keep your profile settings available on your signed-in devices."
 msgstr "Mantén la configuración de tu perfil disponible en los dispositivos donde has iniciado sesión."
 
-#: src/routes/new/route.tsx:249
+#: src/routes/new/route.tsx:252
 msgid "Kenyan Shilling"
 msgstr "Chelín Keniata"
 
-#: src/routes/new/route.tsx:254
+#: src/routes/new/route.tsx:257
 msgid "Kuwaiti Dinar"
 msgstr "Dinar Kuwaití"
 
-#: src/routes/new/route.tsx:250
+#: src/routes/new/route.tsx:253
 msgid "Kyrgystani Som"
 msgstr "Som Kirguís"
 
-#: src/routes/settings.tsx:394
+#: src/routes/settings.tsx:399
 msgid "Language"
 msgstr "Idioma"
 
-#: src/routes/new/route.tsx:257
+#: src/routes/new/route.tsx:260
 msgid "Laotian Kip"
 msgstr "Kip Laosiano"
 
@@ -1374,19 +1374,19 @@ msgstr "Año pasado"
 msgid "Leave party"
 msgstr "Dejar el grupo"
 
-#: src/routes/new/route.tsx:258
+#: src/routes/new/route.tsx:261
 msgid "Lebanese Pound"
 msgstr "Libra Libanesa"
 
-#: src/routes/new/route.tsx:261
+#: src/routes/new/route.tsx:264
 msgid "Lesotho Loti"
 msgstr "Loti de Lesoto"
 
-#: src/routes/new/route.tsx:260
+#: src/routes/new/route.tsx:263
 msgid "Liberian Dollar"
 msgstr "Dólar Liberiano"
 
-#: src/routes/new/route.tsx:262
+#: src/routes/new/route.tsx:265
 msgid "Libyan Dinar"
 msgstr "Dinar Libio"
 
@@ -1394,7 +1394,7 @@ msgstr "Dinar Libio"
 msgid "License"
 msgstr "Licencia"
 
-#: src/routes/join.tsx:171
+#: src/routes/join.tsx:174
 msgid "Link or code"
 msgstr "Enlace o código"
 
@@ -1410,27 +1410,27 @@ msgstr "Cargando licencias..."
 msgid "Long press for party actions"
 msgstr "Mantén pulsado para abrir las acciones del grupo"
 
-#: src/routes/new/route.tsx:269
+#: src/routes/new/route.tsx:272
 msgid "Macanese Pataca"
 msgstr "Pataca de Macao"
 
-#: src/routes/new/route.tsx:266
+#: src/routes/new/route.tsx:269
 msgid "Macedonian Denar"
 msgstr "Denar Macedonio"
 
-#: src/routes/new/route.tsx:265
+#: src/routes/new/route.tsx:268
 msgid "Malagasy Ariary"
 msgstr "Ariary Malgache"
 
-#: src/routes/new/route.tsx:273
+#: src/routes/new/route.tsx:276
 msgid "Malawian Kwacha"
 msgstr "Kwacha Malauí"
 
-#: src/routes/new/route.tsx:275
+#: src/routes/new/route.tsx:278
 msgid "Malaysian Ringgit"
 msgstr "Ringgit Malasio"
 
-#: src/routes/new/route.tsx:272
+#: src/routes/new/route.tsx:275
 msgid "Maldivian Rufiyaa"
 msgstr "Rufiyaa Maldiva"
 
@@ -1452,11 +1452,11 @@ msgstr "Marcar como pagado"
 msgid "Marking expense as paid..."
 msgstr "Marcando gasto como pagado..."
 
-#: src/routes/new/route.tsx:270
+#: src/routes/new/route.tsx:273
 msgid "Mauritanian Ouguiya"
 msgstr "Ouguiya Mauritano"
 
-#: src/routes/new/route.tsx:271
+#: src/routes/new/route.tsx:274
 msgid "Mauritian Rupee"
 msgstr "Rupia de Mauricio"
 
@@ -1467,18 +1467,18 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:345
+#: src/components/ExpenseEditor.tsx:349
 #: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:86
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
 msgstr "Menú"
 
-#: src/routes/new/route.tsx:274
+#: src/routes/new/route.tsx:277
 msgid "Mexican Investment Unit"
 msgstr "Unidad de Inversión Mexicana"
 
-#: src/routes/new/route.tsx:170
+#: src/routes/new/route.tsx:173
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
@@ -1501,15 +1501,15 @@ msgstr "Migración exitosa"
 msgid "Missing search params"
 msgstr "Faltan parámetros de búsqueda"
 
-#: src/routes/new/route.tsx:264
+#: src/routes/new/route.tsx:267
 msgid "Moldovan Leu"
 msgstr "Leu Moldavo"
 
-#: src/routes/new/route.tsx:268
+#: src/routes/new/route.tsx:271
 msgid "Mongolian Tugrik"
 msgstr "Tugrik Mongol"
 
-#: src/routes/new/route.tsx:263
+#: src/routes/new/route.tsx:266
 msgid "Moroccan Dirham"
 msgstr "Dírham Marroquí"
 
@@ -1525,7 +1525,7 @@ msgstr "Mover cursor a la derecha"
 msgid "Moved to"
 msgstr "Movida a"
 
-#: src/routes/new/route.tsx:276
+#: src/routes/new/route.tsx:279
 msgid "Mozambican Metical"
 msgstr "Metical Mozambiqueño"
 
@@ -1537,7 +1537,7 @@ msgstr "División Multi-Grupo"
 msgid "Multiply"
 msgstr "Multiplicar"
 
-#: src/routes/new/route.tsx:267
+#: src/routes/new/route.tsx:270
 msgid "Myanma Kyat"
 msgstr "Kyat Birmano"
 
@@ -1551,7 +1551,7 @@ msgstr "Nombre"
 msgid "Name must be less than 50 characters"
 msgstr "El nombre debe tener menos de 50 caracteres"
 
-#: src/routes/new/route.tsx:277
+#: src/routes/new/route.tsx:280
 msgid "Namibian Dollar"
 msgstr "Dólar Namibio"
 
@@ -1559,11 +1559,11 @@ msgstr "Dólar Namibio"
 msgid "Need help with trizum? We're here to assist you."
 msgstr "¿Necesitas ayuda con trizum? Estamos aquí para ayudarte."
 
-#: src/routes/new/route.tsx:280
+#: src/routes/new/route.tsx:283
 msgid "Nepalese Rupee"
 msgstr "Rupia Nepalí"
 
-#: src/routes/new/route.tsx:196
+#: src/routes/new/route.tsx:199
 msgid "Netherlands Antillean Guilder"
 msgstr "Florín de las Antillas Neerlandesas"
 
@@ -1576,11 +1576,11 @@ msgstr "Nuevo gasto"
 msgid "New participant name"
 msgstr "Nombre del nuevo participante"
 
-#: src/routes/reset-password.tsx:124
+#: src/routes/reset-password.tsx:127
 msgid "New password"
 msgstr "Nueva contraseña"
 
-#: src/routes/new/route.tsx:308
+#: src/routes/new/route.tsx:311
 msgid "New Taiwan Dollar"
 msgstr "Nuevo Dólar Taiwanés"
 
@@ -1588,7 +1588,7 @@ msgstr "Nuevo Dólar Taiwanés"
 msgid "New trizum"
 msgstr "Nuevo trizum"
 
-#: src/routes/new/route.tsx:184
+#: src/routes/new/route.tsx:187
 msgid "New Zealand Dollar"
 msgstr "Dólar Neozelandés"
 
@@ -1596,11 +1596,11 @@ msgstr "Dólar Neozelandés"
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/routes/new/route.tsx:279
+#: src/routes/new/route.tsx:282
 msgid "Nicaraguan Córdoba"
 msgstr "Córdoba Nicaragüense"
 
-#: src/routes/new/route.tsx:278
+#: src/routes/new/route.tsx:281
 msgid "Nigerian Naira"
 msgstr "Naira Nigeriano"
 
@@ -1620,7 +1620,7 @@ msgstr "No se encontró cámara en este dispositivo"
 msgid "No cloud settings saved yet"
 msgstr "Todavía no hay configuración guardada en la nube"
 
-#: src/routes/new/route.tsx:337
+#: src/routes/new/route.tsx:340
 msgid "No currency"
 msgstr "Sin moneda"
 
@@ -1661,11 +1661,11 @@ msgstr "Todavía nadie"
 msgid "Non-transfer expenses in this timeframe"
 msgstr "Gastos no asociados a transferencias en este período"
 
-#: src/routes/new/route.tsx:253
+#: src/routes/new/route.tsx:256
 msgid "North Korean Won"
 msgstr "Won Norcoreano"
 
-#: src/routes/new/route.tsx:174
+#: src/routes/new/route.tsx:177
 msgid "Norwegian Krone"
 msgstr "Corona Noruega"
 
@@ -1678,11 +1678,11 @@ msgstr "No es un código de grupo de trizum válido"
 msgid "Not connected"
 msgstr "No conectado"
 
-#: src/routes/settings.tsx:488
+#: src/routes/settings.tsx:493
 msgid "Not set up"
 msgstr "No configurada"
 
-#: src/routes/settings.tsx:476
+#: src/routes/settings.tsx:481
 msgid "Not signed in"
 msgstr "No has iniciado sesión"
 
@@ -1698,7 +1698,7 @@ msgstr "Sin Conexión Primero"
 msgid "Older parties stay tucked away, not gone"
 msgstr "Los grupos antiguos quedan apartados, no desaparecen"
 
-#: src/routes/new/route.tsx:281
+#: src/routes/new/route.tsx:284
 msgid "Omani Rial"
 msgstr "Rial Omaní"
 
@@ -1718,7 +1718,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:355
+#: src/components/ExpenseEditor.tsx:359
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1726,7 +1726,7 @@ msgstr "Abrir calculadora al enfocar campos de importe"
 msgid "Open GitHub Issues"
 msgstr "Abrir GitHub Issues"
 
-#: src/routes/settings.tsx:415
+#: src/routes/settings.tsx:420
 msgid "Open last party on launch"
 msgstr "Abrir el último grupo al abrir la app"
 
@@ -1759,7 +1759,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:470
+#: src/components/ExpenseEditor.tsx:474
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -1772,23 +1772,23 @@ msgstr "Deuda pagada a {0}"
 msgid "Paid debt to {toName}"
 msgstr "Deuda pagada a {toName}"
 
-#: src/routes/new/route.tsx:286
+#: src/routes/new/route.tsx:289
 msgid "Pakistani Rupee"
 msgstr "Rupia Paquistaní"
 
-#: src/routes/new/route.tsx:331
+#: src/routes/new/route.tsx:334
 msgid "Palladium (troy ounce)"
 msgstr "Paladio (onza troy)"
 
-#: src/routes/new/route.tsx:282
+#: src/routes/new/route.tsx:285
 msgid "Panamanian Balboa"
 msgstr "Balboa Panameño"
 
-#: src/routes/new/route.tsx:284
+#: src/routes/new/route.tsx:287
 msgid "Papua New Guinean Kina"
 msgstr "Kina de Papúa Nueva Guinea"
 
-#: src/routes/new/route.tsx:287
+#: src/routes/new/route.tsx:290
 msgid "Paraguayan Guarani"
 msgstr "Guaraní Paraguayo"
 
@@ -1872,7 +1872,7 @@ msgstr "Correo de contraseña enviado"
 msgid "Password enabled"
 msgstr "Contraseña activada"
 
-#: src/routes/reset-password.tsx:118
+#: src/routes/reset-password.tsx:121
 msgid "Password must be at least 8 characters"
 msgstr "La contraseña debe tener al menos 8 caracteres"
 
@@ -1896,7 +1896,7 @@ msgstr "El inicio de sesión con contraseña está activado"
 msgid "Password updated"
 msgstr "Contraseña actualizada"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:74
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:77
 msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 msgstr "Pega el mensaje de compartir de Tricount, la URL (p. ej., https://tricount.com/abc123), o la clave directa"
 
@@ -1917,15 +1917,15 @@ msgstr "Eliminar permanentemente tu cuenta de trizum cloud"
 msgid "Personal mode"
 msgstr "Modo personal"
 
-#: src/routes/new/route.tsx:283
+#: src/routes/new/route.tsx:286
 msgid "Peruvian Sol"
 msgstr "Sol Peruano"
 
-#: src/routes/new/route.tsx:285
+#: src/routes/new/route.tsx:288
 msgid "Philippine Peso"
 msgstr "Peso Filipino"
 
-#: src/routes/settings.tsx:378
+#: src/routes/settings.tsx:383
 msgid "Phone number"
 msgstr "Número de teléfono"
 
@@ -1957,7 +1957,7 @@ msgstr "Los grupos fijados se mantienen a mano. La actividad reciente mantiene e
 msgid "Pinned parties stay on top, then the rest follow your latest activity."
 msgstr "Los grupos fijados se quedan arriba y el resto sigue tu actividad más reciente."
 
-#: src/routes/new/route.tsx:333
+#: src/routes/new/route.tsx:336
 msgid "Platinum (troy ounce)"
 msgstr "Platino (onza troy)"
 
@@ -1965,7 +1965,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:869
+#: src/components/ExpenseEditor.tsx:873
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -1989,7 +1989,7 @@ msgstr "Por favor espera mientras obtenemos los datos más recientes"
 msgid "Point your camera at a trizum QR code"
 msgstr "Apunta tu cámara a un código QR de trizum"
 
-#: src/routes/new/route.tsx:176
+#: src/routes/new/route.tsx:179
 msgid "Polish Zloty"
 msgstr "Zloty Polaco"
 
@@ -2001,7 +2001,7 @@ msgstr "Anterior"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: src/routes/new/route.tsx:288
+#: src/routes/new/route.tsx:291
 msgid "Qatari Rial"
 msgstr "Rial Catarí"
 
@@ -2013,7 +2013,7 @@ msgstr "Captura de fotograma del código QR"
 msgid "Ranking based on how much each participant paid in the selected timeframe."
 msgstr "Clasificación según cuánto ha pagado cada participante en el período seleccionado."
 
-#: src/routes/settings.tsx:495
+#: src/routes/settings.tsx:500
 msgid "Ready on another device"
 msgstr "Listo en otro dispositivo"
 
@@ -2038,7 +2038,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1066
+#: src/components/ExpenseEditor.tsx:1070
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2075,35 +2075,35 @@ msgstr "Restaurar al inicio"
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/routes/new/route.tsx:179
+#: src/routes/new/route.tsx:182
 msgid "Romanian Leu"
 msgstr "Leu Rumano"
 
-#: src/routes/new/route.tsx:182
+#: src/routes/new/route.tsx:185
 msgid "Russian Ruble"
 msgstr "Rublo Ruso"
 
-#: src/routes/new/route.tsx:290
+#: src/routes/new/route.tsx:293
 msgid "Rwandan Franc"
 msgstr "Franco Ruandés"
 
-#: src/routes/new/route.tsx:294
+#: src/routes/new/route.tsx:297
 msgid "Saint Helena Pound"
 msgstr "Libra de Santa Elena"
 
-#: src/routes/new/route.tsx:300
+#: src/routes/new/route.tsx:303
 msgid "Salvadoran Colón"
 msgstr "Colón Salvadoreño"
 
-#: src/routes/new/route.tsx:320
+#: src/routes/new/route.tsx:323
 msgid "Samoan Tala"
 msgstr "Tala Samoano"
 
-#: src/routes/new/route.tsx:299
+#: src/routes/new/route.tsx:302
 msgid "São Tomé and Príncipe Dobra"
 msgstr "Dobra de Santo Tomé y Príncipe"
 
-#: src/routes/new/route.tsx:191
+#: src/routes/new/route.tsx:194
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
@@ -2154,7 +2154,7 @@ msgstr "Enviar enlace de contraseña"
 msgid "Send us an email and we'll get back to you as soon as possible."
 msgstr "Envíanos un email y te responderemos lo antes posible."
 
-#: src/routes/new/route.tsx:289
+#: src/routes/new/route.tsx:292
 msgid "Serbian Dinar"
 msgstr "Dinar Serbio"
 
@@ -2188,7 +2188,7 @@ msgstr "Configuración guardada"
 msgid "Settled in"
 msgstr "Saldada en"
 
-#: src/routes/new/route.tsx:292
+#: src/routes/new/route.tsx:295
 msgid "Seychellois Rupee"
 msgstr "Rupia de Seychelles"
 
@@ -2210,7 +2210,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:725
+#: src/components/ExpenseEditor.tsx:729
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -2218,11 +2218,11 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:855
+#: src/components/ExpenseEditor.tsx:859
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
-#: src/routes/new/route.tsx:295
+#: src/routes/new/route.tsx:298
 msgid "Sierra Leonean Leone"
 msgstr "Leone de Sierra Leona"
 
@@ -2291,19 +2291,19 @@ msgstr "Sesión iniciada"
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
-#: src/routes/new/route.tsx:322
+#: src/routes/new/route.tsx:325
 msgid "Silver (troy ounce)"
 msgstr "Plata (onza troy)"
 
-#: src/routes/new/route.tsx:185
+#: src/routes/new/route.tsx:188
 msgid "Singapore Dollar"
 msgstr "Dólar de Singapur"
 
-#: src/routes/new/route.tsx:291
+#: src/routes/new/route.tsx:294
 msgid "Solomon Islands Dollar"
 msgstr "Dólar de las Islas Salomón"
 
-#: src/routes/new/route.tsx:296
+#: src/routes/new/route.tsx:299
 msgid "Somali Shilling"
 msgstr "Chelín Somalí"
 
@@ -2319,19 +2319,19 @@ msgstr "Algo salió mal"
 msgid "Sort balances"
 msgstr "Ordenar balances"
 
-#: src/routes/new/route.tsx:188
+#: src/routes/new/route.tsx:191
 msgid "South African Rand"
 msgstr "Rand Sudafricano"
 
-#: src/routes/new/route.tsx:172
+#: src/routes/new/route.tsx:175
 msgid "South Korean Won"
 msgstr "Won Surcoreano"
 
-#: src/routes/new/route.tsx:298
+#: src/routes/new/route.tsx:301
 msgid "South Sudanese Pound"
 msgstr "Libra Sursudanesa"
 
-#: src/routes/new/route.tsx:329
+#: src/routes/new/route.tsx:332
 msgid "Special Drawing Rights"
 msgstr "Derechos Especiales de Giro"
 
@@ -2347,7 +2347,7 @@ msgstr "Divide facturas con amigos y familia. Registra, calcula y salda gastos j
 msgid "Split expenses fairly among multiple participants"
 msgstr "Divide los gastos de forma justa entre múltiples participantes"
 
-#: src/routes/new/route.tsx:259
+#: src/routes/new/route.tsx:262
 msgid "Sri Lankan Rupee"
 msgstr "Rupia de Sri Lanka"
 
@@ -2386,11 +2386,11 @@ msgstr "Enviando..."
 msgid "Subtract"
 msgstr "Restar"
 
-#: src/routes/new/route.tsx:334
+#: src/routes/new/route.tsx:337
 msgid "Sucre"
 msgstr "Sucre"
 
-#: src/routes/new/route.tsx:293
+#: src/routes/new/route.tsx:296
 msgid "Sudanese Pound"
 msgstr "Libra Sudanesa"
 
@@ -2399,15 +2399,15 @@ msgstr "Libra Sudanesa"
 msgid "Support"
 msgstr "Soporte"
 
-#: src/routes/new/route.tsx:297
+#: src/routes/new/route.tsx:300
 msgid "Surinamese Dollar"
 msgstr "Dólar Surinamés"
 
-#: src/routes/new/route.tsx:302
+#: src/routes/new/route.tsx:305
 msgid "Swazi Lilangeni"
 msgstr "Lilangeni Suazi"
 
-#: src/routes/new/route.tsx:173
+#: src/routes/new/route.tsx:176
 msgid "Swedish Krona"
 msgstr "Corona Sueca"
 
@@ -2415,15 +2415,15 @@ msgstr "Corona Sueca"
 msgid "Swipe between expenses and balances tabs."
 msgstr "Desliza entre las pestañas de gastos y balance."
 
-#: src/routes/new/route.tsx:165
+#: src/routes/new/route.tsx:168
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:749
+#: src/components/ExpenseEditor.tsx:753
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:750
+#: src/components/ExpenseEditor.tsx:754
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2448,7 +2448,7 @@ msgstr "Sincronizar configuración del perfil"
 msgid "Syncing party information..."
 msgstr "Sincronizando información del grupo..."
 
-#: src/routes/new/route.tsx:301
+#: src/routes/new/route.tsx:304
 msgid "Syrian Pound"
 msgstr "Libra Siria"
 
@@ -2456,18 +2456,18 @@ msgstr "Libra Siria"
 msgid "System (fallbacks to {DEFAULT_LOCALE})"
 msgstr "Sistema (por defecto {DEFAULT_LOCALE})"
 
-#: src/routes/new/route.tsx:303
+#: src/routes/new/route.tsx:306
 msgid "Tajikistani Somoni"
 msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:994
-#: src/components/ExpenseEditor.tsx:1008
+#: src/components/ExpenseEditor.tsx:998
+#: src/components/ExpenseEditor.tsx:1012
 msgid "Take photo"
 msgstr "Hacer foto"
 
-#: src/routes/new/route.tsx:309
+#: src/routes/new/route.tsx:312
 msgid "Tanzanian Shilling"
 msgstr "Chelín Tanzano"
 
@@ -2475,7 +2475,7 @@ msgstr "Chelín Tanzano"
 msgid "Tap to change"
 msgstr "Toca para cambiar"
 
-#: src/routes/new/route.tsx:187
+#: src/routes/new/route.tsx:190
 msgid "Thai Baht"
 msgstr "Baht Tailandés"
 
@@ -2562,7 +2562,7 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:411
+#: src/components/ExpenseEditor.tsx:415
 msgid "Title"
 msgstr "Título"
 
@@ -2582,11 +2582,11 @@ msgstr "Para conectar Google o Apple, elige una cuenta con el mismo correo que t
 msgid "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "Para unirte al <0>{0}</0>, por favor selecciona quién eres para que podamos mostrarte los gastos y estadísticas que te importan."
 
-#: src/routes/party_.$partyId.who.tsx:129
+#: src/routes/party_.$partyId.who.tsx:132
 msgid "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "Para unirte al <0>{partyName}</0>, por favor selecciona quién eres para que podamos mostrarte los gastos y estadísticas que te importan."
 
-#: src/routes/new/route.tsx:306
+#: src/routes/new/route.tsx:309
 msgid "Tongan Paʻanga"
 msgstr "Paʻanga Tongano"
 
@@ -2616,11 +2616,11 @@ msgstr "Transferir a otro grupo"
 msgid "Tricount key or URL is required"
 msgstr "Se requiere la clave o URL de Tricount"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:73
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:76
 msgid "Tricount URL or key"
 msgstr "URL o clave de Tricount"
 
-#: src/routes/new/route.tsx:307
+#: src/routes/new/route.tsx:310
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
@@ -2680,15 +2680,15 @@ msgstr "Prueba otro período para comparar otra etapa de tu grupo."
 msgid "Try scanning another code"
 msgstr "Prueba escaneando otro código"
 
-#: src/routes/new/route.tsx:305
+#: src/routes/new/route.tsx:308
 msgid "Tunisian Dinar"
 msgstr "Dinar Tunecino"
 
-#: src/routes/new/route.tsx:183
+#: src/routes/new/route.tsx:186
 msgid "Turkish Lira"
 msgstr "Lira Turca"
 
-#: src/routes/new/route.tsx:304
+#: src/routes/new/route.tsx:307
 msgid "Turkmenistani Manat"
 msgstr "Manat Turkmeno"
 
@@ -2696,19 +2696,19 @@ msgstr "Manat Turkmeno"
 msgid "Type \"delete account\" to confirm."
 msgstr "Escribe \"delete account\" para confirmar."
 
-#: src/routes/new/route.tsx:190
+#: src/routes/new/route.tsx:193
 msgid "UAE Dirham"
 msgstr "Dírham de los EAU"
 
-#: src/routes/new/route.tsx:311
+#: src/routes/new/route.tsx:314
 msgid "Ugandan Shilling"
 msgstr "Chelín Ugandés"
 
-#: src/routes/new/route.tsx:310
+#: src/routes/new/route.tsx:313
 msgid "Ukrainian Hryvnia"
 msgstr "Grivna Ucraniana"
 
-#: src/routes/new/route.tsx:315
+#: src/routes/new/route.tsx:318
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
@@ -2733,11 +2733,11 @@ msgstr "No se ha podido actualizar. Inténtalo de nuevo."
 msgid "Update is no longer available."
 msgstr "La actualización ya no está disponible."
 
-#: src/routes/reset-password.tsx:139
+#: src/routes/reset-password.tsx:142
 msgid "Update password"
 msgstr "Actualizar contraseña"
 
-#: src/routes/party_.$partyId.who.tsx:134
+#: src/routes/party_.$partyId.who.tsx:137
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 msgstr "Actualiza quién eres en este grupo para que podamos mostrarte los gastos y estadísticas que te importan."
 
@@ -2749,14 +2749,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:894
+#: src/components/ExpenseEditor.tsx:898
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1003
-#: src/components/ExpenseEditor.tsx:1020
+#: src/components/ExpenseEditor.tsx:1007
+#: src/components/ExpenseEditor.tsx:1024
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2764,23 +2764,23 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:934
+#: src/components/ExpenseEditor.tsx:938
 msgid "Uploading..."
 msgstr "Subiendo..."
 
-#: src/routes/new/route.tsx:313
+#: src/routes/new/route.tsx:316
 msgid "Uruguay Peso en Unidades Indexadas"
 msgstr "Peso Uruguayo en Unidades Indexadas"
 
-#: src/routes/new/route.tsx:314
+#: src/routes/new/route.tsx:317
 msgid "Uruguayan Peso"
 msgstr "Peso Uruguayo"
 
-#: src/routes/new/route.tsx:162
+#: src/routes/new/route.tsx:165
 msgid "US Dollar"
 msgstr "Dólar Estadounidense"
 
-#: src/routes/new/route.tsx:312
+#: src/routes/new/route.tsx:315
 msgid "US Dollar (Next day)"
 msgstr "Dólar Estadounidense (Día siguiente)"
 
@@ -2809,7 +2809,7 @@ msgstr "¿Usar trizum cloud en este dispositivo?"
 msgid "Use your camera to scan a trizum invite"
 msgstr "Usa tu cámara para escanear una invitación de trizum"
 
-#: src/routes/settings.tsx:356
+#: src/routes/settings.tsx:361
 msgid "Username"
 msgstr "Nombre de usuario"
 
@@ -2817,15 +2817,15 @@ msgstr "Nombre de usuario"
 msgid "Username, phone, language, launch behavior, and accent color"
 msgstr "Nombre de usuario, teléfono, idioma, comportamiento de inicio y color de acento"
 
-#: src/routes/new/route.tsx:316
+#: src/routes/new/route.tsx:319
 msgid "Uzbekistan Som"
 msgstr "Som Uzbeko"
 
-#: src/routes/new/route.tsx:319
+#: src/routes/new/route.tsx:322
 msgid "Vanuatu Vatu"
 msgstr "Vatu de Vanuatu"
 
-#: src/routes/new/route.tsx:317
+#: src/routes/new/route.tsx:320
 msgid "Venezuelan Bolívar Soberano"
 msgstr "Bolívar Soberano Venezolano"
 
@@ -2833,7 +2833,7 @@ msgstr "Bolívar Soberano Venezolano"
 msgid "Version"
 msgstr "Versión"
 
-#: src/routes/new/route.tsx:318
+#: src/routes/new/route.tsx:321
 msgid "Vietnamese Dong"
 msgstr "Dong Vietnamita"
 
@@ -2845,7 +2845,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1055
+#: src/components/ExpenseEditor.tsx:1059
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"
@@ -2891,7 +2891,7 @@ msgstr "Bienvenid@ a trizum"
 msgid "What is this party about?"
 msgstr "¿De qué trata este grupo?"
 
-#: src/routes/settings.tsx:357
+#: src/routes/settings.tsx:362
 msgid "What's your preferred way to be addressed?"
 msgstr "¿Cuál es tu forma preferida de que te llamen?"
 
@@ -2907,11 +2907,11 @@ msgstr "¿Quién está invitado a este grupo? Puedes añadir más participantes 
 msgid "Why is this taking so long?"
 msgstr "¿Por qué está tardando tanto?"
 
-#: src/routes/new/route.tsx:216
+#: src/routes/new/route.tsx:219
 msgid "WIR Euro"
 msgstr "Euro WIR"
 
-#: src/routes/new/route.tsx:217
+#: src/routes/new/route.tsx:220
 msgid "WIR Franc"
 msgstr "Franco WIR"
 
@@ -2919,7 +2919,7 @@ msgstr "Franco WIR"
 msgid "Works seamlessly offline with automatic sync when online"
 msgstr "Funciona sin problemas sin conexión con sincronización automática cuando estás en línea"
 
-#: src/routes/new/route.tsx:338
+#: src/routes/new/route.tsx:341
 msgid "Yemeni Rial"
 msgstr "Rial Yemení"
 
@@ -2975,10 +2975,10 @@ msgstr "Tus grupos"
 msgid "Your total"
 msgstr "Tu total"
 
-#: src/routes/new/route.tsx:339
+#: src/routes/new/route.tsx:342
 msgid "Zambian Kwacha"
 msgstr "Kwacha Zambiano"
 
-#: src/routes/new/route.tsx:340
+#: src/routes/new/route.tsx:343
 msgid "Zimbabwean Dollar"
 msgstr "Dólar Zimbabuense"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -67,7 +67,7 @@ msgstr "Acerca de"
 msgid "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 msgstr "¡Por supuesto! trizum funciona sin necesidad de crear una cuenta o registrarte. Solo crea un grupo y empieza a registrar gastos."
 
-#: src/routes/settings.tsx:446
+#: src/routes/settings.tsx:444
 msgid "Accent color"
 msgstr "Color de acento"
 
@@ -87,11 +87,11 @@ msgstr "En el período seleccionado"
 msgid "Active"
 msgstr "Activos"
 
-#: src/routes/settings.tsx:497
+#: src/routes/settings.tsx:495
 msgid "Active on this device"
 msgstr "Activo en este dispositivo"
 
-#: src/routes/new/route.tsx:339
+#: src/routes/new/route.tsx:337
 msgid "ADB Unit of Account"
 msgstr "Unidad de Cuenta del BAsD"
 
@@ -138,15 +138,15 @@ msgstr "Añade tu nombre para que otros sepan quién eres y cómo pagarte"
 msgid "Adding expense..."
 msgstr "Añadiendo gasto..."
 
-#: src/routes/new/route.tsx:196
+#: src/routes/new/route.tsx:194
 msgid "Afghan Afghani"
 msgstr "Afgani Afgano"
 
-#: src/routes/new/route.tsx:197
+#: src/routes/new/route.tsx:195
 msgid "Albanian Lek"
 msgstr "Lek Albanés"
 
-#: src/routes/new/route.tsx:231
+#: src/routes/new/route.tsx:229
 msgid "Algerian Dinar"
 msgstr "Dinar Argelino"
 
@@ -158,7 +158,7 @@ msgstr "Alinea el código QR aquí"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:449
+#: src/components/ExpenseEditor.tsx:447
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -166,15 +166,15 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:767
+#: src/components/ExpenseEditor.tsx:765
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:439
+#: src/components/ExpenseEditor.tsx:437
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
-#: src/routes/new/route.tsx:200
+#: src/routes/new/route.tsx:198
 msgid "Angolan Kwanza"
 msgstr "Kwanza Angoleño"
 
@@ -226,15 +226,15 @@ msgstr "Grupos archivados"
 msgid "Archived parties live here until you restore them to the home screen."
 msgstr "Los grupos archivados se quedan aquí hasta que los restaures al inicio."
 
-#: src/routes/new/route.tsx:201
+#: src/routes/new/route.tsx:199
 msgid "Argentine Peso"
 msgstr "Peso Argentino"
 
-#: src/routes/new/route.tsx:198
+#: src/routes/new/route.tsx:196
 msgid "Armenian Dram"
 msgstr "Dram Armenio"
 
-#: src/routes/new/route.tsx:202
+#: src/routes/new/route.tsx:200
 msgid "Aruban Florin"
 msgstr "Florín Arubeño"
 
@@ -247,7 +247,7 @@ msgstr "Se requiere al menos un participante"
 msgid "Attachments"
 msgstr "Adjuntos"
 
-#: src/routes/new/route.tsx:170
+#: src/routes/new/route.tsx:168
 msgid "Australian Dollar"
 msgstr "Dólar Australiano"
 
@@ -262,16 +262,16 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:356
-#: src/routes/settings.tsx:433
+#: src/components/ExpenseEditor.tsx:354
+#: src/routes/settings.tsx:431
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
 
-#: src/routes/settings.tsx:435
+#: src/routes/settings.tsx:433
 msgid "Automatically open the calculator when focusing amount fields"
 msgstr "Abrir automáticamente la calculadora al enfocar campos de importe"
 
-#: src/routes/settings.tsx:422
+#: src/routes/settings.tsx:420
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Abrir automáticamente el último grupo visitado cuando abras la app"
 
@@ -283,7 +283,7 @@ msgstr "Avatar eliminado"
 msgid "Avatar updated successfully"
 msgstr "Avatar actualizado correctamente"
 
-#: src/routes/new/route.tsx:203
+#: src/routes/new/route.tsx:201
 msgid "Azerbaijani Manat"
 msgstr "Manat Azerbaiyano"
 
@@ -304,11 +304,11 @@ msgstr "Volver a iniciar sesión"
 msgid "Backspace"
 msgstr "Retroceso"
 
-#: src/routes/new/route.tsx:213
+#: src/routes/new/route.tsx:211
 msgid "Bahamian Dollar"
 msgstr "Dólar Bahameño"
 
-#: src/routes/new/route.tsx:207
+#: src/routes/new/route.tsx:205
 msgid "Bahraini Dinar"
 msgstr "Dinar Bareiní"
 
@@ -324,27 +324,27 @@ msgstr "Balance, Menor Primero"
 msgid "Balances"
 msgstr "Balance"
 
-#: src/routes/new/route.tsx:206
+#: src/routes/new/route.tsx:204
 msgid "Bangladeshi Taka"
 msgstr "Taka Bangladesí"
 
-#: src/routes/new/route.tsx:205
+#: src/routes/new/route.tsx:203
 msgid "Barbadian Dollar"
 msgstr "Dólar de Barbados"
 
-#: src/routes/new/route.tsx:216
+#: src/routes/new/route.tsx:214
 msgid "Belarusian Ruble"
 msgstr "Rublo Bielorruso"
 
-#: src/routes/new/route.tsx:217
+#: src/routes/new/route.tsx:215
 msgid "Belize Dollar"
 msgstr "Dólar Beliceño"
 
-#: src/routes/new/route.tsx:209
+#: src/routes/new/route.tsx:207
 msgid "Bermudan Dollar"
 msgstr "Dólar Bermudeño"
 
-#: src/routes/new/route.tsx:214
+#: src/routes/new/route.tsx:212
 msgid "Bhutanese Ngultrum"
 msgstr "Ngultrum Butanés"
 
@@ -352,31 +352,31 @@ msgstr "Ngultrum Butanés"
 msgid "Biggest spenders"
 msgstr "Quiénes más han pagado"
 
-#: src/routes/new/route.tsx:211
+#: src/routes/new/route.tsx:209
 msgid "Bolivian Boliviano"
 msgstr "Boliviano"
 
-#: src/routes/new/route.tsx:212
+#: src/routes/new/route.tsx:210
 msgid "Bolivian Mvdol"
 msgstr "Mvdol Boliviano"
 
-#: src/routes/new/route.tsx:204
+#: src/routes/new/route.tsx:202
 msgid "Bosnia-Herzegovina Convertible Mark"
 msgstr "Marco Convertible de Bosnia-Herzegovina"
 
-#: src/routes/new/route.tsx:215
+#: src/routes/new/route.tsx:213
 msgid "Botswanan Pula"
 msgstr "Pula Botsuano"
 
-#: src/routes/new/route.tsx:174
+#: src/routes/new/route.tsx:172
 msgid "Brazilian Real"
 msgstr "Real Brasileño"
 
-#: src/routes/new/route.tsx:166
+#: src/routes/new/route.tsx:164
 msgid "British Pound"
 msgstr "Libra Esterlina"
 
-#: src/routes/new/route.tsx:210
+#: src/routes/new/route.tsx:208
 msgid "Brunei Dollar"
 msgstr "Dólar de Brunéi"
 
@@ -384,11 +384,11 @@ msgstr "Dólar de Brunéi"
 msgid "Bug Reports"
 msgstr "Reportar errores"
 
-#: src/routes/new/route.tsx:183
+#: src/routes/new/route.tsx:181
 msgid "Bulgarian Lev"
 msgstr "Lev Búlgaro"
 
-#: src/routes/new/route.tsx:208
+#: src/routes/new/route.tsx:206
 msgid "Burundian Franc"
 msgstr "Franco Burundés"
 
@@ -404,7 +404,7 @@ msgstr "Calculadora"
 msgid "Calculator expression"
 msgstr "Expresión de calculadora"
 
-#: src/routes/new/route.tsx:254
+#: src/routes/new/route.tsx:252
 msgid "Cambodian Riel"
 msgstr "Riel Camboyano"
 
@@ -420,7 +420,7 @@ msgstr "Vista previa de la cámara"
 msgid "Can I use trizum without an account?"
 msgstr "¿Puedo usar trizum sin una cuenta?"
 
-#: src/routes/new/route.tsx:169
+#: src/routes/new/route.tsx:167
 msgid "Canadian Dollar"
 msgstr "Dólar Canadiense"
 
@@ -429,7 +429,7 @@ msgstr "Dólar Canadiense"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/routes/new/route.tsx:228
+#: src/routes/new/route.tsx:226
 msgid "Cape Verdean Escudo"
 msgstr "Escudo Caboverdiano"
 
@@ -437,19 +437,19 @@ msgstr "Escudo Caboverdiano"
 msgid "Cash or other ways"
 msgstr "Efectivo u otras formas"
 
-#: src/routes/new/route.tsx:258
+#: src/routes/new/route.tsx:256
 msgid "Cayman Islands Dollar"
 msgstr "Dólar de las Islas Caimán"
 
-#: src/routes/new/route.tsx:333
+#: src/routes/new/route.tsx:331
 msgid "CFA Franc BCEAO"
 msgstr "Franco CFA BCEAO"
 
-#: src/routes/new/route.tsx:324
+#: src/routes/new/route.tsx:322
 msgid "CFA Franc BEAC"
 msgstr "Franco CFA BEAC"
 
-#: src/routes/new/route.tsx:335
+#: src/routes/new/route.tsx:333
 msgid "CFP Franc"
 msgstr "Franco CFP"
 
@@ -469,19 +469,19 @@ msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
-#: src/routes/settings.tsx:485
+#: src/routes/settings.tsx:483
 msgid "Checking..."
 msgstr "Comprobando..."
 
-#: src/routes/new/route.tsx:222
+#: src/routes/new/route.tsx:220
 msgid "Chilean Peso"
 msgstr "Peso Chileno"
 
-#: src/routes/new/route.tsx:221
+#: src/routes/new/route.tsx:219
 msgid "Chilean Unit of Account (UF)"
 msgstr "Unidad de Fomento Chilena (UF)"
 
-#: src/routes/new/route.tsx:171
+#: src/routes/new/route.tsx:169
 msgid "Chinese Yuan"
 msgstr "Yuan Chino"
 
@@ -530,15 +530,15 @@ msgstr "Configuración en la nube aplicada"
 msgid "Cloud settings saved"
 msgstr "Configuración en la nube guardada"
 
-#: src/routes/new/route.tsx:338
+#: src/routes/new/route.tsx:336
 msgid "Code for testing"
 msgstr "Código para pruebas"
 
-#: src/routes/new/route.tsx:223
+#: src/routes/new/route.tsx:221
 msgid "Colombian Peso"
 msgstr "Peso Colombiano"
 
-#: src/routes/new/route.tsx:224
+#: src/routes/new/route.tsx:222
 msgid "Colombian Real Value Unit"
 msgstr "Unidad de Valor Real Colombiana"
 
@@ -546,7 +546,7 @@ msgstr "Unidad de Valor Real Colombiana"
 msgid "Color"
 msgstr "Color"
 
-#: src/routes/new/route.tsx:255
+#: src/routes/new/route.tsx:253
 msgid "Comorian Franc"
 msgstr "Franco Comorense"
 
@@ -580,7 +580,7 @@ msgstr "Confirmación"
 msgid "Confirming..."
 msgstr "Confirmando..."
 
-#: src/routes/new/route.tsx:218
+#: src/routes/new/route.tsx:216
 msgid "Congolese Franc"
 msgstr "Franco Congoleño"
 
@@ -651,7 +651,7 @@ msgstr "Copiar enlace del grupo"
 msgid "Copy the phone number and pay through Bizum using your bank app."
 msgstr "Copia el número de teléfono y paga mediante Bizum usando la aplicación de tu banco."
 
-#: src/routes/new/route.tsx:225
+#: src/routes/new/route.tsx:223
 msgid "Costa Rican Colón"
 msgstr "Colón Costarricense"
 
@@ -676,7 +676,7 @@ msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
 #: src/hooks/useCloudSyncAccountState.ts:220
-#: src/routes/settings.tsx:489
+#: src/routes/settings.tsx:487
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
 
@@ -722,15 +722,15 @@ msgstr "Acreedor"
 msgid "Credits"
 msgstr "Créditos"
 
-#: src/routes/new/route.tsx:184
+#: src/routes/new/route.tsx:182
 msgid "Croatian Kuna"
 msgstr "Kuna Croata"
 
-#: src/routes/new/route.tsx:226
+#: src/routes/new/route.tsx:224
 msgid "Cuban Convertible Peso"
 msgstr "Peso Cubano Convertible"
 
-#: src/routes/new/route.tsx:227
+#: src/routes/new/route.tsx:225
 msgid "Cuban Peso"
 msgstr "Peso Cubano"
 
@@ -753,15 +753,15 @@ msgstr "Año actual"
 msgid "Custom range"
 msgstr "Rango personalizado"
 
-#: src/routes/new/route.tsx:180
+#: src/routes/new/route.tsx:178
 msgid "Czech Koruna"
 msgstr "Corona Checa"
 
-#: src/routes/new/route.tsx:178
+#: src/routes/new/route.tsx:176
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:499
+#: src/components/ExpenseEditor.tsx:497
 msgid "Date"
 msgstr "Fecha"
 
@@ -833,15 +833,15 @@ msgstr "¿Sabías que?"
 msgid "Divide"
 msgstr "Dividir"
 
-#: src/routes/new/route.tsx:229
+#: src/routes/new/route.tsx:227
 msgid "Djiboutian Franc"
 msgstr "Franco Yibutiano"
 
-#: src/routes/new/route.tsx:230
+#: src/routes/new/route.tsx:228
 msgid "Dominican Peso"
 msgstr "Peso Dominicano"
 
-#: src/routes/new/route.tsx:331
+#: src/routes/new/route.tsx:329
 msgid "East Caribbean Dollar"
 msgstr "Dólar del Caribe Oriental"
 
@@ -857,7 +857,7 @@ msgstr "Editando {0}"
 msgid "Editing {expenseName}"
 msgstr "Editando {expenseName}"
 
-#: src/routes/new/route.tsx:232
+#: src/routes/new/route.tsx:230
 msgid "Egyptian Pound"
 msgstr "Libra Egipcia"
 
@@ -926,11 +926,11 @@ msgstr "Inglés"
 msgid "Enter a party link or code to join"
 msgstr "Introduce un enlace o código de grupo para unirte"
 
-#: src/routes/join.tsx:175
+#: src/routes/join.tsx:173
 msgid "Enter the link or code of the trizum party you want to join"
 msgstr "Introduce el enlace o código del grupo de trizum al que quieres unirte"
 
-#: src/routes/new/route.tsx:233
+#: src/routes/new/route.tsx:231
 msgid "Eritrean Nakfa"
 msgstr "Nakfa Eritreo"
 
@@ -938,27 +938,27 @@ msgstr "Nakfa Eritreo"
 msgid "Español"
 msgstr "Español"
 
-#: src/routes/new/route.tsx:234
+#: src/routes/new/route.tsx:232
 msgid "Ethiopian Birr"
 msgstr "Birr Etíope"
 
-#: src/routes/new/route.tsx:164
+#: src/routes/new/route.tsx:162
 msgid "Euro"
 msgstr "Euro"
 
-#: src/routes/new/route.tsx:327
+#: src/routes/new/route.tsx:325
 msgid "European Composite Unit"
 msgstr "Unidad Compuesta Europea"
 
-#: src/routes/new/route.tsx:328
+#: src/routes/new/route.tsx:326
 msgid "European Monetary Unit"
 msgstr "Unidad Monetaria Europea"
 
-#: src/routes/new/route.tsx:330
+#: src/routes/new/route.tsx:328
 msgid "European Unit of Account 17"
 msgstr "Unidad de Cuenta Europea 17"
 
-#: src/routes/new/route.tsx:329
+#: src/routes/new/route.tsx:327
 msgid "European Unit of Account 9"
 msgstr "Unidad de Cuenta Europea 9"
 
@@ -987,7 +987,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:978
+#: src/components/ExpenseEditor.tsx:976
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1028,11 +1028,11 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:953
+#: src/components/ExpenseEditor.tsx:951
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
-#: src/routes/new/route.tsx:236
+#: src/routes/new/route.tsx:234
 msgid "Falkland Islands Pound"
 msgstr "Libra Malvinense"
 
@@ -1044,7 +1044,7 @@ msgstr "Sugerencias"
 msgid "Features"
 msgstr "Características"
 
-#: src/routes/new/route.tsx:235
+#: src/routes/new/route.tsx:233
 msgid "Fijian Dollar"
 msgstr "Dólar Fiyiano"
 
@@ -1057,7 +1057,7 @@ msgstr "Filtra totales y rankings"
 msgid "Finishing sign in"
 msgstr "Terminando el inicio de sesión"
 
-#: src/routes/settings.tsx:384
+#: src/routes/settings.tsx:382
 msgid "For payments through Bizum or similar services"
 msgstr "Para pagos mediante Bizum o servicios similares"
 
@@ -1073,11 +1073,11 @@ msgstr "¿Encontraste un error? Avísanos en GitHub y lo solucionaremos."
 msgid "Frequently Asked Questions"
 msgstr "Preguntas frecuentes"
 
-#: src/routes/new/route.tsx:240
+#: src/routes/new/route.tsx:238
 msgid "Gambian Dalasi"
 msgstr "Dalasi Gambiano"
 
-#: src/routes/new/route.tsx:237
+#: src/routes/new/route.tsx:235
 msgid "Georgian Lari"
 msgstr "Lari Georgiano"
 
@@ -1085,11 +1085,11 @@ msgstr "Lari Georgiano"
 msgid "Get in touch with the person to make the payment in cash or a different way outside of the ones described above."
 msgstr "Ponte en contacto con la persona para hacer el pago en efectivo o de otra forma diferente a las descritas anteriormente."
 
-#: src/routes/new/route.tsx:238
+#: src/routes/new/route.tsx:236
 msgid "Ghanaian Cedi"
 msgstr "Cedi Ghanés"
 
-#: src/routes/new/route.tsx:239
+#: src/routes/new/route.tsx:237
 msgid "Gibraltar Pound"
 msgstr "Libra de Gibraltar"
 
@@ -1110,7 +1110,7 @@ msgstr "Vuelve atrás e inténtalo de nuevo desde la lista de saldos."
 msgid "Go back to home"
 msgstr "Volver al inicio"
 
-#: src/routes/new/route.tsx:326
+#: src/routes/new/route.tsx:324
 msgid "Gold (troy ounce)"
 msgstr "Oro (onza troy)"
 
@@ -1130,19 +1130,19 @@ msgstr "Google está conectado a esta cuenta"
 msgid "Got it"
 msgstr "Entendido"
 
-#: src/routes/new/route.tsx:242
+#: src/routes/new/route.tsx:240
 msgid "Guatemalan Quetzal"
 msgstr "Quetzal Guatemalteco"
 
-#: src/routes/new/route.tsx:241
+#: src/routes/new/route.tsx:239
 msgid "Guinean Franc"
 msgstr "Franco Guineano"
 
-#: src/routes/new/route.tsx:243
+#: src/routes/new/route.tsx:241
 msgid "Guyanaese Dollar"
 msgstr "Dólar Guyanés"
 
-#: src/routes/new/route.tsx:245
+#: src/routes/new/route.tsx:243
 msgid "Haitian Gourde"
 msgstr "Gourde Haitiano"
 
@@ -1150,7 +1150,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:855
+#: src/components/ExpenseEditor.tsx:853
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -1170,11 +1170,11 @@ msgstr "Ocultar inicio de sesión con contraseña"
 msgid "Home"
 msgstr "Inicio"
 
-#: src/routes/new/route.tsx:244
+#: src/routes/new/route.tsx:242
 msgid "Honduran Lempira"
 msgstr "Lempira Hondureño"
 
-#: src/routes/new/route.tsx:189
+#: src/routes/new/route.tsx:187
 msgid "Hong Kong Dollar"
 msgstr "Dólar de Hong Kong"
 
@@ -1195,11 +1195,11 @@ msgstr "¿Cómo debería equilibrar?"
 msgid "How to pay?"
 msgstr "¿Cómo pagar?"
 
-#: src/routes/new/route.tsx:181
+#: src/routes/new/route.tsx:179
 msgid "Hungarian Forint"
 msgstr "Forinto Húngaro"
 
-#: src/routes/new/route.tsx:249
+#: src/routes/new/route.tsx:247
 msgid "Icelandic Króna"
 msgstr "Corona Islandesa"
 
@@ -1219,7 +1219,7 @@ msgstr "Impacto en mi balance: <0/>"
 msgid "Impact on my balance: <0/>"
 msgstr "Impacto en mi balance: <0/>"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:97
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:95
 msgid "Import attachments"
 msgstr "Importar adjuntos"
 
@@ -1239,11 +1239,11 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:543
+#: src/components/ExpenseEditor.tsx:541
 msgid "Include all"
 msgstr "Incluir todos"
 
-#: src/routes/new/route.tsx:172
+#: src/routes/new/route.tsx:170
 msgid "Indian Rupee"
 msgstr "Rupia India"
 
@@ -1251,7 +1251,7 @@ msgstr "Rupia India"
 msgid "Individual totals"
 msgstr "Totales individuales"
 
-#: src/routes/new/route.tsx:246
+#: src/routes/new/route.tsx:244
 msgid "Indonesian Rupiah"
 msgstr "Rupia Indonesia"
 
@@ -1273,11 +1273,11 @@ msgstr "Código de grupo de trizum no válido"
 msgid "Invalid trizum party link"
 msgstr "Enlace de grupo de trizum no válido"
 
-#: src/routes/new/route.tsx:248
+#: src/routes/new/route.tsx:246
 msgid "Iranian Rial"
 msgstr "Rial Iraní"
 
-#: src/routes/new/route.tsx:247
+#: src/routes/new/route.tsx:245
 msgid "Iraqi Dinar"
 msgstr "Dinar Iraquí"
 
@@ -1285,19 +1285,19 @@ msgstr "Dinar Iraquí"
 msgid "Is my data secure?"
 msgstr "¿Mis datos están seguros?"
 
-#: src/routes/new/route.tsx:192
+#: src/routes/new/route.tsx:190
 msgid "Israeli Shekel"
 msgstr "Shekel Israelí"
 
-#: src/routes/new/route.tsx:250
+#: src/routes/new/route.tsx:248
 msgid "Jamaican Dollar"
 msgstr "Dólar Jamaicano"
 
-#: src/routes/new/route.tsx:167
+#: src/routes/new/route.tsx:165
 msgid "Japanese Yen"
 msgstr "Yen Japonés"
 
-#: src/routes/join.tsx:195
+#: src/routes/join.tsx:193
 msgid "Join"
 msgstr "Unirse"
 
@@ -1318,7 +1318,7 @@ msgstr "Unirse a un Grupo"
 msgid "Join a trizum"
 msgstr "Unirse a un trizum"
 
-#: src/routes/new/route.tsx:251
+#: src/routes/new/route.tsx:249
 msgid "Jordanian Dinar"
 msgstr "Dinar Jordano"
 
@@ -1326,7 +1326,7 @@ msgstr "Dinar Jordano"
 msgid "Jump back into the groups you use most"
 msgstr "Vuelve a los grupos que más usas"
 
-#: src/routes/new/route.tsx:259
+#: src/routes/new/route.tsx:257
 msgid "Kazakhstani Tenge"
 msgstr "Tenge Kazajo"
 
@@ -1338,23 +1338,23 @@ msgstr "Mantener datos locales"
 msgid "Keep your profile settings available on your signed-in devices."
 msgstr "Mantén la configuración de tu perfil disponible en los dispositivos donde has iniciado sesión."
 
-#: src/routes/new/route.tsx:252
+#: src/routes/new/route.tsx:250
 msgid "Kenyan Shilling"
 msgstr "Chelín Keniata"
 
-#: src/routes/new/route.tsx:257
+#: src/routes/new/route.tsx:255
 msgid "Kuwaiti Dinar"
 msgstr "Dinar Kuwaití"
 
-#: src/routes/new/route.tsx:253
+#: src/routes/new/route.tsx:251
 msgid "Kyrgystani Som"
 msgstr "Som Kirguís"
 
-#: src/routes/settings.tsx:399
+#: src/routes/settings.tsx:397
 msgid "Language"
 msgstr "Idioma"
 
-#: src/routes/new/route.tsx:260
+#: src/routes/new/route.tsx:258
 msgid "Laotian Kip"
 msgstr "Kip Laosiano"
 
@@ -1374,19 +1374,19 @@ msgstr "Año pasado"
 msgid "Leave party"
 msgstr "Dejar el grupo"
 
-#: src/routes/new/route.tsx:261
+#: src/routes/new/route.tsx:259
 msgid "Lebanese Pound"
 msgstr "Libra Libanesa"
 
-#: src/routes/new/route.tsx:264
+#: src/routes/new/route.tsx:262
 msgid "Lesotho Loti"
 msgstr "Loti de Lesoto"
 
-#: src/routes/new/route.tsx:263
+#: src/routes/new/route.tsx:261
 msgid "Liberian Dollar"
 msgstr "Dólar Liberiano"
 
-#: src/routes/new/route.tsx:265
+#: src/routes/new/route.tsx:263
 msgid "Libyan Dinar"
 msgstr "Dinar Libio"
 
@@ -1394,7 +1394,7 @@ msgstr "Dinar Libio"
 msgid "License"
 msgstr "Licencia"
 
-#: src/routes/join.tsx:174
+#: src/routes/join.tsx:172
 msgid "Link or code"
 msgstr "Enlace o código"
 
@@ -1410,27 +1410,27 @@ msgstr "Cargando licencias..."
 msgid "Long press for party actions"
 msgstr "Mantén pulsado para abrir las acciones del grupo"
 
-#: src/routes/new/route.tsx:272
+#: src/routes/new/route.tsx:270
 msgid "Macanese Pataca"
 msgstr "Pataca de Macao"
 
-#: src/routes/new/route.tsx:269
+#: src/routes/new/route.tsx:267
 msgid "Macedonian Denar"
 msgstr "Denar Macedonio"
 
-#: src/routes/new/route.tsx:268
+#: src/routes/new/route.tsx:266
 msgid "Malagasy Ariary"
 msgstr "Ariary Malgache"
 
-#: src/routes/new/route.tsx:276
+#: src/routes/new/route.tsx:274
 msgid "Malawian Kwacha"
 msgstr "Kwacha Malauí"
 
-#: src/routes/new/route.tsx:278
+#: src/routes/new/route.tsx:276
 msgid "Malaysian Ringgit"
 msgstr "Ringgit Malasio"
 
-#: src/routes/new/route.tsx:275
+#: src/routes/new/route.tsx:273
 msgid "Maldivian Rufiyaa"
 msgstr "Rufiyaa Maldiva"
 
@@ -1452,11 +1452,11 @@ msgstr "Marcar como pagado"
 msgid "Marking expense as paid..."
 msgstr "Marcando gasto como pagado..."
 
-#: src/routes/new/route.tsx:273
+#: src/routes/new/route.tsx:271
 msgid "Mauritanian Ouguiya"
 msgstr "Ouguiya Mauritano"
 
-#: src/routes/new/route.tsx:274
+#: src/routes/new/route.tsx:272
 msgid "Mauritian Rupee"
 msgstr "Rupia de Mauricio"
 
@@ -1467,18 +1467,18 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:349
+#: src/components/ExpenseEditor.tsx:347
 #: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:86
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
 msgstr "Menú"
 
-#: src/routes/new/route.tsx:277
+#: src/routes/new/route.tsx:275
 msgid "Mexican Investment Unit"
 msgstr "Unidad de Inversión Mexicana"
 
-#: src/routes/new/route.tsx:173
+#: src/routes/new/route.tsx:171
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
@@ -1501,15 +1501,15 @@ msgstr "Migración exitosa"
 msgid "Missing search params"
 msgstr "Faltan parámetros de búsqueda"
 
-#: src/routes/new/route.tsx:267
+#: src/routes/new/route.tsx:265
 msgid "Moldovan Leu"
 msgstr "Leu Moldavo"
 
-#: src/routes/new/route.tsx:271
+#: src/routes/new/route.tsx:269
 msgid "Mongolian Tugrik"
 msgstr "Tugrik Mongol"
 
-#: src/routes/new/route.tsx:266
+#: src/routes/new/route.tsx:264
 msgid "Moroccan Dirham"
 msgstr "Dírham Marroquí"
 
@@ -1525,7 +1525,7 @@ msgstr "Mover cursor a la derecha"
 msgid "Moved to"
 msgstr "Movida a"
 
-#: src/routes/new/route.tsx:279
+#: src/routes/new/route.tsx:277
 msgid "Mozambican Metical"
 msgstr "Metical Mozambiqueño"
 
@@ -1537,7 +1537,7 @@ msgstr "División Multi-Grupo"
 msgid "Multiply"
 msgstr "Multiplicar"
 
-#: src/routes/new/route.tsx:270
+#: src/routes/new/route.tsx:268
 msgid "Myanma Kyat"
 msgstr "Kyat Birmano"
 
@@ -1551,7 +1551,7 @@ msgstr "Nombre"
 msgid "Name must be less than 50 characters"
 msgstr "El nombre debe tener menos de 50 caracteres"
 
-#: src/routes/new/route.tsx:280
+#: src/routes/new/route.tsx:278
 msgid "Namibian Dollar"
 msgstr "Dólar Namibio"
 
@@ -1559,11 +1559,11 @@ msgstr "Dólar Namibio"
 msgid "Need help with trizum? We're here to assist you."
 msgstr "¿Necesitas ayuda con trizum? Estamos aquí para ayudarte."
 
-#: src/routes/new/route.tsx:283
+#: src/routes/new/route.tsx:281
 msgid "Nepalese Rupee"
 msgstr "Rupia Nepalí"
 
-#: src/routes/new/route.tsx:199
+#: src/routes/new/route.tsx:197
 msgid "Netherlands Antillean Guilder"
 msgstr "Florín de las Antillas Neerlandesas"
 
@@ -1576,11 +1576,11 @@ msgstr "Nuevo gasto"
 msgid "New participant name"
 msgstr "Nombre del nuevo participante"
 
-#: src/routes/reset-password.tsx:127
+#: src/routes/reset-password.tsx:125
 msgid "New password"
 msgstr "Nueva contraseña"
 
-#: src/routes/new/route.tsx:311
+#: src/routes/new/route.tsx:309
 msgid "New Taiwan Dollar"
 msgstr "Nuevo Dólar Taiwanés"
 
@@ -1588,7 +1588,7 @@ msgstr "Nuevo Dólar Taiwanés"
 msgid "New trizum"
 msgstr "Nuevo trizum"
 
-#: src/routes/new/route.tsx:187
+#: src/routes/new/route.tsx:185
 msgid "New Zealand Dollar"
 msgstr "Dólar Neozelandés"
 
@@ -1596,11 +1596,11 @@ msgstr "Dólar Neozelandés"
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/routes/new/route.tsx:282
+#: src/routes/new/route.tsx:280
 msgid "Nicaraguan Córdoba"
 msgstr "Córdoba Nicaragüense"
 
-#: src/routes/new/route.tsx:281
+#: src/routes/new/route.tsx:279
 msgid "Nigerian Naira"
 msgstr "Naira Nigeriano"
 
@@ -1620,7 +1620,7 @@ msgstr "No se encontró cámara en este dispositivo"
 msgid "No cloud settings saved yet"
 msgstr "Todavía no hay configuración guardada en la nube"
 
-#: src/routes/new/route.tsx:340
+#: src/routes/new/route.tsx:338
 msgid "No currency"
 msgstr "Sin moneda"
 
@@ -1661,11 +1661,11 @@ msgstr "Todavía nadie"
 msgid "Non-transfer expenses in this timeframe"
 msgstr "Gastos no asociados a transferencias en este período"
 
-#: src/routes/new/route.tsx:256
+#: src/routes/new/route.tsx:254
 msgid "North Korean Won"
 msgstr "Won Norcoreano"
 
-#: src/routes/new/route.tsx:177
+#: src/routes/new/route.tsx:175
 msgid "Norwegian Krone"
 msgstr "Corona Noruega"
 
@@ -1678,11 +1678,11 @@ msgstr "No es un código de grupo de trizum válido"
 msgid "Not connected"
 msgstr "No conectado"
 
-#: src/routes/settings.tsx:493
+#: src/routes/settings.tsx:491
 msgid "Not set up"
 msgstr "No configurada"
 
-#: src/routes/settings.tsx:481
+#: src/routes/settings.tsx:479
 msgid "Not signed in"
 msgstr "No has iniciado sesión"
 
@@ -1698,7 +1698,7 @@ msgstr "Sin Conexión Primero"
 msgid "Older parties stay tucked away, not gone"
 msgstr "Los grupos antiguos quedan apartados, no desaparecen"
 
-#: src/routes/new/route.tsx:284
+#: src/routes/new/route.tsx:282
 msgid "Omani Rial"
 msgstr "Rial Omaní"
 
@@ -1718,7 +1718,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:359
+#: src/components/ExpenseEditor.tsx:357
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1726,7 +1726,7 @@ msgstr "Abrir calculadora al enfocar campos de importe"
 msgid "Open GitHub Issues"
 msgstr "Abrir GitHub Issues"
 
-#: src/routes/settings.tsx:420
+#: src/routes/settings.tsx:418
 msgid "Open last party on launch"
 msgstr "Abrir el último grupo al abrir la app"
 
@@ -1759,7 +1759,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:474
+#: src/components/ExpenseEditor.tsx:472
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -1772,23 +1772,23 @@ msgstr "Deuda pagada a {0}"
 msgid "Paid debt to {toName}"
 msgstr "Deuda pagada a {toName}"
 
-#: src/routes/new/route.tsx:289
+#: src/routes/new/route.tsx:287
 msgid "Pakistani Rupee"
 msgstr "Rupia Paquistaní"
 
-#: src/routes/new/route.tsx:334
+#: src/routes/new/route.tsx:332
 msgid "Palladium (troy ounce)"
 msgstr "Paladio (onza troy)"
 
-#: src/routes/new/route.tsx:285
+#: src/routes/new/route.tsx:283
 msgid "Panamanian Balboa"
 msgstr "Balboa Panameño"
 
-#: src/routes/new/route.tsx:287
+#: src/routes/new/route.tsx:285
 msgid "Papua New Guinean Kina"
 msgstr "Kina de Papúa Nueva Guinea"
 
-#: src/routes/new/route.tsx:290
+#: src/routes/new/route.tsx:288
 msgid "Paraguayan Guarani"
 msgstr "Guaraní Paraguayo"
 
@@ -1872,7 +1872,7 @@ msgstr "Correo de contraseña enviado"
 msgid "Password enabled"
 msgstr "Contraseña activada"
 
-#: src/routes/reset-password.tsx:121
+#: src/routes/reset-password.tsx:119
 msgid "Password must be at least 8 characters"
 msgstr "La contraseña debe tener al menos 8 caracteres"
 
@@ -1896,7 +1896,7 @@ msgstr "El inicio de sesión con contraseña está activado"
 msgid "Password updated"
 msgstr "Contraseña actualizada"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:77
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:75
 msgid "Paste the Tricount sharing message, URL (e.g., https://tricount.com/abc123), or the direct key"
 msgstr "Pega el mensaje de compartir de Tricount, la URL (p. ej., https://tricount.com/abc123), o la clave directa"
 
@@ -1917,15 +1917,15 @@ msgstr "Eliminar permanentemente tu cuenta de trizum cloud"
 msgid "Personal mode"
 msgstr "Modo personal"
 
-#: src/routes/new/route.tsx:286
+#: src/routes/new/route.tsx:284
 msgid "Peruvian Sol"
 msgstr "Sol Peruano"
 
-#: src/routes/new/route.tsx:288
+#: src/routes/new/route.tsx:286
 msgid "Philippine Peso"
 msgstr "Peso Filipino"
 
-#: src/routes/settings.tsx:383
+#: src/routes/settings.tsx:381
 msgid "Phone number"
 msgstr "Número de teléfono"
 
@@ -1957,7 +1957,7 @@ msgstr "Los grupos fijados se mantienen a mano. La actividad reciente mantiene e
 msgid "Pinned parties stay on top, then the rest follow your latest activity."
 msgstr "Los grupos fijados se quedan arriba y el resto sigue tu actividad más reciente."
 
-#: src/routes/new/route.tsx:336
+#: src/routes/new/route.tsx:334
 msgid "Platinum (troy ounce)"
 msgstr "Platino (onza troy)"
 
@@ -1965,7 +1965,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:873
+#: src/components/ExpenseEditor.tsx:871
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -1989,7 +1989,7 @@ msgstr "Por favor espera mientras obtenemos los datos más recientes"
 msgid "Point your camera at a trizum QR code"
 msgstr "Apunta tu cámara a un código QR de trizum"
 
-#: src/routes/new/route.tsx:179
+#: src/routes/new/route.tsx:177
 msgid "Polish Zloty"
 msgstr "Zloty Polaco"
 
@@ -2001,7 +2001,7 @@ msgstr "Anterior"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: src/routes/new/route.tsx:291
+#: src/routes/new/route.tsx:289
 msgid "Qatari Rial"
 msgstr "Rial Catarí"
 
@@ -2013,7 +2013,7 @@ msgstr "Captura de fotograma del código QR"
 msgid "Ranking based on how much each participant paid in the selected timeframe."
 msgstr "Clasificación según cuánto ha pagado cada participante en el período seleccionado."
 
-#: src/routes/settings.tsx:500
+#: src/routes/settings.tsx:498
 msgid "Ready on another device"
 msgstr "Listo en otro dispositivo"
 
@@ -2038,7 +2038,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1070
+#: src/components/ExpenseEditor.tsx:1068
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2075,35 +2075,35 @@ msgstr "Restaurar al inicio"
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/routes/new/route.tsx:182
+#: src/routes/new/route.tsx:180
 msgid "Romanian Leu"
 msgstr "Leu Rumano"
 
-#: src/routes/new/route.tsx:185
+#: src/routes/new/route.tsx:183
 msgid "Russian Ruble"
 msgstr "Rublo Ruso"
 
-#: src/routes/new/route.tsx:293
+#: src/routes/new/route.tsx:291
 msgid "Rwandan Franc"
 msgstr "Franco Ruandés"
 
-#: src/routes/new/route.tsx:297
+#: src/routes/new/route.tsx:295
 msgid "Saint Helena Pound"
 msgstr "Libra de Santa Elena"
 
-#: src/routes/new/route.tsx:303
+#: src/routes/new/route.tsx:301
 msgid "Salvadoran Colón"
 msgstr "Colón Salvadoreño"
 
-#: src/routes/new/route.tsx:323
+#: src/routes/new/route.tsx:321
 msgid "Samoan Tala"
 msgstr "Tala Samoano"
 
-#: src/routes/new/route.tsx:302
+#: src/routes/new/route.tsx:300
 msgid "São Tomé and Príncipe Dobra"
 msgstr "Dobra de Santo Tomé y Príncipe"
 
-#: src/routes/new/route.tsx:194
+#: src/routes/new/route.tsx:192
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
@@ -2154,7 +2154,7 @@ msgstr "Enviar enlace de contraseña"
 msgid "Send us an email and we'll get back to you as soon as possible."
 msgstr "Envíanos un email y te responderemos lo antes posible."
 
-#: src/routes/new/route.tsx:292
+#: src/routes/new/route.tsx:290
 msgid "Serbian Dinar"
 msgstr "Dinar Serbio"
 
@@ -2188,7 +2188,7 @@ msgstr "Configuración guardada"
 msgid "Settled in"
 msgstr "Saldada en"
 
-#: src/routes/new/route.tsx:295
+#: src/routes/new/route.tsx:293
 msgid "Seychellois Rupee"
 msgstr "Rupia de Seychelles"
 
@@ -2210,7 +2210,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:729
+#: src/components/ExpenseEditor.tsx:727
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -2218,11 +2218,11 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:859
+#: src/components/ExpenseEditor.tsx:857
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
-#: src/routes/new/route.tsx:298
+#: src/routes/new/route.tsx:296
 msgid "Sierra Leonean Leone"
 msgstr "Leone de Sierra Leona"
 
@@ -2291,19 +2291,19 @@ msgstr "Sesión iniciada"
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
-#: src/routes/new/route.tsx:325
+#: src/routes/new/route.tsx:323
 msgid "Silver (troy ounce)"
 msgstr "Plata (onza troy)"
 
-#: src/routes/new/route.tsx:188
+#: src/routes/new/route.tsx:186
 msgid "Singapore Dollar"
 msgstr "Dólar de Singapur"
 
-#: src/routes/new/route.tsx:294
+#: src/routes/new/route.tsx:292
 msgid "Solomon Islands Dollar"
 msgstr "Dólar de las Islas Salomón"
 
-#: src/routes/new/route.tsx:299
+#: src/routes/new/route.tsx:297
 msgid "Somali Shilling"
 msgstr "Chelín Somalí"
 
@@ -2319,19 +2319,19 @@ msgstr "Algo salió mal"
 msgid "Sort balances"
 msgstr "Ordenar balances"
 
-#: src/routes/new/route.tsx:191
+#: src/routes/new/route.tsx:189
 msgid "South African Rand"
 msgstr "Rand Sudafricano"
 
-#: src/routes/new/route.tsx:175
+#: src/routes/new/route.tsx:173
 msgid "South Korean Won"
 msgstr "Won Surcoreano"
 
-#: src/routes/new/route.tsx:301
+#: src/routes/new/route.tsx:299
 msgid "South Sudanese Pound"
 msgstr "Libra Sursudanesa"
 
-#: src/routes/new/route.tsx:332
+#: src/routes/new/route.tsx:330
 msgid "Special Drawing Rights"
 msgstr "Derechos Especiales de Giro"
 
@@ -2347,7 +2347,7 @@ msgstr "Divide facturas con amigos y familia. Registra, calcula y salda gastos j
 msgid "Split expenses fairly among multiple participants"
 msgstr "Divide los gastos de forma justa entre múltiples participantes"
 
-#: src/routes/new/route.tsx:262
+#: src/routes/new/route.tsx:260
 msgid "Sri Lankan Rupee"
 msgstr "Rupia de Sri Lanka"
 
@@ -2386,11 +2386,11 @@ msgstr "Enviando..."
 msgid "Subtract"
 msgstr "Restar"
 
-#: src/routes/new/route.tsx:337
+#: src/routes/new/route.tsx:335
 msgid "Sucre"
 msgstr "Sucre"
 
-#: src/routes/new/route.tsx:296
+#: src/routes/new/route.tsx:294
 msgid "Sudanese Pound"
 msgstr "Libra Sudanesa"
 
@@ -2399,15 +2399,15 @@ msgstr "Libra Sudanesa"
 msgid "Support"
 msgstr "Soporte"
 
-#: src/routes/new/route.tsx:300
+#: src/routes/new/route.tsx:298
 msgid "Surinamese Dollar"
 msgstr "Dólar Surinamés"
 
-#: src/routes/new/route.tsx:305
+#: src/routes/new/route.tsx:303
 msgid "Swazi Lilangeni"
 msgstr "Lilangeni Suazi"
 
-#: src/routes/new/route.tsx:176
+#: src/routes/new/route.tsx:174
 msgid "Swedish Krona"
 msgstr "Corona Sueca"
 
@@ -2415,15 +2415,15 @@ msgstr "Corona Sueca"
 msgid "Swipe between expenses and balances tabs."
 msgstr "Desliza entre las pestañas de gastos y balance."
 
-#: src/routes/new/route.tsx:168
+#: src/routes/new/route.tsx:166
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:753
+#: src/components/ExpenseEditor.tsx:751
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:754
+#: src/components/ExpenseEditor.tsx:752
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2448,7 +2448,7 @@ msgstr "Sincronizar configuración del perfil"
 msgid "Syncing party information..."
 msgstr "Sincronizando información del grupo..."
 
-#: src/routes/new/route.tsx:304
+#: src/routes/new/route.tsx:302
 msgid "Syrian Pound"
 msgstr "Libra Siria"
 
@@ -2456,18 +2456,18 @@ msgstr "Libra Siria"
 msgid "System (fallbacks to {DEFAULT_LOCALE})"
 msgstr "Sistema (por defecto {DEFAULT_LOCALE})"
 
-#: src/routes/new/route.tsx:306
+#: src/routes/new/route.tsx:304
 msgid "Tajikistani Somoni"
 msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:998
-#: src/components/ExpenseEditor.tsx:1012
+#: src/components/ExpenseEditor.tsx:996
+#: src/components/ExpenseEditor.tsx:1010
 msgid "Take photo"
 msgstr "Hacer foto"
 
-#: src/routes/new/route.tsx:312
+#: src/routes/new/route.tsx:310
 msgid "Tanzanian Shilling"
 msgstr "Chelín Tanzano"
 
@@ -2475,7 +2475,7 @@ msgstr "Chelín Tanzano"
 msgid "Tap to change"
 msgstr "Toca para cambiar"
 
-#: src/routes/new/route.tsx:190
+#: src/routes/new/route.tsx:188
 msgid "Thai Baht"
 msgstr "Baht Tailandés"
 
@@ -2562,7 +2562,7 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:415
+#: src/components/ExpenseEditor.tsx:413
 msgid "Title"
 msgstr "Título"
 
@@ -2582,11 +2582,11 @@ msgstr "Para conectar Google o Apple, elige una cuenta con el mismo correo que t
 msgid "To join the <0>{0}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "Para unirte al <0>{0}</0>, por favor selecciona quién eres para que podamos mostrarte los gastos y estadísticas que te importan."
 
-#: src/routes/party_.$partyId.who.tsx:132
+#: src/routes/party_.$partyId.who.tsx:130
 msgid "To join the <0>{partyName}</0>, please select who you are so that we can show you the expenses and stats that matter to you."
 msgstr "Para unirte al <0>{partyName}</0>, por favor selecciona quién eres para que podamos mostrarte los gastos y estadísticas que te importan."
 
-#: src/routes/new/route.tsx:309
+#: src/routes/new/route.tsx:307
 msgid "Tongan Paʻanga"
 msgstr "Paʻanga Tongano"
 
@@ -2616,11 +2616,11 @@ msgstr "Transferir a otro grupo"
 msgid "Tricount key or URL is required"
 msgstr "Se requiere la clave o URL de Tricount"
 
-#: src/routes/migrate_.tricount/-components/IdleState.tsx:76
+#: src/routes/migrate_.tricount/-components/IdleState.tsx:74
 msgid "Tricount URL or key"
 msgstr "URL o clave de Tricount"
 
-#: src/routes/new/route.tsx:310
+#: src/routes/new/route.tsx:308
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
@@ -2680,15 +2680,15 @@ msgstr "Prueba otro período para comparar otra etapa de tu grupo."
 msgid "Try scanning another code"
 msgstr "Prueba escaneando otro código"
 
-#: src/routes/new/route.tsx:308
+#: src/routes/new/route.tsx:306
 msgid "Tunisian Dinar"
 msgstr "Dinar Tunecino"
 
-#: src/routes/new/route.tsx:186
+#: src/routes/new/route.tsx:184
 msgid "Turkish Lira"
 msgstr "Lira Turca"
 
-#: src/routes/new/route.tsx:307
+#: src/routes/new/route.tsx:305
 msgid "Turkmenistani Manat"
 msgstr "Manat Turkmeno"
 
@@ -2696,19 +2696,19 @@ msgstr "Manat Turkmeno"
 msgid "Type \"delete account\" to confirm."
 msgstr "Escribe \"delete account\" para confirmar."
 
-#: src/routes/new/route.tsx:193
+#: src/routes/new/route.tsx:191
 msgid "UAE Dirham"
 msgstr "Dírham de los EAU"
 
-#: src/routes/new/route.tsx:314
+#: src/routes/new/route.tsx:312
 msgid "Ugandan Shilling"
 msgstr "Chelín Ugandés"
 
-#: src/routes/new/route.tsx:313
+#: src/routes/new/route.tsx:311
 msgid "Ukrainian Hryvnia"
 msgstr "Grivna Ucraniana"
 
-#: src/routes/new/route.tsx:318
+#: src/routes/new/route.tsx:316
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
@@ -2733,11 +2733,11 @@ msgstr "No se ha podido actualizar. Inténtalo de nuevo."
 msgid "Update is no longer available."
 msgstr "La actualización ya no está disponible."
 
-#: src/routes/reset-password.tsx:142
+#: src/routes/reset-password.tsx:140
 msgid "Update password"
 msgstr "Actualizar contraseña"
 
-#: src/routes/party_.$partyId.who.tsx:137
+#: src/routes/party_.$partyId.who.tsx:135
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 msgstr "Actualiza quién eres en este grupo para que podamos mostrarte los gastos y estadísticas que te importan."
 
@@ -2749,14 +2749,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:898
+#: src/components/ExpenseEditor.tsx:896
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1007
-#: src/components/ExpenseEditor.tsx:1024
+#: src/components/ExpenseEditor.tsx:1005
+#: src/components/ExpenseEditor.tsx:1022
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2764,23 +2764,23 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:938
+#: src/components/ExpenseEditor.tsx:936
 msgid "Uploading..."
 msgstr "Subiendo..."
 
-#: src/routes/new/route.tsx:316
+#: src/routes/new/route.tsx:314
 msgid "Uruguay Peso en Unidades Indexadas"
 msgstr "Peso Uruguayo en Unidades Indexadas"
 
-#: src/routes/new/route.tsx:317
+#: src/routes/new/route.tsx:315
 msgid "Uruguayan Peso"
 msgstr "Peso Uruguayo"
 
-#: src/routes/new/route.tsx:165
+#: src/routes/new/route.tsx:163
 msgid "US Dollar"
 msgstr "Dólar Estadounidense"
 
-#: src/routes/new/route.tsx:315
+#: src/routes/new/route.tsx:313
 msgid "US Dollar (Next day)"
 msgstr "Dólar Estadounidense (Día siguiente)"
 
@@ -2809,7 +2809,7 @@ msgstr "¿Usar trizum cloud en este dispositivo?"
 msgid "Use your camera to scan a trizum invite"
 msgstr "Usa tu cámara para escanear una invitación de trizum"
 
-#: src/routes/settings.tsx:361
+#: src/routes/settings.tsx:359
 msgid "Username"
 msgstr "Nombre de usuario"
 
@@ -2817,15 +2817,15 @@ msgstr "Nombre de usuario"
 msgid "Username, phone, language, launch behavior, and accent color"
 msgstr "Nombre de usuario, teléfono, idioma, comportamiento de inicio y color de acento"
 
-#: src/routes/new/route.tsx:319
+#: src/routes/new/route.tsx:317
 msgid "Uzbekistan Som"
 msgstr "Som Uzbeko"
 
-#: src/routes/new/route.tsx:322
+#: src/routes/new/route.tsx:320
 msgid "Vanuatu Vatu"
 msgstr "Vatu de Vanuatu"
 
-#: src/routes/new/route.tsx:320
+#: src/routes/new/route.tsx:318
 msgid "Venezuelan Bolívar Soberano"
 msgstr "Bolívar Soberano Venezolano"
 
@@ -2833,7 +2833,7 @@ msgstr "Bolívar Soberano Venezolano"
 msgid "Version"
 msgstr "Versión"
 
-#: src/routes/new/route.tsx:321
+#: src/routes/new/route.tsx:319
 msgid "Vietnamese Dong"
 msgstr "Dong Vietnamita"
 
@@ -2845,7 +2845,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1059
+#: src/components/ExpenseEditor.tsx:1057
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"
@@ -2891,7 +2891,7 @@ msgstr "Bienvenid@ a trizum"
 msgid "What is this party about?"
 msgstr "¿De qué trata este grupo?"
 
-#: src/routes/settings.tsx:362
+#: src/routes/settings.tsx:360
 msgid "What's your preferred way to be addressed?"
 msgstr "¿Cuál es tu forma preferida de que te llamen?"
 
@@ -2907,11 +2907,11 @@ msgstr "¿Quién está invitado a este grupo? Puedes añadir más participantes 
 msgid "Why is this taking so long?"
 msgstr "¿Por qué está tardando tanto?"
 
-#: src/routes/new/route.tsx:219
+#: src/routes/new/route.tsx:217
 msgid "WIR Euro"
 msgstr "Euro WIR"
 
-#: src/routes/new/route.tsx:220
+#: src/routes/new/route.tsx:218
 msgid "WIR Franc"
 msgstr "Franco WIR"
 
@@ -2919,7 +2919,7 @@ msgstr "Franco WIR"
 msgid "Works seamlessly offline with automatic sync when online"
 msgstr "Funciona sin problemas sin conexión con sincronización automática cuando estás en línea"
 
-#: src/routes/new/route.tsx:341
+#: src/routes/new/route.tsx:339
 msgid "Yemeni Rial"
 msgstr "Rial Yemení"
 
@@ -2975,10 +2975,10 @@ msgstr "Tus grupos"
 msgid "Your total"
 msgstr "Tu total"
 
-#: src/routes/new/route.tsx:342
+#: src/routes/new/route.tsx:340
 msgid "Zambian Kwacha"
 msgstr "Kwacha Zambiano"
 
-#: src/routes/new/route.tsx:343
+#: src/routes/new/route.tsx:341
 msgid "Zimbabwean Dollar"
 msgstr "Dólar Zimbabuense"

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -286,12 +286,10 @@ export function ExpenseEditor({
         title={title}
       />
 
-      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
         onSubmit={(event) => {
           event.preventDefault();
-          event.stopPropagation();
 
           if (form.state.isSubmitting || saveInFlightRef.current) {
             return;

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -286,9 +286,13 @@ export function ExpenseEditor({
         title={title}
       />
 
+      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
-        action={() => {
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+
           if (form.state.isSubmitting || saveInFlightRef.current) {
             return;
           }

--- a/packages/pwa/src/routes/join.tsx
+++ b/packages/pwa/src/routes/join.tsx
@@ -153,12 +153,10 @@ function Join() {
         </div>
 
         {/* Secondary action: Manual entry */}
-        {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
         <form
           id={formId}
           onSubmit={(event) => {
             event.preventDefault();
-            event.stopPropagation();
             void form.handleSubmit();
           }}
           className="container mt-6 flex flex-col gap-4 px-4"

--- a/packages/pwa/src/routes/join.tsx
+++ b/packages/pwa/src/routes/join.tsx
@@ -153,9 +153,12 @@ function Join() {
         </div>
 
         {/* Secondary action: Manual entry */}
+        {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
         <form
           id={formId}
-          action={() => {
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
             void form.handleSubmit();
           }}
           className="container mt-6 flex flex-col gap-4 px-4"

--- a/packages/pwa/src/routes/migrate_.tricount/-components/IdleState.tsx
+++ b/packages/pwa/src/routes/migrate_.tricount/-components/IdleState.tsx
@@ -60,9 +60,12 @@ export function IdleState({ onSubmit }: { onSubmit: (values: MigrateParams) => v
 
       <div className="h-2" />
 
+      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
-        action={() => {
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
           void form.handleSubmit();
         }}
         className="container mt-4 flex flex-col gap-6 px-4"

--- a/packages/pwa/src/routes/migrate_.tricount/-components/IdleState.tsx
+++ b/packages/pwa/src/routes/migrate_.tricount/-components/IdleState.tsx
@@ -60,12 +60,10 @@ export function IdleState({ onSubmit }: { onSubmit: (values: MigrateParams) => v
 
       <div className="h-2" />
 
-      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
         onSubmit={(event) => {
           event.preventDefault();
-          event.stopPropagation();
           void form.handleSubmit();
         }}
         className="container mt-4 flex flex-col gap-6 px-4"

--- a/packages/pwa/src/routes/new/route.tsx
+++ b/packages/pwa/src/routes/new/route.tsx
@@ -133,9 +133,12 @@ function New() {
         }
       />
 
+      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
-        action={() => {
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
           void form.handleSubmit();
         }}
         className="container mt-4 flex flex-col gap-6 px-4"

--- a/packages/pwa/src/routes/new/route.tsx
+++ b/packages/pwa/src/routes/new/route.tsx
@@ -133,12 +133,10 @@ function New() {
         }
       />
 
-      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
         onSubmit={(event) => {
           event.preventDefault();
-          event.stopPropagation();
           void form.handleSubmit();
         }}
         className="container mt-4 flex flex-col gap-6 px-4"

--- a/packages/pwa/src/routes/party_.$partyId.settings/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.settings/route.tsx
@@ -129,7 +129,7 @@ function PartySettings() {
         }
       />
 
-      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form to stale defaults after saving settings. */}
+      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
         onSubmit={(event) => {

--- a/packages/pwa/src/routes/party_.$partyId.settings/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.settings/route.tsx
@@ -129,12 +129,10 @@ function PartySettings() {
         }
       />
 
-      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
         onSubmit={(event) => {
           event.preventDefault();
-          event.stopPropagation();
           void form.handleSubmit();
         }}
         className="container mt-4 flex flex-col gap-6 px-4"

--- a/packages/pwa/src/routes/party_.$partyId.who.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.who.tsx
@@ -117,12 +117,10 @@ function Who() {
         </form.Subscribe>
       </div>
 
-      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
         onSubmit={(event) => {
           event.preventDefault();
-          event.stopPropagation();
           void form.handleSubmit();
         }}
         className="container mt-2 flex flex-col gap-4 px-2"

--- a/packages/pwa/src/routes/party_.$partyId.who.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.who.tsx
@@ -117,9 +117,12 @@ function Who() {
         </form.Subscribe>
       </div>
 
+      {/* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */}
       <form
         id={formId}
-        action={() => {
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
           void form.handleSubmit();
         }}
         className="container mt-2 flex flex-col gap-4 px-2"

--- a/packages/pwa/src/routes/reset-password.tsx
+++ b/packages/pwa/src/routes/reset-password.tsx
@@ -104,9 +104,12 @@ function ResetPassword() {
             </Button>
           </div>
         ) : (
+          /* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */
           <form
             id={formId}
-            action={() => {
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
               void form.handleSubmit();
             }}
             className="flex flex-col gap-4"

--- a/packages/pwa/src/routes/reset-password.tsx
+++ b/packages/pwa/src/routes/reset-password.tsx
@@ -104,12 +104,10 @@ function ResetPassword() {
             </Button>
           </div>
         ) : (
-          /* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */
           <form
             id={formId}
             onSubmit={(event) => {
               event.preventDefault();
-              event.stopPropagation();
               void form.handleSubmit();
             }}
             className="flex flex-col gap-4"

--- a/packages/pwa/src/routes/settings.tsx
+++ b/packages/pwa/src/routes/settings.tsx
@@ -326,12 +326,10 @@ function SettingsFormFields({
   localeOptions: LocaleOption[];
 }) {
   return (
-    /* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */
     <form
       id={formId}
       onSubmit={(event) => {
         event.preventDefault();
-        event.stopPropagation();
         void form.handleSubmit();
       }}
       className="pb-safe container mt-6 flex flex-col gap-6 px-4 pb-8"

--- a/packages/pwa/src/routes/settings.tsx
+++ b/packages/pwa/src/routes/settings.tsx
@@ -326,9 +326,14 @@ function SettingsFormFields({
   localeOptions: LocaleOption[];
 }) {
   return (
+    /* eslint-disable-next-line react-doctor/no-prevent-default -- React form actions reset TanStack Form fields after validation failures. */
     <form
       id={formId}
-      action={() => form.handleSubmit()}
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void form.handleSubmit();
+      }}
       className="pb-safe container mt-6 flex flex-col gap-6 px-4 pb-8"
     >
       <form.Field name="avatarId">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,8 @@ const formatIgnorePatterns = [".agents/**", ...ignorePatterns];
 const pwaReactDoctorRules = {
   ...RECOMMENDED_REACT_DOCTOR_RULES,
   "react-doctor/no-multi-comp": "off" as const,
+  // TanStack Form handles submission in JS and requires cancelling the native browser submit.
+  "react-doctor/no-prevent-default": "off" as const,
 };
 
 function rootAppCommandGuard() {


### PR DESCRIPTION
## Summary
- Replace React form `action` submissions in TanStack-backed PWA forms with the documented/previously working `onSubmit` + `preventDefault()` + `form.handleSubmit()` pattern so validation failures do not reset draft field state.
- Apply the submit fix across create party, join, Tricount import, reset password, user settings, party settings, expense editor, and who-are-you forms.
- Disable `react-doctor/no-prevent-default` centrally for this project because these TanStack Form screens intentionally cancel native browser submission; remove the repeated per-form inline disables and unnecessary `stopPropagation()` calls.
- Add per-screen Playwright regressions that invalid submissions preserve the user-entered values/options for new trizum, join, Tricount import, reset password, user settings, party settings, and expense editor.
- Add a patch changeset and refresh Lingui catalog references after the source-line changes.

## Testing
- `vp run check`
- `vp run test`
- `vp run build`
- `vp exec react-doctor --verbose --scope changed`
- `vp exec playwright test e2e/new-trizum.spec.ts e2e/join-trizum.spec.ts e2e/migrate-tricount.spec.ts e2e/reset-password.spec.ts e2e/settings.spec.ts e2e/expense-log.spec.ts --grep "keeps"`
- `vp exec playwright test e2e/expense-log.spec.ts --grep "keeps expense draft values"` (rerun after a WebKit seeded harness heartbeat during the combined run)
