### PR TITLE
fix(pwa): handle Android party back fallback

### DIFF
--- a/.changeset/android-party-back.md
+++ b/.changeset/android-party-back.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Keep Android back navigation inside a party from exiting the app when the party was opened directly on launch.

--- a/packages/pwa/src/lib/navigationHistory.test.ts
+++ b/packages/pwa/src/lib/navigationHistory.test.ts
@@ -6,6 +6,7 @@ import {
   preventDuplicateHistoryEntries,
   pushHistoryWithoutDuplicateEntry,
   shouldReplaceNavigation,
+  shouldNavigateToPartyListOnNativeBack,
 } from "./navigationHistory.ts";
 
 describe("navigationHistory", () => {
@@ -100,5 +101,53 @@ describe("navigationHistory", () => {
 
     expect(history.go).not.toHaveBeenCalled();
     expect(replaceFallback).toHaveBeenCalledOnce();
+  });
+
+  test("uses the party list as the native back fallback inside a party", () => {
+    expect(
+      shouldNavigateToPartyListOnNativeBack({
+        canGoBack: false,
+        pathname: "/party/abc123",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldNavigateToPartyListOnNativeBack({
+        canGoBack: false,
+        pathname: "/party/abc123/settings",
+      }),
+    ).toBe(true);
+  });
+
+  test("does not use the party list native back fallback when history is available", () => {
+    expect(
+      shouldNavigateToPartyListOnNativeBack({
+        canGoBack: true,
+        pathname: "/party/abc123",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not use the party list native back fallback outside a party", () => {
+    expect(
+      shouldNavigateToPartyListOnNativeBack({
+        canGoBack: false,
+        pathname: "/",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldNavigateToPartyListOnNativeBack({
+        canGoBack: false,
+        pathname: "/settings",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldNavigateToPartyListOnNativeBack({
+        canGoBack: false,
+        pathname: "/party-settings",
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/pwa/src/lib/navigationHistory.ts
+++ b/packages/pwa/src/lib/navigationHistory.ts
@@ -64,3 +64,13 @@ export function closeRouteState(
 
   replaceFallback();
 }
+
+export function shouldNavigateToPartyListOnNativeBack({
+  canGoBack,
+  pathname,
+}: {
+  canGoBack: boolean;
+  pathname: string;
+}) {
+  return !canGoBack && (pathname === "/party" || pathname.startsWith("/party/"));
+}

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -40,6 +40,7 @@ import { resolveNativeDeepLink } from "./lib/nativeDeepLinks.ts";
 import {
   preventDuplicateHistoryEntries,
   pushHistoryWithoutDuplicateEntry,
+  shouldNavigateToPartyListOnNativeBack,
 } from "./lib/navigationHistory.ts";
 import { createPartyFromMigrationData, type MigrationData } from "./models/migration.ts";
 import type { Party } from "./models/party.ts";
@@ -208,6 +209,13 @@ if (Capacitor.isNativePlatform()) {
   void App.addListener("backButton", ({ canGoBack }) => {
     if (canGoBack) {
       router.history.go(-1);
+    } else if (
+      shouldNavigateToPartyListOnNativeBack({
+        canGoBack,
+        pathname: router.state.location.pathname,
+      })
+    ) {
+      void router.navigate({ to: "/", replace: true });
     } else {
       void App.exitApp();
     }


### PR DESCRIPTION
## Description

Fixes Android native back navigation when trizum opens directly into the last party on launch. If Capacitor reports there is no WebView history and the current path is inside `/party/...`, the Android back gesture/button now replaces the current route with the party list instead of exiting the app.

The normal behavior is unchanged when WebView history exists or when the user is already outside a party.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable. This is an Android native navigation behavior fix with no UI changes.

## Additional Notes

The focused test command also passed: `vp test packages/pwa/src/lib/navigationHistory.test.ts`.
