### PR TITLE
fix(pwa): address expense calculator review findings

### DIFF
--- a/.changeset/fuzzy-calculators-remember.md
+++ b/.changeset/fuzzy-calculators-remember.md
@@ -1,5 +1,0 @@
----
-"@trizum/pwa": patch
----
-
-Fix expense calculator focus, closing, mobile sheet scrolling, and attachment preview behavior.

--- a/.changeset/steady-calculator.md
+++ b/.changeset/steady-calculator.md
@@ -1,5 +1,9 @@
 ---
-"@trizum/pwa": patch
+"@trizum/pwa": minor
 ---
 
-Improve the expense editor calculator so selected amounts are replaced on input, mobile auto-open avoids the native keyboard, attachments remain accessible, scroll position stays stable, mobile users can drag the calculator sheet closed, and browser back can close the calculator.
+Improve the expense editor calculator across desktop and mobile.
+
+- Make selected amount editing, operators, localized physical-keyboard input, and close/reopen behavior reliable.
+- Add a draggable mobile calculator sheet that keeps the active field visible and preserves scroll through rapid navigation.
+- Keep receipt attachments accessible from the mobile calculator with an indexed, keyboard-friendly thumbnail preview.

--- a/packages/pwa/e2e/calculator.spec.ts
+++ b/packages/pwa/e2e/calculator.spec.ts
@@ -313,6 +313,20 @@ test.describe("Expense calculator", () => {
         )
         .toBeGreaterThan(0);
 
+      await expect(calculator).toHaveCSS("transform", "none");
+      await expect
+        .poll(async () => {
+          const fieldBox = await participantAmountField.boundingBox();
+          const calculatorBox = await calculator.boundingBox();
+
+          if (!fieldBox || !calculatorBox) {
+            return Number.POSITIVE_INFINITY;
+          }
+
+          return Math.round(fieldBox.y + fieldBox.height - calculatorBox.y);
+        })
+        .toBeLessThanOrEqual(0);
+
       await page.clock.runFor(700);
       await page.clock.resume();
 
@@ -1083,7 +1097,10 @@ test.describe("Expense calculator", () => {
     await expect(page).toHaveURL(/\/add$/);
   });
 
-  test("lets Enter activate a focused calculator keypad button", async ({ harness, page }) => {
+  test("lets Enter and Space activate a focused calculator keypad button", async ({
+    harness,
+    page,
+  }) => {
     await page.setViewportSize({ width: 1280, height: 633 });
     await navigateToAddExpense({ autoOpenCalculator: true, harness });
 
@@ -1100,6 +1117,13 @@ test.describe("Expense calculator", () => {
     await page.keyboard.press("Enter");
 
     await expect(amountField).toHaveValue("7");
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+    await expect(calculator).toBeVisible();
+    await expect(sevenButton).toBeFocused();
+
+    await page.keyboard.press("Space");
+
+    await expect(amountField).toHaveValue("77");
     await expect(page).toHaveURL(/\/add\?calculator=amount$/);
     await expect(calculator).toBeVisible();
     await expect(sevenButton).toBeFocused();

--- a/packages/pwa/e2e/calculator.spec.ts
+++ b/packages/pwa/e2e/calculator.spec.ts
@@ -3,7 +3,7 @@ import {
   createPartyFixture,
   defaultParticipants,
 } from "./harness/scenarios";
-import { expect, test } from "./harness/trizum.fixture";
+import { expect, test, type BrowserHarness } from "./harness/trizum.fixture";
 
 const scrollTargetParticipant = {
   id: "participant-traveler-24",
@@ -40,6 +40,37 @@ function createScrollableParticipantFixture() {
       },
     },
   };
+}
+
+async function navigateToAddExpense({
+  autoOpenCalculator,
+  fixture = createExpenseLogFixture(1),
+  harness,
+}: {
+  autoOpenCalculator: boolean;
+  fixture?: unknown;
+  harness: BrowserHarness;
+}) {
+  const seededParty = await harness.seedJoinedParty({
+    fixture,
+    memberParticipantId: defaultParticipants.blair.id,
+  });
+
+  await harness.seedPartyList({
+    username: "Harness User",
+    phone: "",
+    autoOpenCalculator,
+    lastOpenedPartyId: seededParty.partyId,
+    parties: {
+      [seededParty.partyId]: true,
+    },
+    participantInParties: {
+      [seededParty.partyId]: defaultParticipants.blair.id,
+    },
+  });
+  await harness.navigate(`/party/${seededParty.partyId}/add`);
+
+  return seededParty;
 }
 
 test.describe("Expense calculator", () => {
@@ -155,6 +186,24 @@ test.describe("Expense calculator", () => {
     await expect(calculator).not.toBeVisible();
   });
 
+  test("applies an operator to a selected existing amount", async ({ harness, page }) => {
+    await page.setViewportSize({ width: 1280, height: 633 });
+    await navigateToAddExpense({ autoOpenCalculator: false, harness });
+
+    const amountField = page.getByLabel("Amount", { exact: true });
+    const calculator = page.getByRole("application", { name: "Calculator" });
+
+    await amountField.fill("12");
+    await page.getByRole("button", { name: "Open calculator", exact: true }).click();
+    await expect(calculator).toBeVisible();
+
+    await calculator.getByRole("button", { name: "Add", exact: true }).click();
+    await calculator.getByRole("button", { name: "3", exact: true }).click();
+
+    await expect(amountField).toHaveValue("15");
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+  });
+
   test.describe("mobile touch", () => {
     test.use({
       hasTouch: true,
@@ -194,6 +243,102 @@ test.describe("Expense calculator", () => {
       await page.waitForTimeout(500);
       await expect(page).toHaveURL(/\/add\?calculator=amount$/);
       await expect(calculator).toBeVisible();
+    });
+
+    test("preserves the mobile scroll allowance through a rapid close and reopen", async ({
+      harness,
+      page,
+    }) => {
+      await page.setViewportSize({ width: 390, height: 520 });
+      await page.clock.install();
+      await navigateToAddExpense({
+        autoOpenCalculator: true,
+        fixture: createScrollableParticipantFixture(),
+        harness,
+      });
+
+      const targetCheckbox = page.getByRole("checkbox", {
+        name: bottomScrollTargetParticipant.name,
+        exact: true,
+      });
+      await targetCheckbox.scrollIntoViewIfNeeded();
+      await targetCheckbox.setChecked(true, { force: true });
+      await expect(targetCheckbox).toBeChecked();
+
+      const participantAmountField = page.getByLabel(
+        `Amount for ${bottomScrollTargetParticipant.name}`,
+        { exact: true },
+      );
+      await participantAmountField.scrollIntoViewIfNeeded();
+      await participantAmountField.evaluate((element) => {
+        element.scrollIntoView({ block: "end", inline: "nearest" });
+      });
+
+      const calculator = page.getByRole("application", { name: "Calculator" });
+      await participantAmountField.click();
+      await expect(page).toHaveURL(
+        new RegExp(`/add\\?calculator=share-${bottomScrollTargetParticipant.id}$`),
+      );
+      await expect(calculator).toBeVisible();
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            Number.parseFloat(
+              window
+                .getComputedStyle(document.documentElement)
+                .getPropertyValue("--calculator-mobile-scroll-allowance"),
+            ),
+          ),
+        )
+        .toBeGreaterThan(0);
+
+      await page.keyboard.press("Escape");
+      await expect(page).toHaveURL(/\/add$/);
+      await expect(calculator).not.toBeVisible();
+
+      await participantAmountField.click();
+      await expect(page).toHaveURL(
+        new RegExp(`/add\\?calculator=share-${bottomScrollTargetParticipant.id}$`),
+      );
+      await expect(calculator).toBeVisible();
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            Number.parseFloat(
+              window
+                .getComputedStyle(document.documentElement)
+                .getPropertyValue("--calculator-mobile-scroll-allowance"),
+            ),
+          ),
+        )
+        .toBeGreaterThan(0);
+
+      await page.clock.runFor(700);
+      await page.clock.resume();
+
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            Number.parseFloat(
+              window
+                .getComputedStyle(document.documentElement)
+                .getPropertyValue("--calculator-mobile-scroll-allowance"),
+            ),
+          ),
+        )
+        .toBeGreaterThan(0);
+      await expect
+        .poll(async () => {
+          const fieldBox = await participantAmountField.boundingBox();
+          const calculatorBox = await calculator.boundingBox();
+
+          if (!fieldBox || !calculatorBox) {
+            return Number.POSITIVE_INFINITY;
+          }
+
+          return Math.round(fieldBox.y + fieldBox.height - calculatorBox.y);
+        })
+        .toBeLessThanOrEqual(0);
     });
   });
 
@@ -244,6 +389,30 @@ test.describe("Expense calculator", () => {
 
     const historyLengthAfterSecondClose = await page.evaluate(() => window.history.length);
     expect(historyLengthAfterSecondClose).toBe(historyLengthAfterFirstClose);
+  });
+
+  test("reopens from browser Forward after a calculator-initiated close", async ({
+    harness,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 633 });
+    await navigateToAddExpense({ autoOpenCalculator: true, harness });
+
+    const amountField = page.getByLabel("Amount", { exact: true });
+    const calculator = page.getByRole("application", { name: "Calculator" });
+
+    await amountField.click();
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+    await expect(calculator).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page).toHaveURL(/\/add$/);
+    await expect(calculator).not.toBeVisible();
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+    await expect(calculator).toBeVisible();
+    await expect(calculator.getByText("Amount", { exact: true })).toBeVisible();
   });
 
   test("shows the active amount field label while editing", async ({ harness, page }) => {
@@ -533,15 +702,20 @@ test.describe("Expense calculator", () => {
     const attachmentsToolbar = page.getByRole("toolbar", { name: "Attachments" });
     const firstAttachmentButton = attachmentsToolbar.getByRole("button", {
       name: "View attachment 1",
+      exact: true,
+    });
+    const fourthAttachmentButton = attachmentsToolbar.getByRole("button", {
+      name: "View attachment 4",
+      exact: true,
     });
     await expect(attachmentsToolbar).toBeVisible();
     for (let attachmentNumber = 1; attachmentNumber <= 4; attachmentNumber++) {
-      await expect(
-        attachmentsToolbar.getByRole("button", {
-          name: `View attachment ${attachmentNumber}`,
-          exact: true,
-        }),
-      ).toBeVisible();
+      const attachmentButton = attachmentsToolbar.getByRole("button", {
+        name: `View attachment ${attachmentNumber}`,
+        exact: true,
+      });
+      await expect(attachmentButton).toBeVisible();
+      await expect(attachmentButton).toHaveAttribute("aria-pressed", "false");
     }
     await expect
       .poll(async () => {
@@ -604,13 +778,22 @@ test.describe("Expense calculator", () => {
 
     await firstAttachmentButton.click();
     const attachmentPreview = page.getByRole("region", { name: "Attachment preview" });
+    const closeAttachmentPreviewButton = page.getByRole("button", {
+      name: "Close attachment preview",
+      exact: true,
+    });
     await expect(attachmentPreview).toBeVisible();
+    await expect(firstAttachmentButton).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      attachmentsToolbar.getByRole("button", {
+        name: "View attachment 2",
+        exact: true,
+      }),
+    ).toHaveAttribute("aria-pressed", "false");
     await expect
       .poll(async () => {
         const toolbarBox = await attachmentsToolbar.boundingBox();
-        const closeButtonBox = await page
-          .getByRole("button", { name: "Close attachment preview" })
-          .boundingBox();
+        const closeButtonBox = await closeAttachmentPreviewButton.boundingBox();
 
         if (!toolbarBox || !closeButtonBox) {
           return Number.POSITIVE_INFINITY;
@@ -646,12 +829,16 @@ test.describe("Expense calculator", () => {
       })
       .toBeLessThanOrEqual(1);
 
-    await attachmentPreview.click({ position: { x: 20, y: 20 } });
+    await attachmentPreview.getByRole("button", { name: "Previous", exact: true }).click();
     await expect(page).toHaveURL(/\/add\?calculator=amount$/);
     await expect(calculator).toBeVisible();
+    await expect(firstAttachmentButton).toHaveAttribute("aria-pressed", "false");
+    await expect(fourthAttachmentButton).toHaveAttribute("aria-pressed", "true");
 
-    await page.getByRole("button", { name: "Close attachment preview" }).click();
+    await closeAttachmentPreviewButton.click();
     await expect(attachmentPreview).not.toBeVisible();
+    await expect(fourthAttachmentButton).toHaveAttribute("aria-pressed", "false");
+    await expect(fourthAttachmentButton).toBeFocused();
 
     await page.mouse.click(10, 120);
     await expect(page).toHaveURL(/\/add$/);
@@ -697,6 +884,35 @@ test.describe("Expense calculator", () => {
     await page.waitForTimeout(1600);
     await expect(page).toHaveURL(/\/add$/);
     await expect(calculator).not.toBeVisible();
+  });
+
+  test("reopens from keyboard focus after close suppression expires", async ({ harness, page }) => {
+    await page.setViewportSize({ width: 1280, height: 633 });
+    await page.clock.install();
+    await navigateToAddExpense({ autoOpenCalculator: true, harness });
+
+    const titleField = page.getByLabel("Title", { exact: true });
+    const amountField = page.getByLabel("Amount", { exact: true });
+    const calculator = page.getByRole("application", { name: "Calculator" });
+
+    await amountField.click();
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+    await expect(calculator).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page).toHaveURL(/\/add$/);
+    await expect(calculator).not.toBeVisible();
+
+    await page.clock.fastForward(1600);
+    await page.clock.resume();
+
+    await titleField.focus();
+    await expect(titleField).toBeFocused();
+    await page.keyboard.press("Tab");
+
+    await expect(amountField).toBeFocused();
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+    await expect(calculator).toBeVisible();
   });
 
   test("animates browser back close without resetting scroll on mobile", async ({
@@ -848,6 +1064,15 @@ test.describe("Expense calculator", () => {
     await amountField.click();
     await expect(page).toHaveURL(/\/add\?calculator=amount$/);
 
+    await page.keyboard.type("12,5");
+    await expect(amountField).toHaveValue("12.5");
+
+    await page.keyboard.press("Escape");
+    await expect(page).toHaveURL(/\/add$/);
+
+    await amountField.click();
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+
     await page.keyboard.type("12+3*2");
     await expect(amountField).toHaveValue("18");
 
@@ -856,5 +1081,27 @@ test.describe("Expense calculator", () => {
 
     await page.keyboard.press("Escape");
     await expect(page).toHaveURL(/\/add$/);
+  });
+
+  test("lets Enter activate a focused calculator keypad button", async ({ harness, page }) => {
+    await page.setViewportSize({ width: 1280, height: 633 });
+    await navigateToAddExpense({ autoOpenCalculator: true, harness });
+
+    const amountField = page.getByLabel("Amount", { exact: true });
+    const calculator = page.getByRole("application", { name: "Calculator" });
+
+    await amountField.click();
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+    await expect(calculator).toBeVisible();
+
+    const sevenButton = calculator.getByRole("button", { name: "7", exact: true });
+    await sevenButton.focus();
+    await expect(sevenButton).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    await expect(amountField).toHaveValue("7");
+    await expect(page).toHaveURL(/\/add\?calculator=amount$/);
+    await expect(calculator).toBeVisible();
+    await expect(sevenButton).toBeFocused();
   });
 });

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -103,7 +103,7 @@ msgstr "Active on this device"
 msgid "ADB Unit of Account"
 msgstr "ADB Unit of Account"
 
-#: src/components/CalculatorToolbar.tsx:1477
+#: src/components/CalculatorToolbar.tsx:1563
 msgid "Add"
 msgstr "Add"
 
@@ -259,11 +259,11 @@ msgstr "At least one participant is required"
 msgid "Attach photos of receipts to your expenses"
 msgstr "Attach photos of receipts to your expenses"
 
-#: src/components/CalculatorToolbar.tsx:1105
+#: src/components/CalculatorToolbar.tsx:1187
 msgid "Attachment preview"
 msgstr "Attachment preview"
 
-#: src/components/CalculatorToolbar.tsx:1075
+#: src/components/CalculatorToolbar.tsx:1156
 #: src/routes/party_.$partyId.expense.$expenseId/-components/Photos.tsx:26
 msgid "Attachments"
 msgstr "Attachments"
@@ -321,7 +321,7 @@ msgstr "Back to settings"
 msgid "Back to sign in"
 msgstr "Back to sign in"
 
-#: src/components/CalculatorToolbar.tsx:1502
+#: src/components/CalculatorToolbar.tsx:1588
 msgid "Backspace"
 msgstr "Backspace"
 
@@ -417,16 +417,16 @@ msgstr "Bulgarian Lev"
 msgid "Burundian Franc"
 msgstr "Burundian Franc"
 
-#: src/components/CalculatorToolbar.tsx:1510
+#: src/components/CalculatorToolbar.tsx:1596
 msgid "Calculate result"
 msgstr "Calculate result"
 
-#: src/components/CalculatorToolbar.tsx:971
-#: src/components/CalculatorToolbar.tsx:990
+#: src/components/CalculatorToolbar.tsx:1027
+#: src/components/CalculatorToolbar.tsx:1046
 msgid "Calculator"
 msgstr "Calculator"
 
-#: src/components/CalculatorToolbar.tsx:1342
+#: src/components/CalculatorToolbar.tsx:1428
 msgid "Calculator expression"
 msgstr "Calculator expression"
 
@@ -531,7 +531,7 @@ msgstr "Choose the currency for expenses in this party"
 msgid "Choose who receives it"
 msgstr "Choose who receives it"
 
-#: src/components/CalculatorToolbar.tsx:1393
+#: src/components/CalculatorToolbar.tsx:1479
 msgid "Clear all"
 msgstr "Clear all"
 
@@ -543,20 +543,20 @@ msgstr "Clear expression"
 msgid "Clear search"
 msgstr "Clear search"
 
-#: src/components/MediaGallery.tsx:218
+#: src/components/MediaGallery.tsx:243
 #: src/components/RouteQRScanner.tsx:60
 msgid "Close"
 msgstr "Close"
 
-#: src/components/CalculatorToolbar.tsx:1093
+#: src/components/CalculatorToolbar.tsx:1175
 msgid "Close attachment preview"
 msgstr "Close attachment preview"
 
-#: src/components/CurrencyField.tsx:452
+#: src/components/CurrencyField.tsx:466
 msgid "Close calculator"
 msgstr "Close calculator"
 
-#: src/components/CalculatorToolbar.tsx:1409
+#: src/components/CalculatorToolbar.tsx:1495
 msgid "Close parenthesis"
 msgstr "Close parenthesis"
 
@@ -832,7 +832,7 @@ msgstr "Debt transfer to another party"
 msgid "Debt transferred"
 msgstr "Debt transferred"
 
-#: src/components/CalculatorToolbar.tsx:1494
+#: src/components/CalculatorToolbar.tsx:1580
 msgid "Decimal point"
 msgstr "Decimal point"
 
@@ -871,7 +871,7 @@ msgstr "Destructive actions"
 msgid "Did you know?"
 msgstr "Did you know?"
 
-#: src/components/CalculatorToolbar.tsx:1417
+#: src/components/CalculatorToolbar.tsx:1503
 msgid "Divide"
 msgstr "Divide"
 
@@ -1607,7 +1607,7 @@ msgstr "Mozambican Metical"
 msgid "Multi-Party Splitting"
 msgstr "Multi-Party Splitting"
 
-#: src/components/CalculatorToolbar.tsx:1437
+#: src/components/CalculatorToolbar.tsx:1523
 msgid "Multiply"
 msgstr "Multiply"
 
@@ -1666,7 +1666,7 @@ msgstr "New trizum"
 msgid "New Zealand Dollar"
 msgstr "New Zealand Dollar"
 
-#: src/components/MediaGallery.tsx:235
+#: src/components/MediaGallery.tsx:260
 msgid "Next"
 msgstr "Next"
 
@@ -1792,7 +1792,7 @@ msgstr "Only your own debt can be transferred"
 msgid "Open archived parties"
 msgstr "Open archived parties"
 
-#: src/components/CurrencyField.tsx:452
+#: src/components/CurrencyField.tsx:466
 msgid "Open calculator"
 msgstr "Open calculator"
 
@@ -1808,7 +1808,7 @@ msgstr "Open GitHub Issues"
 msgid "Open last party on launch"
 msgstr "Open last party on launch"
 
-#: src/components/CalculatorToolbar.tsx:1401
+#: src/components/CalculatorToolbar.tsx:1487
 msgid "Open parenthesis"
 msgstr "Open parenthesis"
 
@@ -2087,7 +2087,7 @@ msgstr "Point your camera at a trizum QR code"
 msgid "Polish Zloty"
 msgstr "Polish Zloty"
 
-#: src/components/MediaGallery.tsx:228
+#: src/components/MediaGallery.tsx:253
 msgid "Previous"
 msgstr "Previous"
 
@@ -2496,7 +2496,7 @@ msgstr "Submit a Request"
 msgid "Submitting..."
 msgstr "Submitting..."
 
-#: src/components/CalculatorToolbar.tsx:1457
+#: src/components/CalculatorToolbar.tsx:1543
 msgid "Subtract"
 msgstr "Subtract"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -99,7 +99,7 @@ msgstr "Activo en este dispositivo"
 msgid "ADB Unit of Account"
 msgstr "Unidad de Cuenta del BAsD"
 
-#: src/components/CalculatorToolbar.tsx:1477
+#: src/components/CalculatorToolbar.tsx:1563
 msgid "Add"
 msgstr "Sumar"
 
@@ -247,11 +247,11 @@ msgstr "Florín Arubeño"
 msgid "At least one participant is required"
 msgstr "Se requiere al menos un participante"
 
-#: src/components/CalculatorToolbar.tsx:1105
+#: src/components/CalculatorToolbar.tsx:1187
 msgid "Attachment preview"
 msgstr "Vista previa del adjunto"
 
-#: src/components/CalculatorToolbar.tsx:1075
+#: src/components/CalculatorToolbar.tsx:1156
 #: src/routes/party_.$partyId.expense.$expenseId/-components/Photos.tsx:26
 msgid "Attachments"
 msgstr "Adjuntos"
@@ -309,7 +309,7 @@ msgstr "Volver a configuración"
 msgid "Back to sign in"
 msgstr "Volver a iniciar sesión"
 
-#: src/components/CalculatorToolbar.tsx:1502
+#: src/components/CalculatorToolbar.tsx:1588
 msgid "Backspace"
 msgstr "Retroceso"
 
@@ -401,16 +401,16 @@ msgstr "Lev Búlgaro"
 msgid "Burundian Franc"
 msgstr "Franco Burundés"
 
-#: src/components/CalculatorToolbar.tsx:1510
+#: src/components/CalculatorToolbar.tsx:1596
 msgid "Calculate result"
 msgstr "Calcular resultado"
 
-#: src/components/CalculatorToolbar.tsx:971
-#: src/components/CalculatorToolbar.tsx:990
+#: src/components/CalculatorToolbar.tsx:1027
+#: src/components/CalculatorToolbar.tsx:1046
 msgid "Calculator"
 msgstr "Calculadora"
 
-#: src/components/CalculatorToolbar.tsx:1342
+#: src/components/CalculatorToolbar.tsx:1428
 msgid "Calculator expression"
 msgstr "Expresión de calculadora"
 
@@ -507,7 +507,7 @@ msgstr "Elige la moneda para los gastos de este grupo"
 msgid "Choose who receives it"
 msgstr "Elige quién la recibe"
 
-#: src/components/CalculatorToolbar.tsx:1393
+#: src/components/CalculatorToolbar.tsx:1479
 msgid "Clear all"
 msgstr "Borrar todo"
 
@@ -519,20 +519,20 @@ msgstr "Borrar expresión"
 msgid "Clear search"
 msgstr "Borrar búsqueda"
 
-#: src/components/MediaGallery.tsx:218
+#: src/components/MediaGallery.tsx:243
 #: src/components/RouteQRScanner.tsx:60
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/components/CalculatorToolbar.tsx:1093
+#: src/components/CalculatorToolbar.tsx:1175
 msgid "Close attachment preview"
 msgstr "Cerrar vista previa del adjunto"
 
-#: src/components/CurrencyField.tsx:452
+#: src/components/CurrencyField.tsx:466
 msgid "Close calculator"
 msgstr "Cerrar calculadora"
 
-#: src/components/CalculatorToolbar.tsx:1409
+#: src/components/CalculatorToolbar.tsx:1495
 msgid "Close parenthesis"
 msgstr "Cerrar paréntesis"
 
@@ -804,7 +804,7 @@ msgstr "Transferencia de deuda a otro grupo"
 msgid "Debt transferred"
 msgstr "Deuda transferida"
 
-#: src/components/CalculatorToolbar.tsx:1494
+#: src/components/CalculatorToolbar.tsx:1580
 msgid "Decimal point"
 msgstr "Punto decimal"
 
@@ -843,7 +843,7 @@ msgstr "Acciones destructivas"
 msgid "Did you know?"
 msgstr "¿Sabías que?"
 
-#: src/components/CalculatorToolbar.tsx:1417
+#: src/components/CalculatorToolbar.tsx:1503
 msgid "Divide"
 msgstr "Dividir"
 
@@ -1555,7 +1555,7 @@ msgstr "Metical Mozambiqueño"
 msgid "Multi-Party Splitting"
 msgstr "División Multi-Grupo"
 
-#: src/components/CalculatorToolbar.tsx:1437
+#: src/components/CalculatorToolbar.tsx:1523
 msgid "Multiply"
 msgstr "Multiplicar"
 
@@ -1614,7 +1614,7 @@ msgstr "Nuevo trizum"
 msgid "New Zealand Dollar"
 msgstr "Dólar Neozelandés"
 
-#: src/components/MediaGallery.tsx:235
+#: src/components/MediaGallery.tsx:260
 msgid "Next"
 msgstr "Siguiente"
 
@@ -1736,7 +1736,7 @@ msgstr "Solo puedes transferir tus propias deudas"
 msgid "Open archived parties"
 msgstr "Abrir grupos archivados"
 
-#: src/components/CurrencyField.tsx:452
+#: src/components/CurrencyField.tsx:466
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
@@ -1752,7 +1752,7 @@ msgstr "Abrir GitHub Issues"
 msgid "Open last party on launch"
 msgstr "Abrir el último grupo al abrir la app"
 
-#: src/components/CalculatorToolbar.tsx:1401
+#: src/components/CalculatorToolbar.tsx:1487
 msgid "Open parenthesis"
 msgstr "Abrir paréntesis"
 
@@ -2019,7 +2019,7 @@ msgstr "Apunta tu cámara a un código QR de trizum"
 msgid "Polish Zloty"
 msgstr "Zloty Polaco"
 
-#: src/components/MediaGallery.tsx:228
+#: src/components/MediaGallery.tsx:253
 msgid "Previous"
 msgstr "Anterior"
 
@@ -2420,7 +2420,7 @@ msgstr "Enviar sugerencia"
 msgid "Submitting..."
 msgstr "Enviando..."
 
-#: src/components/CalculatorToolbar.tsx:1457
+#: src/components/CalculatorToolbar.tsx:1543
 msgid "Subtract"
 msgstr "Restar"
 

--- a/packages/pwa/src/components/CalculatorToolbar.tsx
+++ b/packages/pwa/src/components/CalculatorToolbar.tsx
@@ -1,6 +1,6 @@
 import { msg, t } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
-import { Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Sheet } from "react-modal-sheet";
 import { AnimatePresence, LazyMotion, domAnimation, m } from "motion/react";
@@ -31,6 +31,7 @@ const viewAttachmentMessage = msg({
   message: "View attachment {attachmentNumber}",
 });
 const currencyPreviewFormatterCache = new Map<string, Intl.NumberFormat>();
+let mobileScrollAllowanceOwner: symbol | null = null;
 
 function getCurrencyPreviewFormatter(currency: string) {
   const cachedFormatter = currencyPreviewFormatterCache.get(currency);
@@ -112,8 +113,17 @@ function blurCalculatorFocus() {
   window.requestAnimationFrame(blurActiveElement);
 }
 
-function removeMobileScrollAllowance() {
+function claimMobileScrollAllowance(owner: symbol) {
+  mobileScrollAllowanceOwner = owner;
+}
+
+function releaseMobileScrollAllowance(owner: symbol) {
+  if (mobileScrollAllowanceOwner !== owner || typeof document === "undefined") {
+    return;
+  }
+
   document.documentElement.style.removeProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY);
+  mobileScrollAllowanceOwner = null;
 }
 
 function getCurrentWindowScrollPosition(): WindowScrollPosition | null {
@@ -464,14 +474,17 @@ function useCalculatorKeyboard({
 }) {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      const target = e.target as HTMLElement | null;
+      const target = e.target instanceof HTMLElement ? e.target : null;
+      const isButtonActivation =
+        (e.key === "Enter" || e.key === " " || e.key === "Spacebar") &&
+        Boolean(target?.closest('button, [role="button"]'));
       const isEditableTarget =
         target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable;
       const isCalculatorTarget =
         target &&
         (fieldContainerRef.current?.contains(target) || toolbarRef.current?.contains(target));
 
-      if (isEditableTarget && !isCalculatorTarget) {
+      if (isButtonActivation || (isEditableTarget && !isCalculatorTarget)) {
         return;
       }
 
@@ -487,10 +500,11 @@ function useCalculatorKeyboard({
         case "*":
         case "/":
         case ".":
+        case ",":
         case "(":
         case ")":
           e.preventDefault();
-          callbacksRef.current.onInsert(e.key);
+          callbacksRef.current.onInsert(e.key === "," ? "." : e.key);
           break;
         case "Backspace":
           e.preventDefault();
@@ -537,6 +551,8 @@ function useMobileCalculatorScroll({
   toolbarRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const [initialWindowScroll] = useState(() => getCurrentWindowScrollPosition());
+  const [scrollAllowanceOwner] = useState(() => Symbol("calculator-mobile-scroll-allowance"));
+  const finalFieldVisibilityCheckTimeoutRef = useRef<number | null>(null);
   const initialWindowScrollRef = useRef<WindowScrollPosition | null>(initialWindowScroll);
   const scrollFieldAboveMobileSheetRef = useRef<
     (behavior: ScrollBehavior, attempts?: number) => void
@@ -549,6 +565,7 @@ function useMobileCalculatorScroll({
 
     const allowanceHeight = Math.max(0, height);
     const root = document.documentElement;
+    claimMobileScrollAllowance(scrollAllowanceOwner);
 
     if (options?.animate && !root.style.getPropertyValue(MOBILE_SCROLL_ALLOWANCE_PROPERTY)) {
       root.style.setProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY, "0px");
@@ -556,7 +573,9 @@ function useMobileCalculatorScroll({
 
     if (options?.animate) {
       window.requestAnimationFrame(() => {
-        root.style.setProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY, `${allowanceHeight}px`);
+        if (mobileScrollAllowanceOwner === scrollAllowanceOwner) {
+          root.style.setProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY, `${allowanceHeight}px`);
+        }
       });
     } else {
       root.style.setProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY, `${allowanceHeight}px`);
@@ -566,6 +585,17 @@ function useMobileCalculatorScroll({
   function scrollFieldAboveMobileSheet(behavior: ScrollBehavior, attempts = 0) {
     if (typeof window === "undefined" || isLargeScreen) {
       return;
+    }
+
+    if (attempts === 0) {
+      // A previous calculator may still be restoring its scroll position even
+      // after it has released the shared allowance. Stop that animation before
+      // the new owner calculates its own target.
+      window.scrollTo({
+        left: window.scrollX,
+        top: window.scrollY,
+        behavior: "auto",
+      });
     }
 
     const fieldElement = fieldContainerRef.current;
@@ -609,6 +639,19 @@ function useMobileCalculatorScroll({
         MOBILE_SCROLL_ALLOWANCE_ANIMATION_MS / 4,
       );
     }
+
+    if (attempts === 0) {
+      if (finalFieldVisibilityCheckTimeoutRef.current !== null) {
+        window.clearTimeout(finalFieldVisibilityCheckTimeoutRef.current);
+      }
+
+      finalFieldVisibilityCheckTimeoutRef.current = window.setTimeout(() => {
+        finalFieldVisibilityCheckTimeoutRef.current = null;
+        if (mobileScrollAllowanceOwner === scrollAllowanceOwner) {
+          scrollFieldAboveMobileSheetRef.current("auto", 4);
+        }
+      }, MOBILE_SCROLL_RESTORE_TIMEOUT_MS);
+    }
   }
 
   useLayoutEffect(() => {
@@ -616,7 +659,7 @@ function useMobileCalculatorScroll({
   });
 
   function collapseMobileScrollAllowance() {
-    if (isLargeScreen) {
+    if (isLargeScreen || mobileScrollAllowanceOwner !== scrollAllowanceOwner) {
       return;
     }
 
@@ -669,9 +712,22 @@ function useMobileCalculatorScroll({
     await waitForInitialWindowScroll();
   }
 
+  function removeMobileScrollAllowance() {
+    releaseMobileScrollAllowance(scrollAllowanceOwner);
+  }
+
   useEffect(() => {
     return () => {
-      if (typeof window !== "undefined" && initialWindowScroll) {
+      if (finalFieldVisibilityCheckTimeoutRef.current !== null) {
+        window.clearTimeout(finalFieldVisibilityCheckTimeoutRef.current);
+        finalFieldVisibilityCheckTimeoutRef.current = null;
+      }
+
+      if (
+        typeof window !== "undefined" &&
+        initialWindowScroll &&
+        mobileScrollAllowanceOwner === scrollAllowanceOwner
+      ) {
         document.documentElement.style.setProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY, "0px");
         window.scrollTo({
           left: initialWindowScroll.left,
@@ -679,23 +735,23 @@ function useMobileCalculatorScroll({
           behavior: "smooth",
         });
         window.setTimeout(
-          () => document.documentElement.style.removeProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY),
+          () => releaseMobileScrollAllowance(scrollAllowanceOwner),
           MOBILE_SCROLL_RESTORE_TIMEOUT_MS,
         );
         return;
       }
 
-      document.documentElement.style.removeProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY);
+      releaseMobileScrollAllowance(scrollAllowanceOwner);
     };
-  }, [initialWindowScroll]);
+  }, [initialWindowScroll, scrollAllowanceOwner]);
 
   useEffect(() => {
     if (!isLargeScreen) {
       return;
     }
 
-    document.documentElement.style.removeProperty(MOBILE_SCROLL_ALLOWANCE_PROPERTY);
-  }, [isLargeScreen]);
+    releaseMobileScrollAllowance(scrollAllowanceOwner);
+  }, [isLargeScreen, scrollAllowanceOwner]);
 
   return {
     finishInitialWindowScrollRestore,
@@ -1051,6 +1107,8 @@ function CalculatorMobileAttachmentContent({
   setSelectedIndex: React.Dispatch<React.SetStateAction<number | null>>;
   sheetHeight: number;
 }) {
+  const attachmentButtonIdPrefix = useId();
+  const pendingAttachmentFocusIndexRef = useRef<number | null>(null);
   const mediaFiles = useMultipleSuspenseDocument<MediaFile>(photoIds, {
     required: true as const,
   }).map(({ doc }) => doc);
@@ -1058,6 +1116,29 @@ function CalculatorMobileAttachmentContent({
   const galleryItems: MediaGalleryItem[] = urls.map((url) => ({ src: url }));
   const activeIndex =
     selectedIndex !== null && selectedIndex < galleryItems.length ? selectedIndex : null;
+
+  function getAttachmentButtonId(index: number) {
+    return `${attachmentButtonIdPrefix}-${index}`;
+  }
+
+  function closeAttachmentPreview() {
+    pendingAttachmentFocusIndexRef.current = activeIndex;
+    setSelectedIndex(null);
+  }
+
+  useEffect(() => {
+    const indexToFocus = pendingAttachmentFocusIndexRef.current;
+    if (activeIndex !== null || indexToFocus === null) {
+      return;
+    }
+
+    const animationFrameId = window.requestAnimationFrame(() => {
+      pendingAttachmentFocusIndexRef.current = null;
+      document.getElementById(`${attachmentButtonIdPrefix}-${indexToFocus}`)?.focus();
+    });
+
+    return () => window.cancelAnimationFrame(animationFrameId);
+  }, [activeIndex, attachmentButtonIdPrefix]);
 
   return (
     <>
@@ -1079,6 +1160,7 @@ function CalculatorMobileAttachmentContent({
             {photoIds.map((photoId, index) => (
               <CalculatorMobileAttachmentButton
                 key={photoId}
+                buttonId={getAttachmentButtonId(index)}
                 index={index}
                 isActive={activeIndex === index}
                 onSelect={setSelectedIndex}
@@ -1093,7 +1175,7 @@ function CalculatorMobileAttachmentContent({
               aria-label={t`Close attachment preview`}
               className="h-10 w-10 shrink-0"
               iconClassName="size-5"
-              onPress={() => setSelectedIndex(null)}
+              onPress={closeAttachmentPreview}
             />
           ) : null}
         </div>
@@ -1121,7 +1203,7 @@ function CalculatorMobileAttachmentContent({
                 index={activeIndex}
                 items={galleryItems}
                 onChange={setSelectedIndex}
-                onClose={() => setSelectedIndex(null)}
+                onClose={closeAttachmentPreview}
                 showCloseButton={false}
               />
             </div>
@@ -1133,11 +1215,13 @@ function CalculatorMobileAttachmentContent({
 }
 
 function CalculatorMobileAttachmentButton({
+  buttonId,
   index,
   isActive,
   onSelect,
   url,
 }: {
+  buttonId: string;
   index: number;
   isActive: boolean;
   onSelect: React.Dispatch<React.SetStateAction<number | null>>;
@@ -1148,7 +1232,9 @@ function CalculatorMobileAttachmentButton({
 
   return (
     <Button
+      id={buttonId}
       color="transparent"
+      aria-pressed={isActive}
       aria-label={i18n._({
         ...viewAttachmentMessage,
         values: { attachmentNumber },

--- a/packages/pwa/src/components/CurrencyField.tsx
+++ b/packages/pwa/src/components/CurrencyField.tsx
@@ -167,6 +167,20 @@ function useCurrencyFieldCalculator({
       return;
     }
 
+    if (
+      activeCalculatorId === undefined &&
+      !state.isActive &&
+      isClosedFromCalculator &&
+      isClosingFromCalculatorRef.current
+    ) {
+      isClosingFromCalculatorRef.current = false;
+      setCalculatorCloseState((currentState) => ({
+        ...currentState,
+        isClosedFromCalculator: false,
+      }));
+      return;
+    }
+
     if (activeCalculatorId === calculatorFieldId) {
       pendingRouteOpenCalculatorIdRef.current = null;
       if (state.isActive || isClosedFromCalculator || isClosingFromCalculatorRef.current) {

--- a/packages/pwa/src/components/MediaGallery.tsx
+++ b/packages/pwa/src/components/MediaGallery.tsx
@@ -5,6 +5,10 @@ import { useGesture } from "@use-gesture/react";
 import { LazyMotion, animate, domAnimation, m, useMotionValue } from "motion/react";
 import type { IconProps } from "#src/ui/Icon.tsx";
 import { IconButton } from "#src/ui/IconButton.tsx";
+import {
+  calculateMediaGalleryPinchTransform,
+  type MediaGalleryPoint,
+} from "./mediaGalleryPinch.ts";
 
 export type MediaGalleryItem = {
   src: string;
@@ -64,17 +68,16 @@ export default function MediaGallery({
 
   const viewportRef = useRef<HTMLDivElement>(null);
   const ref = useRef<HTMLDivElement>(null);
+  const previousPinchOriginRef = useRef<MediaGalleryPoint | null>(null);
 
   // Track if we're in a "closing drag" gesture (dragging up at scale=1)
   const isClosingDragRef = useRef(false);
 
-  function zoomAroundOrigin(nextScale: number, [originX, originY]: [number, number]) {
+  function getLocalPinchOrigin([originX, originY]: MediaGalleryPoint) {
     const viewport = viewportRef.current;
-    const currentScale = scale.get();
 
-    if (!viewport || currentScale <= 0) {
-      scale.set(nextScale);
-      return;
+    if (!viewport) {
+      return null;
     }
 
     const viewportRect = viewport.getBoundingClientRect();
@@ -82,15 +85,34 @@ export default function MediaGallery({
     const localOriginY = originY - viewportRect.top - viewportRect.height / 2;
 
     if (!Number.isFinite(localOriginX) || !Number.isFinite(localOriginY)) {
+      return null;
+    }
+
+    return [localOriginX, localOriginY] as const;
+  }
+
+  function zoomAroundOrigin(nextScale: number, origin: MediaGalleryPoint) {
+    const currentScale = scale.get();
+    const nextOrigin = getLocalPinchOrigin(origin);
+
+    if (!nextOrigin || currentScale <= 0) {
       scale.set(nextScale);
+      previousPinchOriginRef.current = nextOrigin;
       return;
     }
 
-    const scaleRatio = nextScale / currentScale;
+    const transform = calculateMediaGalleryPinchTransform({
+      currentPosition: [x.get(), y.get()],
+      currentScale,
+      previousOrigin: previousPinchOriginRef.current ?? nextOrigin,
+      nextOrigin,
+      nextScale,
+    });
 
-    x.set(localOriginX - (localOriginX - x.get()) * scaleRatio);
-    y.set(localOriginY - (localOriginY - y.get()) * scaleRatio);
-    scale.set(nextScale);
+    x.set(transform.x);
+    y.set(transform.y);
+    scale.set(transform.scale);
+    previousPinchOriginRef.current = nextOrigin;
   }
 
   useGesture(
@@ -131,14 +153,16 @@ export default function MediaGallery({
         }
         isClosingDragRef.current = false;
       },
-      onPinchStart: () => {
+      onPinchStart: ({ origin }) => {
         isClosingDragRef.current = false;
+        previousPinchOriginRef.current = getLocalPinchOrigin(origin);
         onDragProgress?.(0);
       },
       onPinch: ({ offset: [s], origin }) => {
         zoomAroundOrigin(s, origin);
       },
       onPinchEnd: ({ offset: [s] }) => {
+        previousPinchOriginRef.current = null;
         if (s <= 1) {
           void animate(x, 0, { type: "spring", stiffness: 400, damping: 30 });
           void animate(y, 0, { type: "spring", stiffness: 400, damping: 30 });
@@ -196,6 +220,7 @@ export default function MediaGallery({
     x.set(0);
     y.set(0);
     scale.set(1);
+    previousPinchOriginRef.current = null;
   }, [index, x, y, scale]);
 
   return (

--- a/packages/pwa/src/components/calculatorAutoOpenSuppression.test.ts
+++ b/packages/pwa/src/components/calculatorAutoOpenSuppression.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test, vi } from "vite-plus/test";
+import {
+  allowCalculatorAutoOpenForUserInteraction,
+  isCalculatorAutoOpenSuppressed,
+  suppressCalculatorAutoOpen,
+} from "./calculatorAutoOpenSuppression.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("calculator auto-open suppression", () => {
+  test("expires without requiring another pointer interaction", () => {
+    let now = 100;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+
+    suppressCalculatorAutoOpen();
+    expect(isCalculatorAutoOpenSuppressed()).toBe(true);
+
+    now = 1_599;
+    expect(isCalculatorAutoOpenSuppressed()).toBe(true);
+
+    now = 1_600;
+    expect(isCalculatorAutoOpenSuppressed()).toBe(false);
+  });
+
+  test("resumes suppression after the pointer allowance until the suppression expires", () => {
+    let now = 100;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+
+    suppressCalculatorAutoOpen();
+    now = 200;
+    allowCalculatorAutoOpenForUserInteraction();
+    expect(isCalculatorAutoOpenSuppressed()).toBe(false);
+
+    now = 699;
+    expect(isCalculatorAutoOpenSuppressed()).toBe(false);
+
+    now = 700;
+    expect(isCalculatorAutoOpenSuppressed()).toBe(true);
+
+    now = 1_600;
+    expect(isCalculatorAutoOpenSuppressed()).toBe(false);
+  });
+});

--- a/packages/pwa/src/components/calculatorAutoOpenSuppression.ts
+++ b/packages/pwa/src/components/calculatorAutoOpenSuppression.ts
@@ -3,7 +3,6 @@ const CALCULATOR_AUTO_OPEN_POINTER_ALLOWANCE_MS = 500;
 
 let suppressCalculatorAutoOpenUntil = 0;
 let allowCalculatorAutoOpenUntil = 0;
-let blockCalculatorAutoOpenUntilUserInteraction = false;
 
 export function suppressCalculatorAutoOpen() {
   if (typeof performance === "undefined") {
@@ -11,7 +10,6 @@ export function suppressCalculatorAutoOpen() {
   }
 
   allowCalculatorAutoOpenUntil = 0;
-  blockCalculatorAutoOpenUntilUserInteraction = true;
   suppressCalculatorAutoOpenUntil = performance.now() + CALCULATOR_AUTO_OPEN_SUPPRESSION_MS;
 }
 
@@ -21,10 +19,7 @@ export function isCalculatorAutoOpenSuppressed() {
   }
 
   const now = performance.now();
-  return (
-    now >= allowCalculatorAutoOpenUntil &&
-    (blockCalculatorAutoOpenUntilUserInteraction || now < suppressCalculatorAutoOpenUntil)
-  );
+  return now >= allowCalculatorAutoOpenUntil && now < suppressCalculatorAutoOpenUntil;
 }
 
 export function allowCalculatorAutoOpenForUserInteraction() {
@@ -33,5 +28,4 @@ export function allowCalculatorAutoOpenForUserInteraction() {
   }
 
   allowCalculatorAutoOpenUntil = performance.now() + CALCULATOR_AUTO_OPEN_POINTER_ALLOWANCE_MS;
-  blockCalculatorAutoOpenUntilUserInteraction = false;
 }

--- a/packages/pwa/src/components/mediaGalleryPinch.test.ts
+++ b/packages/pwa/src/components/mediaGalleryPinch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vite-plus/test";
+import { calculateMediaGalleryPinchTransform } from "./mediaGalleryPinch.ts";
+
+describe("calculateMediaGalleryPinchTransform", () => {
+  test("scales around a stationary pinch origin", () => {
+    expect(
+      calculateMediaGalleryPinchTransform({
+        currentPosition: [0, 0],
+        currentScale: 1,
+        previousOrigin: [100, -50],
+        nextOrigin: [100, -50],
+        nextScale: 2,
+      }),
+    ).toEqual({ x: -100, y: 50, scale: 2 });
+  });
+
+  test("follows a moving pinch midpoint while scaling", () => {
+    expect(
+      calculateMediaGalleryPinchTransform({
+        currentPosition: [0, 0],
+        currentScale: 1,
+        previousOrigin: [0, 0],
+        nextOrigin: [50, 30],
+        nextScale: 2,
+      }),
+    ).toEqual({ x: 50, y: 30, scale: 2 });
+  });
+
+  test("tracks midpoint movement one-to-one when scale is unchanged", () => {
+    expect(
+      calculateMediaGalleryPinchTransform({
+        currentPosition: [10, -5],
+        currentScale: 2,
+        previousOrigin: [20, 15],
+        nextOrigin: [45, 5],
+        nextScale: 2,
+      }),
+    ).toEqual({ x: 35, y: -15, scale: 2 });
+  });
+});

--- a/packages/pwa/src/components/mediaGalleryPinch.ts
+++ b/packages/pwa/src/components/mediaGalleryPinch.ts
@@ -1,0 +1,23 @@
+export type MediaGalleryPoint = readonly [x: number, y: number];
+
+export function calculateMediaGalleryPinchTransform({
+  currentPosition,
+  currentScale,
+  nextOrigin,
+  nextScale,
+  previousOrigin,
+}: {
+  currentPosition: MediaGalleryPoint;
+  currentScale: number;
+  nextOrigin: MediaGalleryPoint;
+  nextScale: number;
+  previousOrigin: MediaGalleryPoint;
+}) {
+  const scaleRatio = nextScale / currentScale;
+
+  return {
+    x: nextOrigin[0] - (previousOrigin[0] - currentPosition[0]) * scaleRatio,
+    y: nextOrigin[1] - (previousOrigin[1] - currentPosition[1]) * scaleRatio,
+    scale: nextScale,
+  };
+}

--- a/packages/pwa/src/hooks/useCalculatorMode.test.ts
+++ b/packages/pwa/src/hooks/useCalculatorMode.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vite-plus/test";
+import { evaluateExpression } from "#src/lib/evaluateExpression.ts";
 import {
   deleteCalculatorText,
   getChangedCalculatorValue,
@@ -18,6 +19,32 @@ describe("calculator text editing", () => {
       expression: "7",
       cursorPosition: 1,
     });
+  });
+
+  test("preserves a selected existing amount when inserting a binary operator", () => {
+    let edit = insertCalculatorText({
+      expression: "50",
+      cursorPosition: 2,
+      selectionRange: { start: 0, end: 2 },
+      text: "+",
+    });
+
+    edit = insertCalculatorText({
+      ...edit,
+      selectionRange: null,
+      text: "1",
+    });
+    edit = insertCalculatorText({
+      ...edit,
+      selectionRange: null,
+      text: "0",
+    });
+
+    expect(edit).toEqual({
+      expression: "50+10",
+      cursorPosition: 5,
+    });
+    expect(evaluateExpression(edit.expression)).toBe(60);
   });
 
   test("inserts at the cursor when there is no active selection", () => {

--- a/packages/pwa/src/hooks/useCalculatorMode.ts
+++ b/packages/pwa/src/hooks/useCalculatorMode.ts
@@ -121,8 +121,16 @@ export function insertCalculatorText({
   text,
 }: CalculatorTextEditOptions & { text: string }): CalculatorTextEditResult {
   const activeSelectionRange = getActiveSelectionRange({ expression, selectionRange });
-  const start = activeSelectionRange?.start ?? cursorPosition;
-  const end = activeSelectionRange?.end ?? cursorPosition;
+  const shouldAppendBinaryOperator =
+    activeSelectionRange?.start === 0 &&
+    activeSelectionRange.end === expression.length &&
+    /^[+\-*/]$/.test(text);
+  const start = shouldAppendBinaryOperator
+    ? activeSelectionRange.end
+    : (activeSelectionRange?.start ?? cursorPosition);
+  const end = shouldAppendBinaryOperator
+    ? activeSelectionRange.end
+    : (activeSelectionRange?.end ?? cursorPosition);
   const nextExpression = expression.slice(0, start) + text + expression.slice(end);
 
   return {


### PR DESCRIPTION
## Description

Fix every actionable review finding from #371 before the expense calculator lands.

- Preserve a selected existing amount when the next calculator input is a binary operator, and accept comma as a localized decimal key.
- Let focused React Aria buttons handle Enter and Space, reopen correctly through browser Forward, and expire auto-open suppression after its intended window.
- Keep mobile scroll allowance and visibility work owned by the current calculator instance, including rapid close/reopen flows.
- Track both the previous and current pinch midpoint so zoomed receipts follow two-finger movement directly.
- Expose active attachment thumbnails with `aria-pressed` and restore focus to the selected thumbnail when preview closes.
- Add focused unit and Playwright regressions and consolidate the two calculator release notes into one PWA minor changeset.
- Stabilize the WebKit rapid-reopen regression by waiting for real layout to settle before advancing mocked timers.

## Related Issues

Related to #371.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable — these changes correct behavior, accessibility semantics, gesture math, and test timing without changing the visual design.

## Additional Notes

- This PR intentionally targets `t3code/fix-expense-calculator`, the source branch for #371.
- All 90 Playwright tests pass across Chromium and WebKit.
- The two updated WebKit scenarios pass 20/20 focused repeat runs.
- Changed-scope React Doctor reports 78/100 with no diagnostics, matching the pre-commit scan.
