### PR TITLE
fix(pwa): resolve React Doctor diagnostics

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -33,12 +33,10 @@ jobs:
           set +e
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            base="origin/${{ github.base_ref }}"
+            vp exec react-doctor packages/pwa/src --scope changed --base "origin/${{ github.base_ref }}" --no-color --verbose --json > react-doctor-report.json
           else
-            base="${{ github.event.before }}"
+            vp exec react-doctor packages/pwa/src --no-color --verbose --json > react-doctor-report.json
           fi
-
-          vp exec react-doctor packages/pwa/src --scope changed --base "$base" --no-color --verbose --json > react-doctor-report.json
 
           exit_code="$?"
           echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -33,10 +33,12 @@ jobs:
           set +e
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            vp exec react-doctor packages/pwa/src --scope changed --base "origin/${{ github.base_ref }}" --no-color --verbose --json > react-doctor-report.json
+            base="origin/${{ github.base_ref }}"
           else
-            vp exec react-doctor packages/pwa/src --no-color --verbose --json > react-doctor-report.json
+            base="${{ github.event.before }}"
           fi
+
+          vp exec react-doctor packages/pwa/src --scope changed --base "$base" --no-color --verbose --json > react-doctor-report.json
 
           exit_code="$?"
           echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -83,7 +83,7 @@ msgstr "Accent color"
 msgid "Account created"
 msgstr "Account created"
 
-#: src/routes/settings_.cloud-sync.tsx:689
+#: src/routes/settings_.cloud-sync.tsx:664
 msgid "Account deleted"
 msgstr "Account deleted"
 
@@ -276,10 +276,10 @@ msgstr "Australian Dollar"
 msgid "Authentication error"
 msgstr "Authentication error"
 
-#: src/routes/settings_.cloud-sync.tsx:454
-#: src/routes/settings_.cloud-sync.tsx:471
-#: src/routes/settings_.cloud-sync.tsx:500
-#: src/routes/settings_.cloud-sync.tsx:513
+#: src/routes/settings_.cloud-sync.tsx:458
+#: src/routes/settings_.cloud-sync.tsx:474
+#: src/routes/settings_.cloud-sync.tsx:498
+#: src/routes/settings_.cloud-sync.tsx:509
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
@@ -296,7 +296,7 @@ msgstr "Automatically open the calculator when focusing amount fields"
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Automatically open the last visited party when you open the app"
 
-#: src/components/AvatarPicker.tsx:97
+#: src/components/AvatarPicker.tsx:95
 msgid "Avatar removed"
 msgstr "Avatar removed"
 
@@ -491,11 +491,11 @@ msgstr "Changes sync automatically across all your devices"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/routes/settings_.cloud-sync.tsx:574
+#: src/routes/settings_.cloud-sync.tsx:559
 msgid "Check your email for the password link"
 msgstr "Check your email for the password link"
 
-#: src/routes/settings_.cloud-sync.tsx:410
+#: src/routes/settings_.cloud-sync.tsx:419
 msgid "Check your email for the sign-in link"
 msgstr "Check your email for the sign-in link"
 
@@ -697,11 +697,11 @@ msgstr "Costa Rican Colón"
 msgid "Could not apply cloud settings"
 msgstr "Could not apply cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:545
+#: src/routes/settings_.cloud-sync.tsx:535
 msgid "Could not connect sign-in method"
 msgstr "Could not connect sign-in method"
 
-#: src/routes/settings_.cloud-sync.tsx:698
+#: src/routes/settings_.cloud-sync.tsx:673
 msgid "Could not delete account"
 msgstr "Could not delete account"
 
@@ -713,7 +713,7 @@ msgstr "Could not load cloud settings"
 msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
-#: src/hooks/useCloudSyncAccountState.ts:220
+#: src/hooks/useCloudSyncAccountState.ts:192
 #: src/routes/settings.tsx:487
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
@@ -726,15 +726,15 @@ msgstr "Could not reset password"
 msgid "Could not save cloud settings"
 msgstr "Could not save cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:579
+#: src/routes/settings_.cloud-sync.tsx:564
 msgid "Could not send password email"
 msgstr "Could not send password email"
 
-#: src/routes/settings_.cloud-sync.tsx:415
+#: src/routes/settings_.cloud-sync.tsx:424
 msgid "Could not send sign-in link"
 msgstr "Could not send sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:643
