### PR TITLE
fix(pwa): anchor expense presence avatars to editor fields

### DIFF
--- a/.changeset/bright-avatars-look.md
+++ b/.changeset/bright-avatars-look.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Fix realtime editor avatars jumping to the top of the screen when collaborators focus amount fields.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -538,7 +538,7 @@ msgstr "Clear search"
 msgid "Close"
 msgstr "Close"
 
-#: src/components/CurrencyField.tsx:80
+#: src/components/CurrencyField.tsx:91
 msgid "Close calculator"
 msgstr "Close calculator"
 
@@ -1770,7 +1770,7 @@ msgstr "Only your own debt can be transferred"
 msgid "Open archived parties"
 msgstr "Open archived parties"
 
-#: src/components/CurrencyField.tsx:80
+#: src/components/CurrencyField.tsx:91
 msgid "Open calculator"
 msgstr "Open calculator"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -1027,7 +1027,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:976
+#: src/components/ExpenseEditor.tsx:977
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1072,7 +1072,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:951
+#: src/components/ExpenseEditor.tsx:952
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -1198,7 +1198,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:853
+#: src/components/ExpenseEditor.tsx:854
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -2033,7 +2033,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:871
+#: src/components/ExpenseEditor.tsx:872
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -2110,7 +2110,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1068
+#: src/components/ExpenseEditor.tsx:1069
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2290,7 +2290,7 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:857
+#: src/components/ExpenseEditor.tsx:858
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
@@ -2538,8 +2538,8 @@ msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:996
-#: src/components/ExpenseEditor.tsx:1010
+#: src/components/ExpenseEditor.tsx:997
+#: src/components/ExpenseEditor.tsx:1011
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2837,14 +2837,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:896
+#: src/components/ExpenseEditor.tsx:897
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1005
-#: src/components/ExpenseEditor.tsx:1022
+#: src/components/ExpenseEditor.tsx:1006
+#: src/components/ExpenseEditor.tsx:1023
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2857,7 +2857,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:936
+#: src/components/ExpenseEditor.tsx:937
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -2942,7 +2942,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1057
+#: src/components/ExpenseEditor.tsx:1058
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -987,7 +987,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:112
-#: src/components/ExpenseEditor.tsx:976
+#: src/components/ExpenseEditor.tsx:977
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1028,7 +1028,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:951
+#: src/components/ExpenseEditor.tsx:952
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -1150,7 +1150,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:853
+#: src/components/ExpenseEditor.tsx:854
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -1965,7 +1965,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:871
+#: src/components/ExpenseEditor.tsx:872
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -2038,7 +2038,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1068
+#: src/components/ExpenseEditor.tsx:1069
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2218,7 +2218,7 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:857
+#: src/components/ExpenseEditor.tsx:858
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
@@ -2462,8 +2462,8 @@ msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:159
 #: src/components/AvatarPicker.tsx:174
-#: src/components/ExpenseEditor.tsx:996
-#: src/components/ExpenseEditor.tsx:1010
+#: src/components/ExpenseEditor.tsx:997
+#: src/components/ExpenseEditor.tsx:1011
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2749,14 +2749,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:896
+#: src/components/ExpenseEditor.tsx:897
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:168
 #: src/components/AvatarPicker.tsx:186
-#: src/components/ExpenseEditor.tsx:1005
-#: src/components/ExpenseEditor.tsx:1022
+#: src/components/ExpenseEditor.tsx:1006
+#: src/components/ExpenseEditor.tsx:1023
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2764,7 +2764,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:936
+#: src/components/ExpenseEditor.tsx:937
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2845,7 +2845,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1057
+#: src/components/ExpenseEditor.tsx:1058
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -514,7 +514,7 @@ msgstr "Borrar búsqueda"
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/components/CurrencyField.tsx:80
+#: src/components/CurrencyField.tsx:91
 msgid "Close calculator"
 msgstr "Cerrar calculadora"
 
@@ -1714,7 +1714,7 @@ msgstr "Solo puedes transferir tus propias deudas"
 msgid "Open archived parties"
 msgstr "Abrir grupos archivados"
 
