### PR TITLE
chore(agent-workflows): use GPT-5.6 Sol for reviews

### DIFF
--- a/packages/agent-workflows/README.md
+++ b/packages/agent-workflows/README.md
@@ -43,6 +43,9 @@ fixes. Review runs use a disposable Sandcastle branch that is removed after the
 run. Superseding fixes use the branch that becomes the replacement PR. The
 workflow passes `--ignore-user-config` to `codex exec` so automation uses Codex
 auth from `CODEX_HOME` without inheriting personal MCP, hook, or local config.
+By default, Codex uses `gpt-5.6-sol` with `high` reasoning effort. Set
+`TRIZUM_AGENT_WORKFLOWS_CODEX_MODEL` or
+`TRIZUM_AGENT_WORKFLOWS_CODEX_EFFORT` to override either setting.
 
 Use `--no-codex` or `--codex off` to run only the deterministic review.
 Use `--codex required` to treat a failed Codex review as a blocker.

--- a/packages/agent-workflows/src/adapters/sandcastle.ts
+++ b/packages/agent-workflows/src/adapters/sandcastle.ts
@@ -134,7 +134,7 @@ export async function runSandcastleCodexFix(
 }
 
 function resolveCodexModel(): string {
-  return process.env.TRIZUM_AGENT_WORKFLOWS_CODEX_MODEL?.trim() || "gpt-5.5";
+  return process.env.TRIZUM_AGENT_WORKFLOWS_CODEX_MODEL?.trim() || "gpt-5.6-sol";
 }
 
 function createCodexAgent(): AgentProvider {
@@ -177,7 +177,7 @@ function resolveCodexEffort(): CodexEffort | undefined {
     return effort;
   }
 
-  return "xhigh";
+  return "high";
 }
 
 function buildSandcastleReviewPrompt(context: PullRequestContext): string {

--- a/packages/agent-workflows/src/cli.ts
+++ b/packages/agent-workflows/src/cli.ts
@@ -35,8 +35,8 @@ Options:
 
 Environment:
   Codex auth is read from the Codex CLI environment, such as ~/.codex/auth.json.
-  TRIZUM_AGENT_WORKFLOWS_CODEX_MODEL     Optional Codex model override. Defaults to gpt-5.5.
-  TRIZUM_AGENT_WORKFLOWS_CODEX_EFFORT    Optional Sandcastle Codex effort. Defaults to xhigh.
+  TRIZUM_AGENT_WORKFLOWS_CODEX_MODEL     Optional Codex model override. Defaults to gpt-5.6-sol.
+  TRIZUM_AGENT_WORKFLOWS_CODEX_EFFORT    Optional Sandcastle Codex effort. Defaults to high.
 `;
 
 export async function main(argv = process.argv.slice(2)): Promise<number> {


### PR DESCRIPTION
## Description

Updates the agent-workflows Codex defaults from `gpt-5.5` at `xhigh` effort to `gpt-5.6-sol` at `high` effort for Renovate reviews and superseding fixes. The existing model and effort environment-variable overrides remain available.

The CLI help and package README now document the new defaults so runtime behavior and operator guidance stay aligned.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other: maintenance automation configuration

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (not applicable; default-only change)
- [x] I've run `vp run lingui:extract` (no new strings; pre-commit hook completed it)
- [x] I've added a changeset (not applicable; private maintenance automation)

## Screenshots

Not applicable; there are no UI changes.

## Additional Notes

The initial workspace build exposed a missing local CocoaPods bundle. After installing the repo-pinned Ruby dependencies, `mise exec -- vp run build` passed. `vp run check` reports two pre-existing React Doctor warnings in unrelated PWA date-formatting files and no errors.