+#: src/routes/settings_.cloud-sync.tsx:595
 msgid "Could not sign out"
 msgstr "Could not sign out"
 
@@ -1040,7 +1040,7 @@ msgstr "Expenses"
 msgid "Expenses counted"
 msgstr "Expenses counted"
 
-#: src/components/AvatarPicker.tsx:112
+#: src/components/AvatarPicker.tsx:110
 #: src/components/ExpenseEditor.tsx:1042
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
@@ -1958,7 +1958,7 @@ msgstr "Party unpinned"
 msgid "Password"
 msgstr "Password"
 
-#: src/routes/settings_.cloud-sync.tsx:577
+#: src/routes/settings_.cloud-sync.tsx:562
 msgid "Password email sent"
 msgstr "Password email sent"
 
@@ -2132,7 +2132,7 @@ msgstr "Reload"
 msgid "Remove"
 msgstr "Remove"
 
-#: src/components/AvatarPicker.tsx:145
+#: src/components/AvatarPicker.tsx:143
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
@@ -2332,7 +2332,7 @@ msgstr "Sierra Leonean Leone"
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/routes/settings_.cloud-sync.tsx:978
+#: src/routes/settings_.cloud-sync.tsx:953
 msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
@@ -2367,15 +2367,15 @@ msgstr "Sign-in link expired"
 msgid "Sign-in link is invalid or expired"
 msgstr "Sign-in link is invalid or expired"
 
-#: src/routes/settings_.cloud-sync.tsx:413
+#: src/routes/settings_.cloud-sync.tsx:422
 msgid "Sign-in link sent"
 msgstr "Sign-in link sent"
 
-#: src/routes/settings_.cloud-sync.tsx:543
+#: src/routes/settings_.cloud-sync.tsx:532
 msgid "Sign-in method connected"
 msgstr "Sign-in method connected"
 
-#: src/routes/settings_.cloud-sync.tsx:468
+#: src/routes/settings_.cloud-sync.tsx:471
 msgid "Sign-in method is not configured"
 msgstr "Sign-in method is not configured"
 
@@ -2385,11 +2385,11 @@ msgstr "Sign-in methods"
 
 #: src/components/CloudSyncAccountSettings.tsx:70
 #: src/components/CloudSyncDialogs.tsx:375
-#: src/routes/settings_.cloud-sync.tsx:374
+#: src/routes/settings_.cloud-sync.tsx:383
 msgid "Signed in"
 msgstr "Signed in"
 
-#: src/routes/settings_.cloud-sync.tsx:640
+#: src/routes/settings_.cloud-sync.tsx:592
 msgid "Signed out"
 msgstr "Signed out"
 
@@ -2574,8 +2574,8 @@ msgstr "System (fallbacks to {DEFAULT_LOCALE})"
 msgid "Tajikistani Somoni"
 msgstr "Tajikistani Somoni"
 
-#: src/components/AvatarPicker.tsx:159
-#: src/components/AvatarPicker.tsx:174
+#: src/components/AvatarPicker.tsx:157
+#: src/components/AvatarPicker.tsx:172
 #: src/components/ExpenseEditor.tsx:1062
 #: src/components/ExpenseEditor.tsx:1076
 msgid "Take photo"
@@ -2750,17 +2750,17 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/settings_.cloud-sync.tsx:853
+#: src/routes/settings_.cloud-sync.tsx:828
 #: src/routes/settings.tsx:308
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/hooks/useCloudSyncAccountState.ts:196
+#: src/hooks/useCloudSyncAccountState.ts:168
 #: src/hooks/useCloudSyncAccountState.ts:248
 msgid "trizum cloud data is invalid"
 msgstr "trizum cloud data is invalid"
 
-#: src/hooks/useCloudSyncAccountState.ts:216
+#: src/hooks/useCloudSyncAccountState.ts:188
 #: src/hooks/useCloudSyncAccountState.ts:270
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud enabled on this device"
@@ -2769,7 +2769,7 @@ msgstr "trizum cloud enabled on this device"
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud is not set up yet"
 
-#: src/hooks/useCloudSyncAccountState.ts:176
+#: src/hooks/useCloudSyncAccountState.ts:148
 msgid "trizum cloud started"
 msgstr "trizum cloud started"
 