-#: src/components/CurrencyField.tsx:80
+#: src/components/CurrencyField.tsx:91
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 

--- a/packages/pwa/src/components/CalculatorToolbar.tsx
+++ b/packages/pwa/src/components/CalculatorToolbar.tsx
@@ -490,7 +490,7 @@ export function CalculatorToolbar({
       ref={toolbarRef}
       role="application"
       aria-label={t`Calculator`}
-      data-presence-element-id={presenceElementId}
+      data-presence-proxy-element-id={presenceElementId}
       className={
         isLargeScreen && popoverPosition
           ? "border-accent-300 dark:border-accent-700 dark:bg-accent-900 fixed z-50 rounded-lg border bg-white shadow-lg"

--- a/packages/pwa/src/components/CurrencyField.tsx
+++ b/packages/pwa/src/components/CurrencyField.tsx
@@ -1,11 +1,12 @@
 import { t } from "@lingui/core/macro";
 import { AppCurrencyField } from "#src/ui/fields/TextField.js";
-import React, { use, useRef } from "react";
+import React, { use, useRef, useState } from "react";
 import { CurrencyContext } from "./CurrencyContext";
 import { useCalculatorMode } from "#src/hooks/useCalculatorMode.ts";
 import { CalculatorToolbar } from "./CalculatorToolbar";
 import { IconButton } from "#src/ui/IconButton.js";
 import { cn } from "#src/ui/utils.js";
+import { getPresenceElementIdFromTarget } from "./presencePosition.ts";
 
 export type CurrencyFieldProps = React.ComponentProps<typeof AppCurrencyField> & {
   calculator?: boolean;
@@ -43,10 +44,13 @@ function CurrencyFieldWithCalculator({
   calculatorButtonClassName?: string;
   autoOpenCalculator?: boolean;
 }) {
-  const presenceElementId =
+  const configuredPresenceElementId =
     (props as { "data-presence-element-id"?: string })["data-presence-element-id"] ??
     (props as { "data-presence-proxy-element-id"?: string })["data-presence-proxy-element-id"];
   const fieldContainerRef = useRef<HTMLDivElement>(null);
+  const [calculatorPresenceElementId, setCalculatorPresenceElementId] = useState<string | null>(
+    configuredPresenceElementId ?? null,
+  );
   const [state, actions] = useCalculatorMode({
     value: props.value ?? 0,
     onChange: (value) => props.onChange?.(value),
@@ -54,11 +58,18 @@ function CurrencyFieldWithCalculator({
     currency: props.currency,
   });
 
+  function activateCalculator() {
+    setCalculatorPresenceElementId(
+      configuredPresenceElementId ?? getPresenceElementIdFromTarget(fieldContainerRef.current),
+    );
+    actions.activate();
+  }
+
   function handleFocus(event: React.FocusEvent<HTMLInputElement>) {
     props.onFocus?.(event);
 
     if (autoOpenCalculator && !state.isActive) {
-      actions.activate();
+      activateCalculator();
     }
   }
 
@@ -81,7 +92,7 @@ function CurrencyFieldWithCalculator({
         color="transparent"
         className={calculatorButtonClassName ?? "absolute right-1 bottom-1 h-8 w-8"}
         iconClassName="size-4"
-        onPress={state.isActive ? actions.deactivate : actions.activate}
+        onPress={state.isActive ? actions.deactivate : activateCalculator}
       />
 
       {state.isActive && (
@@ -96,7 +107,7 @@ function CurrencyFieldWithCalculator({
           onClear={actions.clear}
           onDismiss={actions.deactivate}
           fieldContainerRef={fieldContainerRef}
-          presenceElementId={presenceElementId}
+          presenceElementId={calculatorPresenceElementId ?? configuredPresenceElementId}
           previewValue={state.previewValue}
           currency={props.currency}
         />

--- a/packages/pwa/src/components/CurrencyField.tsx
+++ b/packages/pwa/src/components/CurrencyField.tsx
@@ -43,9 +43,9 @@ function CurrencyFieldWithCalculator({
   calculatorButtonClassName?: string;
   autoOpenCalculator?: boolean;
 }) {
-  const presenceElementId = (props as { "data-presence-element-id"?: string })[
-    "data-presence-element-id"
-  ];
+  const presenceElementId =
+    (props as { "data-presence-element-id"?: string })["data-presence-element-id"] ??
+    (props as { "data-presence-proxy-element-id"?: string })["data-presence-proxy-element-id"];
   const fieldContainerRef = useRef<HTMLDivElement>(null);
   const [state, actions] = useCalculatorMode({
     value: props.value ?? 0,

--- a/packages/pwa/src/components/CurrencyField.tsx
+++ b/packages/pwa/src/components/CurrencyField.tsx
@@ -90,6 +90,7 @@ function CurrencyFieldWithCalculator({
         icon={state.isActive ? "lucide.x" : "lucide.calculator"}
         aria-label={state.isActive ? t`Close calculator` : t`Open calculator`}
         color="transparent"
+        data-presence-proxy-element-id={configuredPresenceElementId}
         className={calculatorButtonClassName ?? "absolute right-1 bottom-1 h-8 w-8"}
         iconClassName="size-4"
         onPress={state.isActive ? actions.deactivate : activateCalculator}

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -806,6 +806,7 @@ function ParticipantSplitAmountField({
       }}
       inputMode="decimal"
       aria-label={ariaLabel}
+      data-presence-proxy-element-id={`participant-${participantId}`}
     />
   );
 }

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vite-plus/test";
-import { getPresenceBubblePosition } from "./presencePosition.ts";
+import { getPresenceBubblePosition, getPresenceElementIdFromTarget } from "./presencePosition.ts";
 
 function createElement({
   dataset,
@@ -23,6 +23,19 @@ function createElement({
   } as HTMLElement;
 }
 
+function createPresenceTarget({
+  dataset,
+  parentElement = null,
+}: {
+  dataset?: Partial<DOMStringMap>;
+  parentElement?: HTMLElement | null;
+}) {
+  return {
+    dataset,
+    parentElement,
+  } as HTMLElement;
+}
+
 describe("getPresenceBubblePosition", () => {
   test("positions the bubble relative to the overlay instead of the element offset parent", () => {
     const overlay = createElement({ left: 40, right: 440, top: 100 });
@@ -40,5 +53,25 @@ describe("getPresenceBubblePosition", () => {
       left: 310,
       top: 166,
     });
+  });
+});
+
+describe("getPresenceElementIdFromTarget", () => {
+  test("uses a proxy presence id when a portaled control represents another anchor", () => {
+    const toolbar = createPresenceTarget({
+      dataset: { presenceProxyElementId: "participant-alice" },
+    });
+    const button = createPresenceTarget({ parentElement: toolbar });
+
+    expect(getPresenceElementIdFromTarget(button)).toBe("participant-alice");
+  });
+
+  test("finds the nearest parent presence id when the target has none", () => {
+    const row = createPresenceTarget({
+      dataset: { presenceElementId: "participant-alice" },
+    });
+    const input = createPresenceTarget({ parentElement: row });
+
+    expect(getPresenceElementIdFromTarget(input)).toBe("participant-alice");
   });
 });

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
@@ -66,6 +66,16 @@ describe("getPresenceElementIdFromTarget", () => {
     expect(getPresenceElementIdFromTarget(button)).toBe("participant-alice");
   });
 
+  test("walks from icon targets to a parent proxy presence id", () => {
+    const toolbar = createPresenceTarget({
+      dataset: { presenceProxyElementId: "participant-alice" },
+    });
+    const button = createPresenceTarget({ parentElement: toolbar });
+    const icon = { parentElement: button } as Element;
+
+    expect(getPresenceElementIdFromTarget(icon)).toBe("participant-alice");
+  });
+
   test("finds the nearest parent presence id when the target has none", () => {
     const row = createPresenceTarget({
       dataset: { presenceElementId: "participant-alice" },

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vite-plus/test";
-import { getPresenceBubblePosition, getPresenceElementIdFromTarget } from "./presencePosition.ts";
+import {
+  arePresenceBubblePositionsEqual,
+  getPresenceBubblePosition,
+  getPresenceElementIdFromTarget,
+} from "./presencePosition.ts";
 
 function createElement({
   dataset,
@@ -53,6 +57,48 @@ describe("getPresenceBubblePosition", () => {
       left: 310,
       top: 166,
     });
+  });
+
+  test("reflects anchor position changes without relying on element size changes", () => {
+    const overlay = createElement({ left: 40, right: 440, top: 100 });
+    let anchorTop = 260;
+    let anchorRight = 360;
+    const amountField = {
+      dataset: {
+        presenceOffsetLeft: "-10",
+        presenceOffsetTop: "6",
+      },
+      getBoundingClientRect: () =>
+        ({
+          right: anchorRight,
+          top: anchorTop,
+        }) as DOMRectReadOnly,
+    } as unknown as HTMLElement;
+
+    expect(getPresenceBubblePosition(amountField, overlay)).toEqual({
+      left: 310,
+      top: 166,
+    });
+
+    anchorTop = 300;
+    anchorRight = 380;
+
+    expect(getPresenceBubblePosition(amountField, overlay)).toEqual({
+      left: 330,
+      top: 206,
+    });
+  });
+});
+
+describe("arePresenceBubblePositionsEqual", () => {
+  test("detects unchanged and changed bubble positions", () => {
+    expect(arePresenceBubblePositionsEqual({ left: 10, top: 20 }, { left: 10, top: 20 })).toBe(
+      true,
+    );
+    expect(arePresenceBubblePositionsEqual({ left: 10, top: 20 }, { left: 10, top: 21 })).toBe(
+      false,
+    );
+    expect(arePresenceBubblePositionsEqual(null, { left: 10, top: 20 })).toBe(false);
   });
 });
 

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
@@ -103,6 +103,14 @@ describe("arePresenceBubblePositionsEqual", () => {
 });
 
 describe("getPresenceElementIdFromTarget", () => {
+  test("uses a proxy presence id directly on a calculator opener", () => {
+    const button = createPresenceTarget({
+      dataset: { presenceProxyElementId: "amount" },
+    });
+
+    expect(getPresenceElementIdFromTarget(button)).toBe("amount");
+  });
+
   test("uses a proxy presence id when a portaled control represents another anchor", () => {
     const toolbar = createPresenceTarget({
       dataset: { presenceProxyElementId: "participant-alice" },

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vite-plus/test";
+import { getPresenceBubblePosition } from "./presencePosition.ts";
+
+function createElement({
+  dataset,
+  left,
+  right,
+  top,
+}: {
+  dataset?: Partial<DOMStringMap>;
+  left: number;
+  right: number;
+  top: number;
+}) {
+  return {
+    dataset,
+    getBoundingClientRect: () =>
+      ({
+        left,
+        right,
+        top,
+      }) as DOMRectReadOnly,
+  } as HTMLElement;
+}
+
+describe("getPresenceBubblePosition", () => {
+  test("positions the bubble relative to the overlay instead of the element offset parent", () => {
+    const overlay = createElement({ left: 40, right: 440, top: 100 });
+    const amountField = createElement({
+      dataset: {
+        presenceOffsetLeft: "-10",
+        presenceOffsetTop: "6",
+      },
+      left: 72,
+      right: 360,
+      top: 260,
+    });
+
+    expect(getPresenceBubblePosition(amountField, overlay)).toEqual({
+      left: 310,
+      top: 166,
+    });
+  });
+});

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.tsx
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.tsx
@@ -13,7 +13,7 @@ import { Avatar } from "#src/ui/Avatar.tsx";
 import { getLogger } from "#src/lib/log.ts";
 import type { DocHandle, DocHandleEphemeralMessagePayload } from "@automerge/automerge-repo";
 import { Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { getPresenceBubblePosition } from "./presencePosition.ts";
+import { getPresenceBubblePosition, getPresenceElementIdFromTarget } from "./presencePosition.ts";
 
 const logger = getLogger("components", "RealtimeExpenseEditorPresence");
 
@@ -166,7 +166,7 @@ export function RealtimeExpenseEditorPresence({ expenseId }: RealtimeExpenseEdit
       const target = event.target as HTMLElement;
 
       const isWithinDialog = findPopoverFormElementFromTarget(target);
-      const presenceElementId = findPresenceElementFromTarget(target);
+      const presenceElementId = getPresenceElementIdFromTarget(target);
 
       if (presenceElementId) {
         broadcastPresenceUpdate({
@@ -226,7 +226,7 @@ export function RealtimeExpenseEditorPresence({ expenseId }: RealtimeExpenseEdit
     function onWindowFocus() {
       // Grab element in focus
       const element = document.activeElement as HTMLElement;
-      const presenceElementId = findPresenceElementFromTarget(element);
+      const presenceElementId = getPresenceElementIdFromTarget(element);
 
       if (presenceElementId) {
         broadcastPresenceUpdate({
@@ -380,26 +380,6 @@ function AvatarWrapper({
       }}
     />
   );
-}
-
-function findPresenceElementFromTarget(target: HTMLElement): string | null {
-  if (!target) {
-    return null;
-  }
-
-  // Check if the target has a data-presence-element-id attribute
-  const presenceElementId =
-    target.dataset?.presenceElementId ?? target.dataset?.presenceProxyElementId;
-
-  if (presenceElementId) {
-    return presenceElementId;
-  }
-
-  if (target.parentElement) {
-    return findPresenceElementFromTarget(target.parentElement);
-  }
-
-  return null;
 }
 
 function findPopoverFormElementFromTarget(target: HTMLElement): HTMLElement | null {

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.tsx
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.tsx
@@ -162,9 +162,7 @@ export function RealtimeExpenseEditorPresence({ expenseId }: RealtimeExpenseEdit
   }, [handle, expenseId, participant.id]);
 
   useEffect(() => {
-    function onClick(event: MouseEvent) {
-      const target = event.target as HTMLElement;
-
+    function updatePresenceFromTarget(target: Element | null, { clearOnMiss = true } = {}) {
       const isWithinDialog = findPopoverFormElementFromTarget(target);
       const presenceElementId = getPresenceElementIdFromTarget(target);
 
@@ -180,7 +178,7 @@ export function RealtimeExpenseEditorPresence({ expenseId }: RealtimeExpenseEdit
         return;
       }
 
-      if (isWithinDialog || presenceElementId) {
+      if (isWithinDialog || !clearOnMiss) {
         return;
       }
 
@@ -194,7 +192,25 @@ export function RealtimeExpenseEditorPresence({ expenseId }: RealtimeExpenseEdit
       presenceElementIdRef.current = null;
     }
 
+    function getElementFromEventTarget(target: EventTarget | null) {
+      return target instanceof Element ? target : null;
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      updatePresenceFromTarget(getElementFromEventTarget(event.target));
+    }
+
+    function onClick(event: MouseEvent) {
+      updatePresenceFromTarget(getElementFromEventTarget(event.target));
+    }
+
+    function onFocusIn(event: FocusEvent) {
+      updatePresenceFromTarget(getElementFromEventTarget(event.target), { clearOnMiss: false });
+    }
+
+    window.addEventListener("pointerdown", onPointerDown, { capture: true });
     window.addEventListener("click", onClick, { capture: true });
+    window.addEventListener("focusin", onFocusIn, { capture: true });
 
     // visibility change listener
     function onVisibilityChange() {
@@ -256,7 +272,9 @@ export function RealtimeExpenseEditorPresence({ expenseId }: RealtimeExpenseEdit
     }, 5000);
 
     return () => {
+      window.removeEventListener("pointerdown", onPointerDown, { capture: true });
       window.removeEventListener("click", onClick, { capture: true });
+      window.removeEventListener("focusin", onFocusIn, { capture: true });
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("blur", onWindowBlur);
       clearInterval(interval);
@@ -382,7 +400,7 @@ function AvatarWrapper({
   );
 }
 
-function findPopoverFormElementFromTarget(target: HTMLElement): HTMLElement | null {
+function findPopoverFormElementFromTarget(target: Element | null): Element | null {
   if (!target) {
     return null;
   }

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.tsx
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.tsx
@@ -13,7 +13,12 @@ import { Avatar } from "#src/ui/Avatar.tsx";
 import { getLogger } from "#src/lib/log.ts";
 import type { DocHandle, DocHandleEphemeralMessagePayload } from "@automerge/automerge-repo";
 import { Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { getPresenceBubblePosition, getPresenceElementIdFromTarget } from "./presencePosition.ts";
+import {
+  arePresenceBubblePositionsEqual,
+  getPresenceBubblePosition,
+  getPresenceElementIdFromTarget,
+  type PresenceBubblePosition,
+} from "./presencePosition.ts";
 
 const logger = getLogger("components", "RealtimeExpenseEditorPresence");
 
@@ -307,35 +312,43 @@ function Bubble({
   } | null>(null);
 
   useLayoutEffect(() => {
-    const element = document.querySelector<HTMLElement>(
-      `[data-presence-element-id="${presence.elementId}"]`,
-    );
-    const overlayElement = overlayRef.current;
+    const selector = `[data-presence-element-id="${presence.elementId}"]`;
+    let currentPosition: PresenceBubblePosition | null = null;
+    let frameId: number | null = null;
 
-    if (!element || !overlayElement) {
-      return;
+    function setNextPosition(nextPosition: PresenceBubblePosition | null) {
+      if (arePresenceBubblePositionsEqual(currentPosition, nextPosition)) {
+        return;
+      }
+
+      currentPosition = nextPosition;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Presence bubbles need committed DOM measurements.
+      setPosition(nextPosition);
     }
-
-    const targetElement = element;
-    const targetOverlayElement = overlayElement;
 
     function updatePosition() {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Presence bubbles need committed DOM measurements.
-      setPosition(getPresenceBubblePosition(targetElement, targetOverlayElement));
+      const element = document.querySelector<HTMLElement>(selector);
+      const overlayElement = overlayRef.current;
+
+      if (!element || !overlayElement) {
+        setNextPosition(null);
+        return;
+      }
+
+      setNextPosition(getPresenceBubblePosition(element, overlayElement));
     }
 
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
+    function updatePositionOnAnimationFrame() {
+      updatePosition();
+      frameId = window.requestAnimationFrame(updatePositionOnAnimationFrame);
+    }
 
-    const resizeObserver = "ResizeObserver" in window ? new ResizeObserver(updatePosition) : null;
-    resizeObserver?.observe(targetElement);
-    resizeObserver?.observe(targetOverlayElement);
+    updatePositionOnAnimationFrame();
 
     return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-      resizeObserver?.disconnect();
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
     };
   }, [overlayRef, presence.elementId]);
 

--- a/packages/pwa/src/components/RealtimeExpenseEditorPresence.tsx
+++ b/packages/pwa/src/components/RealtimeExpenseEditorPresence.tsx
@@ -13,6 +13,7 @@ import { Avatar } from "#src/ui/Avatar.tsx";
 import { getLogger } from "#src/lib/log.ts";
 import type { DocHandle, DocHandleEphemeralMessagePayload } from "@automerge/automerge-repo";
 import { Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { getPresenceBubblePosition } from "./presencePosition.ts";
 
 const logger = getLogger("components", "RealtimeExpenseEditorPresence");
 
@@ -82,6 +83,7 @@ export function RealtimeExpenseEditorPresence({ expenseId }: RealtimeExpenseEdit
     required: true,
   });
   const participant = useCurrentParticipant();
+  const overlayRef = useRef<HTMLDivElement>(null);
   const presenceElementIdRef = useRef<string | null>(null);
   const [visiblePresence, setVisiblePresence] = useState<ExpenseParticipantPresence[]>([]);
   const lastSentElementIdRef = useRef<string | null>(null);
@@ -262,17 +264,23 @@ export function RealtimeExpenseEditorPresence({ expenseId }: RealtimeExpenseEdit
   }, [expenseId, handle, participant.id]);
 
   return (
-    <div className="pointer-events-none absolute inset-0 touch-none">
+    <div ref={overlayRef} className="pointer-events-none absolute inset-0 touch-none">
       {visiblePresence.map((presence) => (
         <Suspense key={presence.participantId}>
-          <Bubble presence={presence} />
+          <Bubble presence={presence} overlayRef={overlayRef} />
         </Suspense>
       ))}
     </div>
   );
 }
 
-function Bubble({ presence }: { presence: ExpenseParticipantPresence }) {
+function Bubble({
+  presence,
+  overlayRef,
+}: {
+  presence: ExpenseParticipantPresence;
+  overlayRef: React.RefObject<HTMLDivElement | null>;
+}) {
   const { party } = useCurrentParty();
   const participant = party.participants[presence.participantId];
   const [position, setPosition] = useState<{
@@ -281,25 +289,37 @@ function Bubble({ presence }: { presence: ExpenseParticipantPresence }) {
   } | null>(null);
 
   useLayoutEffect(() => {
-    const element = document.querySelector(
+    const element = document.querySelector<HTMLElement>(
       `[data-presence-element-id="${presence.elementId}"]`,
-    ) as HTMLElement;
+    );
+    const overlayElement = overlayRef.current;
 
-    if (!element) {
+    if (!element || !overlayElement) {
       return;
     }
 
-    const width = element.offsetWidth;
+    const targetElement = element;
+    const targetOverlayElement = overlayElement;
 
-    const offsetTop = Number(element.dataset?.presenceOffsetTop ?? 0);
-    const offsetLeft = Number(element.dataset?.presenceOffsetLeft ?? 0);
+    function updatePosition() {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Presence bubbles need committed DOM measurements.
+      setPosition(getPresenceBubblePosition(targetElement, targetOverlayElement));
+    }
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- This is fine for now
-    setPosition({
-      top: element.offsetTop + offsetTop,
-      left: element.offsetLeft + width + offsetLeft,
-    });
-  }, [presence.elementId]);
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    const resizeObserver = "ResizeObserver" in window ? new ResizeObserver(updatePosition) : null;
+    resizeObserver?.observe(targetElement);
+    resizeObserver?.observe(targetOverlayElement);
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+      resizeObserver?.disconnect();
+    };
+  }, [overlayRef, presence.elementId]);
 
   if (!position) {
     return null;
@@ -368,7 +388,8 @@ function findPresenceElementFromTarget(target: HTMLElement): string | null {
   }
 
   // Check if the target has a data-presence-element-id attribute
-  const presenceElementId = target.dataset?.presenceElementId;
+  const presenceElementId =
+    target.dataset?.presenceElementId ?? target.dataset?.presenceProxyElementId;
 
   if (presenceElementId) {
     return presenceElementId;

--- a/packages/pwa/src/components/presencePosition.ts
+++ b/packages/pwa/src/components/presencePosition.ts
@@ -9,3 +9,18 @@ export function getPresenceBubblePosition(element: HTMLElement, overlayElement: 
     left: elementRect.right - overlayRect.left + offsetLeft,
   };
 }
+
+export function getPresenceElementIdFromTarget(target: HTMLElement | null): string | null {
+  if (!target) {
+    return null;
+  }
+
+  const presenceElementId =
+    target.dataset?.presenceElementId ?? target.dataset?.presenceProxyElementId;
+
+  if (presenceElementId) {
+    return presenceElementId;
+  }
+
+  return getPresenceElementIdFromTarget(target.parentElement);
+}

--- a/packages/pwa/src/components/presencePosition.ts
+++ b/packages/pwa/src/components/presencePosition.ts
@@ -1,0 +1,11 @@
+export function getPresenceBubblePosition(element: HTMLElement, overlayElement: HTMLElement) {
+  const elementRect = element.getBoundingClientRect();
+  const overlayRect = overlayElement.getBoundingClientRect();
+  const offsetTop = Number(element.dataset?.presenceOffsetTop ?? 0);
+  const offsetLeft = Number(element.dataset?.presenceOffsetLeft ?? 0);
+
+  return {
+    top: elementRect.top - overlayRect.top + offsetTop,
+    left: elementRect.right - overlayRect.left + offsetLeft,
+  };
+}

--- a/packages/pwa/src/components/presencePosition.ts
+++ b/packages/pwa/src/components/presencePosition.ts
@@ -10,13 +10,13 @@ export function getPresenceBubblePosition(element: HTMLElement, overlayElement: 
   };
 }
 
-export function getPresenceElementIdFromTarget(target: HTMLElement | null): string | null {
+export function getPresenceElementIdFromTarget(target: Element | null): string | null {
   if (!target) {
     return null;
   }
 
-  const presenceElementId =
-    target.dataset?.presenceElementId ?? target.dataset?.presenceProxyElementId;
+  const dataset = "dataset" in target ? (target.dataset as DOMStringMap) : undefined;
+  const presenceElementId = dataset?.presenceElementId ?? dataset?.presenceProxyElementId;
 
   if (presenceElementId) {
     return presenceElementId;

--- a/packages/pwa/src/components/presencePosition.ts
+++ b/packages/pwa/src/components/presencePosition.ts
@@ -1,4 +1,12 @@
-export function getPresenceBubblePosition(element: HTMLElement, overlayElement: HTMLElement) {
+export interface PresenceBubblePosition {
+  top: number;
+  left: number;
+}
+
+export function getPresenceBubblePosition(
+  element: HTMLElement,
+  overlayElement: HTMLElement,
+): PresenceBubblePosition {
   const elementRect = element.getBoundingClientRect();
   const overlayRect = overlayElement.getBoundingClientRect();
   const offsetTop = Number(element.dataset?.presenceOffsetTop ?? 0);
@@ -8,6 +16,21 @@ export function getPresenceBubblePosition(element: HTMLElement, overlayElement: 
     top: elementRect.top - overlayRect.top + offsetTop,
     left: elementRect.right - overlayRect.left + offsetLeft,
   };
+}
+
+export function arePresenceBubblePositionsEqual(
+  first: PresenceBubblePosition | null,
+  second: PresenceBubblePosition | null,
+) {
+  if (first === second) {
+    return true;
+  }
+
+  if (!first || !second) {
+    return false;
+  }
+
+  return first.top === second.top && first.left === second.left;
 }
 
 export function getPresenceElementIdFromTarget(target: Element | null): string | null {


### PR DESCRIPTION
## Description

Fixes realtime expense editor presence avatars for calculator-backed amount fields and moving anchors.

The original issue came from positioning avatars with `offsetTop` and `offsetLeft`; the Amount field lives inside a relatively positioned calculator wrapper while avatars render in the editor overlay, so the coordinate systems diverged. Presence bubbles now measure the focused field and overlay with `getBoundingClientRect()` and position relative to the overlay.

This also fixes participant split amount fields. Those inputs inherit presence from the participant row, while their calculator opener and portaled toolbar controls proxy presence back to the represented amount field or participant row. Realtime presence updates run on `pointerdown` and `focusin` as well as `click`, so opening the calculator manually and pressing calculator keys do not clear the collaborator avatar.

Finally, visible presence bubbles now keep tracking their anchor rect while mounted. This catches layout shifts where the anchor moves but does not resize, so avatars follow anchors instead of preserving the original top/left.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not captured; this is a realtime multi-client positioning/presence bug covered by coordinate/proxy lookup regression tests and browser DOM/event-path verification.

## Additional Notes

Validation included:

- `vp test packages/pwa/src/components/RealtimeExpenseEditorPresence.test.ts`
- `vp check --fix .`
- `vp exec react-doctor --verbose --scope changed`
- `vp run check`
- `vp run test`
- `vp run build`
- Browser check against the local dev server confirming participant calculator key `pointerdown` and `click` events resolve to `participant-participant-alex`.

React Doctor reported no new diagnostics; its score output remains at 80 due to an existing `react-hooks-js/todo` scoring rule.
