### PR TITLE
chore(renovate): group Cloudflare tooling updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,6 @@
       "description": "Keep Vite+ toolchain and Vite/Vitest ecosystem updates together.",
       "matchManagers": ["npm"],
       "matchPackageNames": [
-        "@cloudflare/vite-plugin",
         "@lingui/vite-plugin",
         "@rolldown/*",
         "@sentry/vite-plugin",
@@ -66,6 +65,13 @@
       ],
       "groupName": "Vite+ toolchain updates",
       "groupSlug": "vite-plus-toolchain"
+    },
+    {
+      "description": "Keep Wrangler and the Cloudflare Vite plugin updates together because they are codependent.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["wrangler", "@cloudflare/vite-plugin"],
+      "groupName": "Cloudflare tooling updates",
+      "groupSlug": "cloudflare-tooling"
     },
     {
       "description": "Keep React Doctor package updates together.",


### PR DESCRIPTION
## Description

Adds a dedicated Renovate group for `wrangler` and `@cloudflare/vite-plugin` so their codependent updates are proposed and reviewed together. The Cloudflare Vite plugin is removed from the broader Vite+ toolchain group to avoid overlapping group ownership.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other (Renovate configuration)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (not applicable; configuration-only change)
- [x] I've run `vp run lingui:extract` (not applicable; no new strings)
- [x] I've added a changeset (not applicable; not user-facing)

## Screenshots

Not applicable; there are no UI changes.

## Additional Notes

The Renovate configuration was also validated with `renovate-config-validator`.