@@ -2879,8 +2879,8 @@ msgstr "Updating trizum..."
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
-#: src/components/AvatarPicker.tsx:168
-#: src/components/AvatarPicker.tsx:186
+#: src/components/AvatarPicker.tsx:166
+#: src/components/AvatarPicker.tsx:184
 #: src/components/ExpenseEditor.tsx:1071
 #: src/components/ExpenseEditor.tsx:1088
 msgid "Upload photo"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -79,7 +79,7 @@ msgstr "Color de acento"
 msgid "Account created"
 msgstr "Cuenta creada"
 
-#: src/routes/settings_.cloud-sync.tsx:689
+#: src/routes/settings_.cloud-sync.tsx:664
 msgid "Account deleted"
 msgstr "Cuenta eliminada"
 
@@ -264,10 +264,10 @@ msgstr "Dólar Australiano"
 msgid "Authentication error"
 msgstr "Error de autenticación"
 
-#: src/routes/settings_.cloud-sync.tsx:454
-#: src/routes/settings_.cloud-sync.tsx:471
-#: src/routes/settings_.cloud-sync.tsx:500
-#: src/routes/settings_.cloud-sync.tsx:513
+#: src/routes/settings_.cloud-sync.tsx:458
+#: src/routes/settings_.cloud-sync.tsx:474
+#: src/routes/settings_.cloud-sync.tsx:498
+#: src/routes/settings_.cloud-sync.tsx:509
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
@@ -284,7 +284,7 @@ msgstr "Abrir automáticamente la calculadora al enfocar campos de importe"
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Abrir automáticamente el último grupo visitado cuando abras la app"
 
-#: src/components/AvatarPicker.tsx:97
+#: src/components/AvatarPicker.tsx:95
 msgid "Avatar removed"
 msgstr "Avatar eliminado"
 
@@ -471,11 +471,11 @@ msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
-#: src/routes/settings_.cloud-sync.tsx:574
+#: src/routes/settings_.cloud-sync.tsx:559
 msgid "Check your email for the password link"
 msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:410
+#: src/routes/settings_.cloud-sync.tsx:419
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
@@ -673,11 +673,11 @@ msgstr "Colón Costarricense"
 msgid "Could not apply cloud settings"
 msgstr "No se pudo aplicar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:545
+#: src/routes/settings_.cloud-sync.tsx:535
 msgid "Could not connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:698
+#: src/routes/settings_.cloud-sync.tsx:673
 msgid "Could not delete account"
 msgstr "No se pudo eliminar la cuenta"
 
@@ -689,7 +689,7 @@ msgstr "No se pudo cargar la configuración en la nube"
 msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
-#: src/hooks/useCloudSyncAccountState.ts:220
+#: src/hooks/useCloudSyncAccountState.ts:192
 #: src/routes/settings.tsx:487
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
@@ -702,15 +702,15 @@ msgstr "No se pudo restablecer la contraseña"
 msgid "Could not save cloud settings"
 msgstr "No se pudo guardar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:579
+#: src/routes/settings_.cloud-sync.tsx:564
 msgid "Could not send password email"
 msgstr "No se pudo enviar el correo de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:415
+#: src/routes/settings_.cloud-sync.tsx:424
 msgid "Could not send sign-in link"
 msgstr "No se pudo enviar el enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:643
+#: src/routes/settings_.cloud-sync.tsx:595
 msgid "Could not sign out"
 msgstr "No se pudo cerrar sesión"
 
@@ -1000,7 +1000,7 @@ msgstr "Gastos"
 msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
-#: src/components/AvatarPicker.tsx:112
+#: src/components/AvatarPicker.tsx:110
 #: src/components/ExpenseEditor.tsx:1042
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
@@ -1890,7 +1890,7 @@ msgstr "Grupo desfijado"
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:577
+#: src/routes/settings_.cloud-sync.tsx:562
 msgid "Password email sent"
 msgstr "Correo de contraseña enviado"
 
@@ -2060,7 +2060,7 @@ msgstr "Recargar"
 msgid "Remove"
 msgstr "Eliminar"
 
-#: src/components/AvatarPicker.tsx:145
+#: src/components/AvatarPicker.tsx:143
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
@@ -2260,7 +2260,7 @@ msgstr "Leone de Sierra Leona"
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:978
+#: src/routes/settings_.cloud-sync.tsx:953
 msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
@@ -2295,15 +2295,15 @@ msgstr "El enlace de inicio de sesión ha caducado"
 msgid "Sign-in link is invalid or expired"
 msgstr "El enlace de inicio de sesión no es válido o ha caducado"
 
