### PR TITLE
chore(server): migrate Hono WebSocket adapter

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,6 @@
     "@automerge/automerge-repo": "catalog:",
     "@automerge/automerge-repo-network-websocket": "catalog:",
     "@hono/node-server": "catalog:",
-    "@hono/node-ws": "catalog:",
     "@kubiks/otel-drizzle": "catalog:",
     "@libsql/client": "catalog:",
     "@logtape/logtape": "catalog:",
@@ -47,11 +46,14 @@
     "drizzle-kit": "catalog:",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
+    "isomorphic-ws": "catalog:",
+    "ws": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@trizum/tsconfig": "workspace:*",
     "@types/node": "catalog:",
+    "@types/ws": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -7,12 +7,12 @@ import { NodeWSServerAdapter } from "@automerge/automerge-repo-network-websocket
 import * as os from "node:os";
 import path from "node:path";
 import { Hono } from "hono";
-import { serve, type ServerType } from "@hono/node-server";
-import { createNodeWebSocket } from "@hono/node-ws";
+import { serve, type ServerType, upgradeWebSocket } from "@hono/node-server";
 import { configureServerLogging, rootLogger as logger } from "./log.ts";
 import { withContext } from "@logtape/logtape";
 import { cors } from "hono/cors";
 import { fileURLToPath } from "node:url";
+import WebSocket from "isomorphic-ws";
 
 configureServerLogging();
 
@@ -28,17 +28,12 @@ export async function startServer() {
   await initializeAutomerge();
 
   const app = new Hono({});
-  const webSockets = createNodeWebSocket({
-    app,
-  });
+  const webSocketServer = new WebSocket.Server({ noServer: true });
 
   const hostname = os.hostname();
   const repo = new Repo({
     storage: new DrizzleSqliteStorageAdapter(db),
-    network: [
-      // @ts-expect-error - This is fine
-      new NodeWSServerAdapter(webSockets.wss),
-    ],
+    network: [new NodeWSServerAdapter(webSocketServer)],
 
     // TODO: supporting multiple servers or processes isn't supported yet
     peerId: `server:${hostname}` as PeerId,
@@ -107,7 +102,7 @@ export async function startServer() {
 
   app.get(
     "/sync",
-    webSockets.upgradeWebSocket(() => ({
+    upgradeWebSocket(() => ({
       onOpen: () => {
         logger.info("WebSocket connection opened");
       },
@@ -157,12 +152,12 @@ export async function startServer() {
     const server = serve(
       {
         fetch: app.fetch,
+        websocket: { server: webSocketServer },
         port,
         hostname: "0.0.0.0",
       },
       () => resolve(server),
     );
-    webSockets.injectWebSocket(server);
 
     process.on("SIGINT", () => {
       logger.info("SIGINT received, server is shutting down...");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,9 +88,6 @@ catalogs:
     '@hono/node-server':
       specifier: 2.0.8
       version: 2.0.8
-    '@hono/node-ws':
-      specifier: 1.3.1
-      version: 1.3.1
     '@internationalized/date':
       specifier: 3.12.2
       version: 3.12.2
@@ -169,6 +166,9 @@ catalogs:
     '@types/node':
       specifier: 24.13.2
       version: 24.13.2
+    '@types/ws':
+      specifier: 8.18.1
+      version: 8.18.1
     '@use-gesture/react':
       specifier: 10.3.1
       version: 10.3.1
@@ -244,6 +244,9 @@ catalogs:
     hono:
       specifier: 4.12.27
       version: 4.12.27
+    isomorphic-ws:
+      specifier: 5.0.0
+      version: 5.0.0
     jose:
       specifier: 6.2.3
       version: 6.2.3
@@ -349,6 +352,9 @@ catalogs:
     wrangler:
       specifier: 4.107.0
       version: 4.107.0
+    ws:
+      specifier: 8.21.0
+      version: 8.21.0
     zod:
       specifier: 4.4.3
       version: 4.4.3
@@ -868,9 +874,6 @@ importers:
       '@hono/node-server':
         specifier: 'catalog:'
         version: 2.0.8(hono@4.12.27)
-      '@hono/node-ws':
-        specifier: 'catalog:'
-        version: 1.3.1(@hono/node-server@2.0.8(hono@4.12.27))(hono@4.12.27)
       '@kubiks/otel-drizzle':
         specifier: 'catalog:'
         version: 2.1.0(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.29.2))
@@ -901,6 +904,12 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.12.27
+      isomorphic-ws:
+        specifier: 'catalog:'
+        version: 5.0.0(ws@8.21.0)
+      ws:
+        specifier: 'catalog:'
+        version: 8.21.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -911,6 +920,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      '@types/ws':
+        specifier: 'catalog:'
+        version: 8.18.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2126,13 +2138,6 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
-
-  '@hono/node-ws@1.3.1':
-    resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      '@hono/node-server': ^1.19.11
-      hono: ^4.6.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -10535,15 +10540,6 @@ snapshots:
   '@hono/node-server@2.0.8(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
-
-  '@hono/node-ws@1.3.1(@hono/node-server@2.0.8(hono@4.12.27))(hono@4.12.27)':
-    dependencies:
-      '@hono/node-server': 2.0.8(hono@4.12.27)
-      hono: 4.12.27
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@humanfs/core@0.19.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,6 @@ catalog:
   "@fontsource-variable/fira-code": 5.2.7
   "@fontsource-variable/inter": 5.2.8
   "@hono/node-server": 2.0.8
-  "@hono/node-ws": 1.3.1
   "@internationalized/date": 3.12.2
   "@kubiks/otel-drizzle": 2.1.0
   "@libsql/client": 0.17.4
@@ -91,6 +90,7 @@ catalog:
   "@types/node": 24.13.2
   "@types/react": npm:types-react@rc
   "@types/react-dom": npm:types-react-dom@rc
+  "@types/ws": 8.18.1
   "@use-gesture/react": 10.3.1
   "@vite-pwa/assets-generator": 1.0.2
   "@vitejs/plugin-react": 6.0.3
@@ -116,6 +116,7 @@ catalog:
   exifr: 7.1.3
   heic-to: 1.5.2
   hono: 4.12.27
+  isomorphic-ws: 5.0.0
   jose: 6.2.3
   lucide-static: 1.23.0
   mathjs: 15.2.0
@@ -154,6 +155,7 @@ catalog:
   workbox-build: 7.4.1
   workbox-window: 7.4.1
   wrangler: 4.107.0
+  ws: 8.21.0
   tsx: 4.23.0
   zod: 4.4.3
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Description

Migrates the server WebSocket wiring away from deprecated `@hono/node-ws` to `@hono/node-server` v2's built-in `upgradeWebSocket` support.

The server now creates a shared `isomorphic-ws` server with `noServer: true`, passes it to Hono through `serve({ websocket })`, and gives the same server to Automerge's `NodeWSServerAdapter`. This removes the old `injectWebSocket` path and the TypeScript suppression around the Automerge adapter.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (dependency maintenance)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (not applicable; no new functionality)
- [x] I've run `vp run lingui:extract` (no new strings; pre-commit hook also ran it)
- [x] I've added a changeset (not applicable; internal dependency migration)

## Screenshots

Not applicable; no UI changes.

## Additional Notes

- Removed `@hono/node-ws` from the server dependency graph and workspace catalog.
- Added explicit `ws`, `isomorphic-ws`, and `@types/ws` dependencies for the server package.
- Also smoke tested a local server with a temp SQLite DB: `/health` returned OK and `ws://127.0.0.1:37641/sync` opened and closed successfully.