-#: src/routes/settings_.cloud-sync.tsx:413
+#: src/routes/settings_.cloud-sync.tsx:422
 msgid "Sign-in link sent"
 msgstr "Enlace de inicio de sesión enviado"
 
-#: src/routes/settings_.cloud-sync.tsx:543
+#: src/routes/settings_.cloud-sync.tsx:532
 msgid "Sign-in method connected"
 msgstr "Método de inicio de sesión conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:468
+#: src/routes/settings_.cloud-sync.tsx:471
 msgid "Sign-in method is not configured"
 msgstr "El método de inicio de sesión no está configurado"
 
@@ -2313,11 +2313,11 @@ msgstr "Métodos de inicio de sesión"
 
 #: src/components/CloudSyncAccountSettings.tsx:70
 #: src/components/CloudSyncDialogs.tsx:375
-#: src/routes/settings_.cloud-sync.tsx:374
+#: src/routes/settings_.cloud-sync.tsx:383
 msgid "Signed in"
 msgstr "Sesión iniciada"
 
-#: src/routes/settings_.cloud-sync.tsx:640
+#: src/routes/settings_.cloud-sync.tsx:592
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
@@ -2498,8 +2498,8 @@ msgstr "Sistema (por defecto {DEFAULT_LOCALE})"
 msgid "Tajikistani Somoni"
 msgstr "Somoni Tayiko"
 
-#: src/components/AvatarPicker.tsx:159
-#: src/components/AvatarPicker.tsx:174
+#: src/components/AvatarPicker.tsx:157
+#: src/components/AvatarPicker.tsx:172
 #: src/components/ExpenseEditor.tsx:1062
 #: src/components/ExpenseEditor.tsx:1076
 msgid "Take photo"
@@ -2662,17 +2662,17 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/settings_.cloud-sync.tsx:853
+#: src/routes/settings_.cloud-sync.tsx:828
 #: src/routes/settings.tsx:308
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/hooks/useCloudSyncAccountState.ts:196
+#: src/hooks/useCloudSyncAccountState.ts:168
 #: src/hooks/useCloudSyncAccountState.ts:248
 msgid "trizum cloud data is invalid"
 msgstr "Los datos de trizum cloud no son válidos"
 
-#: src/hooks/useCloudSyncAccountState.ts:216
+#: src/hooks/useCloudSyncAccountState.ts:188
 #: src/hooks/useCloudSyncAccountState.ts:270
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud activado en este dispositivo"
@@ -2681,7 +2681,7 @@ msgstr "trizum cloud activado en este dispositivo"
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud todavía no está configurado"
 
-#: src/hooks/useCloudSyncAccountState.ts:176
+#: src/hooks/useCloudSyncAccountState.ts:148
 msgid "trizum cloud started"
 msgstr "trizum cloud iniciado"
 
@@ -2791,8 +2791,8 @@ msgstr "Actualizando trizum..."
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
-#: src/components/AvatarPicker.tsx:168
-#: src/components/AvatarPicker.tsx:186
+#: src/components/AvatarPicker.tsx:166
+#: src/components/AvatarPicker.tsx:184
 #: src/components/ExpenseEditor.tsx:1071
 #: src/components/ExpenseEditor.tsx:1088
 msgid "Upload photo"

--- a/packages/pwa/src/components/AvatarPicker.tsx
+++ b/packages/pwa/src/components/AvatarPicker.tsx
@@ -75,21 +75,19 @@ export function AvatarPicker({ value, name, onChange, className }: AvatarPickerP
       toast.error(
         getImageUploadErrorMessage(error) ?? t`Failed to upload avatar. Please try again.`,
       );
-    } finally {
-      setIsUploading(false);
     }
+
+    setIsUploading(false);
   }
 
   async function onFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     if (!file) return;
 
-    try {
-      await updateAvatarFromFile(file);
-    } finally {
+    await updateAvatarFromFile(file).finally(() => {
       // Reset the input value to allow selecting the same file again
       event.target.value = "";
-    }
+    });
   }
 
   function handleRemoveAvatar() {

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -169,11 +169,11 @@ export function ExpenseEditor({
 
       saveInFlightRef.current = true;
 
-      try {
-        await onSubmit(value);
-      } finally {
-        saveInFlightRef.current = false;
-      }
+      await Promise.resolve()
+        .then(() => onSubmit(value))
+        .finally(() => {
+          saveInFlightRef.current = false;
+        });
     },
   });
 
@@ -772,7 +772,7 @@ function ParticipantItem({
 
                     updateShares(newShares);
                   }}
-                  aria-label={t`Shares for ${participantName}`}
+                  aria-label={t({ message: `Shares for ${participantName}` })}
                 />
                 <IconButton
                   icon="lucide.plus"
@@ -814,7 +814,7 @@ function ParticipantItem({
               onCloseCalculator={onCloseCalculator}
               onOpenCalculator={onOpenCalculator}
               onChange={onExactAmountChange}
-              aria-label={t`Amount for ${participantName}`}
+              aria-label={t({ message: `Amount for ${participantName}` })}
             />
           </div>
         </div>

--- a/packages/pwa/src/hooks/useCloudSyncAccountState.ts
+++ b/packages/pwa/src/hooks/useCloudSyncAccountState.ts
@@ -114,34 +114,6 @@ export function useCloudSyncAccountState({
     const currentUserId = userId;
     const cachedAccountState = readCachedCloudAccountState(currentUserId);
 
-    if (cachedAccountState) {
-      dispatch({
-        type: "accountDataLoaded",
-        linkedAccounts: cachedAccountState.linkedAccounts,
-        cloudSettings: cachedAccountState.cloudSettings,
-      });
-    } else {
-      dispatch({
-        type: "accountDataLoaded",
-        linkedAccounts: [],
-        cloudSettings: null,
-      });
-    }
-
-    void loadAccountState({
-      showErrorToast: !cachedAccountState,
-      showStartToast: true,
-    });
-
-    const intervalId = window.setInterval(() => {
-      void loadAccountState({ showErrorToast: false, showStartToast: false });
-    }, CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS);
-
-    return () => {
-      isCancelled = true;
-      window.clearInterval(intervalId);
-    };
-
     async function loadAccountState({
       showErrorToast,
       showStartToast,
@@ -221,6 +193,34 @@ export function useCloudSyncAccountState({
         }
       }
     }
+
+    if (cachedAccountState) {
+      dispatch({
+        type: "accountDataLoaded",
+        linkedAccounts: cachedAccountState.linkedAccounts,
+        cloudSettings: cachedAccountState.cloudSettings,
+      });
+    } else {
+      dispatch({
+        type: "accountDataLoaded",
+        linkedAccounts: [],
+        cloudSettings: null,
+      });
+    }
+
+    void loadAccountState({
+      showErrorToast: !cachedAccountState,
+      showStartToast: true,
+    });
+
+    const intervalId = window.setInterval(() => {
+      void loadAccountState({ showErrorToast: false, showStartToast: false });
+    }, CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS);
+
+    return () => {
+      isCancelled = true;
+      window.clearInterval(intervalId);
+    };
   }, [isSignInSuccessVisibleRef, userId]);
 
   function saveLinkedAccounts(accounts: LinkedAuthAccount[]) {

--- a/packages/pwa/src/lib/cloudSyncSettings.ts
+++ b/packages/pwa/src/lib/cloudSyncSettings.ts
@@ -3,8 +3,8 @@ import type { PartyList } from "#src/models/partyList.js";
 import { getAuthBaseURL } from "./auth-client";
 import { fetchWithNativeAuth } from "./nativeAuthSession";
 
-const CLOUD_USER_SETTINGS_CACHE_KEY_PREFIX = "trizumCloudUserSettings:";
-const LAST_CLOUD_USER_SETTINGS_CACHE_KEY = "trizumCloudUserSettings:last";
+const CLOUD_USER_SETTINGS_CACHE_KEY_PREFIX = "trizumCloudUserSettings:v1:";
+const LAST_CLOUD_USER_SETTINGS_CACHE_KEY = "trizumCloudUserSettings:last:v1";
 
 export interface CloudUserSettings {
   partyListDocumentId: DocumentId;

--- a/packages/pwa/src/lib/debtTransfer.ts
+++ b/packages/pwa/src/lib/debtTransfer.ts
@@ -147,9 +147,9 @@ function getParticipantMatchScore({
     return 100;
   }
 
-  const participantTokens = tokenizeParticipantName(normalizedParticipantName);
+  const participantTokens = new Set(tokenizeParticipantName(normalizedParticipantName));
   const sharedTokens = normalizedSourceTokens.filter((token) =>
-    participantTokens.includes(token),
+    participantTokens.has(token),
   ).length;
   const hasContainedName =
     normalizedParticipantName.includes(normalizedSourceName) ||

--- a/packages/pwa/src/lib/nativeAuthSession.ts
+++ b/packages/pwa/src/lib/nativeAuthSession.ts
@@ -22,6 +22,7 @@ export function setNativeAuthToken(token: string | undefined) {
 
   try {
     if (token) {
+      // eslint-disable-next-line react-doctor/auth-token-in-web-storage -- Capacitor's native bridge cannot rely on browser HttpOnly cookies; native requests must persist and forward this bearer token.
       localStorage.setItem(NATIVE_AUTH_TOKEN_STORAGE_KEY, token);
     } else {
       localStorage.removeItem(NATIVE_AUTH_TOKEN_STORAGE_KEY);

--- a/packages/pwa/src/routes/migrate_.tricount/route.tsx
+++ b/packages/pwa/src/routes/migrate_.tricount/route.tsx
@@ -67,7 +67,8 @@ function useMigrateTricount() {
           typeof data === "object" && data && "error" in data && typeof data.error === "string"
             ? data.error
             : response.statusText;
-        throw new Error(message);
+        setState({ type: "error", message });
+        return;
       }
 
       const partyId = await createPartyFromMigrationData({

--- a/packages/pwa/src/routes/party.$partyId/-components/PullToRefresh.tsx
+++ b/packages/pwa/src/routes/party.$partyId/-components/PullToRefresh.tsx
@@ -49,7 +49,9 @@ export function PullToRefresh({
   });
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  refreshActionRef.current = refreshAction;
+  useEffect(() => {
+    refreshActionRef.current = refreshAction;
+  }, [refreshAction]);
 
   function stopPullAnimation() {
     pullAnimationRef.current?.stop();
@@ -90,11 +92,9 @@ export function PullToRefresh({
     setIsRefreshing(true);
     animatePullDistance(refreshingIndicatorHeight);
 
-    try {
-      await refreshActionRef.current();
-    } finally {
-      scheduleRefreshFinish();
-    }
+    await Promise.resolve()
+      .then(() => refreshActionRef.current())
+      .finally(scheduleRefreshFinish);
   }
 
   function clearScheduledRefreshFinish() {

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx
@@ -221,7 +221,7 @@ function EditExpense() {
     <>
       <RealtimeExpenseEditorPresence expenseId={expenseId} />
       <ExpenseEditor
-        title={t`Editing ${expenseName}`}
+        title={t({ message: `Editing ${expenseName}` })}
         onSubmit={onSubmit}
         defaultValues={formValues}
         onChange={onChange}

--- a/packages/pwa/src/routes/party_.$partyId.pay/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.pay/route.tsx
@@ -61,7 +61,7 @@ function RouteComponent() {
 
   function onMarkAsPaid() {
     const expensePromise = addExpenseToParty({
-      name: t`Paid debt to ${toName}`,
+      name: t({ message: `Paid debt to ${toName}` }),
       paidAt: new Date(),
       paidBy: { [fromId]: amount },
       isTransfer: true,
@@ -71,7 +71,7 @@ function RouteComponent() {
 
     toast.promise(expensePromise, {
       loading: t`Marking expense as paid...`,
-      success: t`Debt settled between ${fromName} and ${toName}!`,
+      success: t({ message: `Debt settled between ${fromName} and ${toName}!` }),
       error: t`Failed to mark expense as paid`,
     });
 

--- a/packages/pwa/src/routes/party_.$partyId.share.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.share.tsx
@@ -33,7 +33,7 @@ function RouteComponent() {
   async function onShareParty() {
     if (canShare) {
       await Share.share({
-        title: t`Join ${partyName} on trizum!`,
+        title: t({ message: `Join ${partyName} on trizum!` }),
         url: shareUrl,
       });
 

--- a/packages/pwa/src/routes/party_.$partyId.who.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.who.tsx
@@ -63,9 +63,9 @@ function Who() {
         avatarId: partyList.avatarId,
       });
 
-      toast.success(t`Welcome to the party, ${participantName}!`);
+      toast.success(t({ message: `Welcome to the party, ${participantName}!` }));
     } else {
-      toast.success(t`You're now seeing the party as ${participantName}`);
+      toast.success(t({ message: `You're now seeing the party as ${participantName}` }));
     }
 
     if (search.redirectTo) {

--- a/packages/pwa/src/routes/reset-password.tsx
+++ b/packages/pwa/src/routes/reset-password.tsx
@@ -55,9 +55,9 @@ function ResetPassword() {
         void navigate({ to: "/settings", replace: true });
       } catch {
         toast.error(t`Could not reset password`);
-      } finally {
-        setIsSubmitting(false);
       }
+
+      setIsSubmitting(false);
     },
   });
 

--- a/packages/pwa/src/routes/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/settings_.cloud-sync.tsx
@@ -362,6 +362,15 @@ function useCloudSyncSettingsView() {
     dispatchRouteState({ type: "clearAuthFeedback" });
   }
 
+  function clearAuthPendingAction() {
+    dispatchRouteState({
+      type: "patch",
+      values: {
+        authPendingAction: null,
+      },
+    });
+  }
+
   function setAuthFailureMessage(message: string) {
     dispatchRouteState({ type: "authFailureMessage", message });
   }
@@ -413,14 +422,9 @@ function useCloudSyncSettingsView() {
       toast.success(t`Sign-in link sent`);
     } catch (error) {
       setAuthFailure(error, t`Could not send sign-in link`);
-    } finally {
-      dispatchRouteState({
-        type: "patch",
-        values: {
-          authPendingAction: null,
-        },
-      });
     }
+
+    clearAuthPendingAction();
   }
 
   async function onPasswordSignInSubmit(event: FormEvent<HTMLFormElement>) {
@@ -452,16 +456,15 @@ function useCloudSyncSettingsView() {
 
       if (result.error) {
         setAuthFailureMessage(result.error.message ?? t`Authentication failed`);
-        return;
+      } else {
+        dispatchRouteState({
+          type: "patch",
+          values: {
+            authPassword: "",
+          },
+        });
+        handleSignInSuccess(getAuthResultUser(result.data));
       }
-
-      dispatchRouteState({
-        type: "patch",
-        values: {
-          authPassword: "",
-        },
-      });
-      handleSignInSuccess(getAuthResultUser(result.data));
     } catch (error) {
       setAuthFailureMessage(
         error instanceof Error && error.message.endsWith("sign-in is not configured.")
@@ -470,14 +473,9 @@ function useCloudSyncSettingsView() {
             ? error.message
             : t`Authentication failed`,
       );
-    } finally {
-      dispatchRouteState({
-        type: "patch",
-        values: {
-          authPendingAction: null,
-        },
-      });
     }
+
+    clearAuthPendingAction();
   }
 
   async function onSocialSignIn(provider: SocialAuthProvider) {
@@ -498,27 +496,20 @@ function useCloudSyncSettingsView() {
 
       if (result?.error) {
         setAuthFailureMessage(result.error.message ?? t`Authentication failed`);
-        return;
+      } else {
+        const redirectUrl = getAuthRedirectUrl(result.data);
+
+        if (redirectUrl) {
+          window.location.replace(redirectUrl);
+        } else {
+          handleSignInSuccess(getAuthResultUser(result.data));
+        }
       }
-
-      const redirectUrl = getAuthRedirectUrl(result.data);
-
-      if (redirectUrl) {
-        window.location.replace(redirectUrl);
-        return;
-      }
-
-      handleSignInSuccess(getAuthResultUser(result.data));
     } catch (error) {
       setAuthFailureMessage(error instanceof Error ? error.message : t`Authentication failed`);
-    } finally {
-      dispatchRouteState({
-        type: "patch",
-        values: {
-          authPendingAction: null,
-        },
-      });
     }
+
+    clearAuthPendingAction();
   }
 
   async function onLinkSocialAccount(provider: SocialAuthProvider) {
@@ -535,22 +526,16 @@ function useCloudSyncSettingsView() {
 
       if (result.url) {
         window.location.replace(result.url);
-        return;
+      } else {
+        const accounts = await fetchLinkedAuthAccounts();
+        saveLinkedAccounts(accounts);
+        toast.success(t`Sign-in method connected`);
       }
-
-      const accounts = await fetchLinkedAuthAccounts();
-      saveLinkedAccounts(accounts);
-      toast.success(t`Sign-in method connected`);
     } catch {
       toast.error(t`Could not connect sign-in method`);
-    } finally {
-      dispatchRouteState({
-        type: "patch",
-        values: {
-          authPendingAction: null,
-        },
-      });
     }
+
+    clearAuthPendingAction();
   }
 
   async function onRequestPasswordReset(email: string) {
@@ -577,19 +562,40 @@ function useCloudSyncSettingsView() {
       toast.success(t`Password email sent`);
     } catch (error) {
       setAuthFailure(error, t`Could not send password email`);
-    } finally {
-      dispatchRouteState({
-        type: "patch",
-        values: {
-          authPendingAction: null,
-        },
-      });
     }
+
+    clearAuthPendingAction();
   }
 
   async function onPasswordResetSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     await onRequestPasswordReset(authEmail);
+  }
+
+  async function onSignOut() {
+    setIsCloudSyncSwitchOpen(false);
+    dispatchRouteState({
+      type: "patch",
+      values: {
+        authPendingAction: "sign-out",
+        cloudActionDialog: null,
+        isSignInSuccessVisible: false,
+        optimisticAuthUser: null,
+      },
+    });
+
+    try {
+      await authClient.signOut();
+      clearNativeAuthToken();
+      clearCloudSyncState();
+      await session.refetch();
+      toast.success(t`Signed out`);
+      void navigate({ to: "/settings", replace: true });
+    } catch {
+      toast.error(t`Could not sign out`);
+    }
+
+    clearAuthPendingAction();
   }
 
   async function onConfirmCloudAction(action: CloudActionDialogType) {
@@ -617,37 +623,6 @@ function useCloudSyncSettingsView() {
       case "sign-out":
         await onSignOut();
         return;
-    }
-  }
-
-  async function onSignOut() {
-    setIsCloudSyncSwitchOpen(false);
-    dispatchRouteState({
-      type: "patch",
-      values: {
-        authPendingAction: "sign-out",
-        cloudActionDialog: null,
-        isSignInSuccessVisible: false,
-        optimisticAuthUser: null,
-      },
-    });
-
-    try {
-      await authClient.signOut();
-      clearNativeAuthToken();
-      clearCloudSyncState();
-      await session.refetch();
-      toast.success(t`Signed out`);
-      void navigate({ to: "/settings", replace: true });
-    } catch {
-      toast.error(t`Could not sign out`);
-    } finally {
-      dispatchRouteState({
-        type: "patch",
-        values: {
-          authPendingAction: null,
-        },
-      });
     }
   }
 
@@ -698,14 +673,14 @@ function useCloudSyncSettingsView() {
               : t`Could not delete account`,
         },
       });
-    } finally {
-      dispatchRouteState({
-        type: "patch",
-        values: {
-          isDeleteAccountPending: false,
-        },
-      });
     }
+
+    dispatchRouteState({
+      type: "patch",
+      values: {
+        isDeleteAccountPending: false,
+      },
+    });
   }
 
   function closeSignInDialog() {


### PR DESCRIPTION
## What changed

- preserve the existing React Doctor workflow behavior: pull requests scan changed code, while pushes to `main` scan the full PWA source tree
- rewrite React Compiler bailout patterns without changing the underlying UI behavior
- move pull-to-refresh ref synchronization out of render
- version the cloud-settings cache keys
- replace repeated participant-token array lookups with a `Set`
- document the intentional native-only bearer-token persistence exception
- refresh Lingui catalog source references after the code movement

## Root cause

The workflow behavior was intentional, but the full `main` scan had accumulated 20 historical diagnostics: 17 React Compiler errors and 3 React Doctor warnings. Fixing the first compiler bailout in the cloud-account screen exposed seven additional compiler limitations that had been masked by the earlier failure, so those were cleaned up in the same pass.

The final diff against `main` does not modify `.github/workflows/react-doctor.yml`.

## Validation

- `vp exec react-doctor src --no-color --verbose --json` — full scan passes with 0 errors, 0 warnings, score 100
- `vp run check` — passes; two existing locale-format lint warnings are outside the pinned React Doctor job
- `vp run test` — passes, including all 226 PWA tests
- `vp run build` — passes, including PWA production build and Capacitor Android/iOS sync
- `vp run lingui:extract` — passes with no missing Spanish translations

## Notes

The native auth token remains persisted only on Capacitor native platforms because native bridge requests cannot rely on browser `HttpOnly` cookies. The storage write now has a narrow, documented React Doctor suppression; migrating it to platform keychain/keystore storage should be handled separately.