### PR TITLE
feat(pwa): redesign first-run home and surface cloud sync

### DIFF
--- a/.changeset/fresh-clouds-gather.md
+++ b/.changeset/fresh-clouds-gather.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": minor
+---
+
+Redesign the first-run home screen and make trizum cloud sign-in directly accessible from home.

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -34,8 +34,17 @@ test.describe("Browser harness", () => {
   test("opens cloud sign-in from the home screen", async ({ harness, page }) => {
     const homePage = new HomePage(page);
 
+    await page.setViewportSize({ width: 390, height: 700 });
     await harness.gotoHome();
     const homeHeading = page.getByRole("heading", { name: "Split expenses, stay even." });
+    await expect(homeHeading).toBeVisible();
+    await page.evaluate(() => document.fonts.ready);
+    await page.evaluate(() => {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+    });
+    const scrollYBeforeSignIn = await page.evaluate(() => window.scrollY);
+    expect(scrollYBeforeSignIn).toBeGreaterThan(0);
+
     const headingBeforeSignIn = await homeHeading.boundingBox();
     const homeHeadingElement = await homeHeading.elementHandle();
     if (!homeHeadingElement) {
@@ -49,6 +58,7 @@ test.describe("Browser harness", () => {
     await expect(page.getByRole("heading", { name: "Sign in to trizum cloud" })).toBeVisible();
     await expect(page.locator('button[aria-label="Profile and app menu"]')).toHaveCount(1);
     await expect(page.locator("html")).toHaveCSS("scrollbar-gutter", "stable");
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(scrollYBeforeSignIn);
 
     const headingBehindSignIn = await page.locator("main h2").boundingBox();
     expect(headingBehindSignIn).toEqual(headingBeforeSignIn);

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -26,8 +26,23 @@ test.describe("Browser harness", () => {
     await harness.gotoHome();
 
     await expect(page).toHaveURL(/\/\?__internal_offline_only=true$/);
-    await expect(page.getByRole("heading", { name: "Welcome to trizum" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Create a new Party" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Split expenses, stay even." })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Create a Party" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Keep every party in sync/ })).toBeVisible();
+  });
+
+  test("opens cloud sign-in from the home screen", async ({ harness, page }) => {
+    const homePage = new HomePage(page);
+
+    await harness.gotoHome();
+    await homePage.openCloudSync();
+
+    await expect(page).toHaveURL(/\/settings\/cloud-sync$/);
+    await expect(page.getByRole("dialog", { name: "Sign in" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Sign in to trizum cloud" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Close sign-in" }).click();
+    await expect(page).toHaveURL(/\/\?__internal_offline_only=true$/);
   });
 
   test("can reopen an existing persisted party from the home screen", async ({ harness, page }) => {

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -85,7 +85,7 @@ test.describe("Browser harness", () => {
       updatedAt: new Date().toISOString(),
     };
     let isSignedIn = false;
-    let partyListId = "";
+    let cloudPartyListId = "";
 
     await page.route("**/api/auth/**", async (route) => {
       const pathname = new URL(route.request().url()).pathname;
@@ -126,15 +126,25 @@ test.describe("Browser harness", () => {
       await route.fulfill({
         json: {
           settings: {
-            partyListDocumentId: partyListId,
+            partyListDocumentId: cloudPartyListId,
             updatedAt: Date.now(),
           },
         },
       });
     });
 
-    await harness.gotoHome();
-    partyListId = (await harness.readPartyList()).partyListId;
+    const cloudParty = await harness.seedParty(createPartyFixture());
+    const localPartyListId = (await harness.readPartyList()).partyListId;
+    cloudPartyListId = (
+      await harness.createInactivePartyList({
+        username: "Cloud User",
+        parties: { [cloudParty.partyId]: true },
+        participantInParties: {
+          [cloudParty.partyId]: defaultParticipants.blair.id,
+        },
+      })
+    ).partyListId;
+    expect(cloudPartyListId).not.toBe(localPartyListId);
     await homePage.menuButton.click();
     await expect(page.getByRole("menuitem", { name: "Sign in to trizum cloud" })).toBeVisible();
     await page.keyboard.press("Escape");
@@ -157,7 +167,14 @@ test.describe("Browser harness", () => {
 
     await expect(page.locator("p").getByText("Signed in", { exact: true })).toBeVisible();
     await expect.poll(() => page.evaluate(() => window.location.pathname)).toBe("/");
-    await expect(homePage.welcomeHeading).toBeVisible();
+    await homePage.expectPartyVisible(/Weekend trip/);
+    const cloudPartyCard = homePage.partyCard(/Weekend trip/);
+    await cloudPartyCard.hover();
+    await cloudPartyCard.getByRole("button", { name: "Party actions" }).click();
+    await page.getByRole("menuitem", { name: "Pin party" }).click();
+    await expect
+      .poll(async () => (await harness.readPartyList()).pinnedParties[cloudParty.partyId])
+      .toBe(true);
     await homePage.menuButton.click();
     await expect(page.getByRole("menuitem", { name: "Manage trizum cloud" })).toBeVisible();
     await expect

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -135,6 +135,9 @@ test.describe("Browser harness", () => {
 
     await harness.gotoHome();
     partyListId = (await harness.readPartyList()).partyListId;
+    await homePage.menuButton.click();
+    await expect(page.getByRole("menuitem", { name: "Sign in to trizum cloud" })).toBeVisible();
+    await page.keyboard.press("Escape");
     await homePage.openCloudSync();
     await page.getByRole("button", { name: "Sign in with password" }).click();
     await page.getByLabel("Email").fill(user.email);
@@ -155,6 +158,8 @@ test.describe("Browser harness", () => {
     await expect(page.locator("p").getByText("Signed in", { exact: true })).toBeVisible();
     await expect.poll(() => page.evaluate(() => window.location.pathname)).toBe("/");
     await expect(homePage.welcomeHeading).toBeVisible();
+    await homePage.menuButton.click();
+    await expect(page.getByRole("menuitem", { name: "Manage trizum cloud" })).toBeVisible();
     await expect
       .poll(() =>
         page.evaluate(

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -136,7 +136,7 @@ test.describe("Browser harness", () => {
     const cloudParty = await harness.seedParty(createPartyFixture());
     const localPartyListId = (await harness.readPartyList()).partyListId;
     cloudPartyListId = (
-      await harness.createInactivePartyList({
+      await harness.createDeferredPartyList({
         username: "Cloud User",
         parties: { [cloudParty.partyId]: true },
         participantInParties: {
@@ -166,6 +166,15 @@ test.describe("Browser harness", () => {
     await page.getByRole("button", { name: "Sign in with password" }).click();
 
     await expect(page.locator("p").getByText("Signed in", { exact: true })).toBeVisible();
+    await expect
+      .poll(() => harness.getDocumentState(cloudPartyListId))
+      .toMatch(/^(loading|requesting|unavailable)$/);
+    await expect(page).toHaveURL(/\/settings\/cloud-sync$/);
+    await expect(homePage.partyCard(/Weekend trip/)).toHaveCount(0);
+    expect(await page.evaluate(() => localStorage.getItem("partyListId"))).toBe(localPartyListId);
+
+    await harness.releaseDeferredPartyList(cloudPartyListId);
+
     await expect.poll(() => page.evaluate(() => window.location.pathname)).toBe("/");
     await homePage.expectPartyVisible(/Weekend trip/);
     const cloudPartyCard = homePage.partyCard(/Weekend trip/);
@@ -211,6 +220,35 @@ test.describe("Browser harness", () => {
     });
 
     await expect.poll(() => sessionRequestCount).toBeGreaterThan(requestsAfterRouteLoaded);
+  });
+
+  test("keeps an open party bound to the list that admitted it", async ({
+    context,
+    harness,
+    page,
+  }) => {
+    const partyPage = new PartyPage(page);
+    const activeParty = await harness.seedJoinedParty({
+      fixture: createPartyFixture(),
+      memberParticipantId: defaultParticipants.blair.id,
+    });
+    const replacementPartyList = await harness.createDeferredPartyList({
+      username: "Another tab",
+    });
+    await harness.releaseDeferredPartyList(replacementPartyList.partyListId);
+
+    await harness.gotoParty(activeParty.partyId);
+    await partyPage.expectLoaded(activeParty.partyId, "Weekend trip");
+
+    const otherPage = await context.newPage();
+    await otherPage.goto("/?__internal_offline_only=true");
+    await otherPage.evaluate((partyListId) => {
+      localStorage.setItem("partyListId", partyListId);
+    }, replacementPartyList.partyListId);
+    await otherPage.close();
+
+    await partyPage.openBalances();
+    await partyPage.expectLoaded(activeParty.partyId, "Weekend trip");
   });
 
   test("can reopen an existing persisted party from the home screen", async ({ harness, page }) => {

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -164,6 +164,33 @@ test.describe("Browser harness", () => {
       .toBe(false);
   });
 
+  test("keeps the auth session active on party routes", async ({ harness, page }) => {
+    const partyPage = new PartyPage(page);
+    let sessionRequestCount = 0;
+
+    await page.route("**/api/auth/get-session", async (route) => {
+      sessionRequestCount += 1;
+      await route.fulfill({ json: null });
+    });
+
+    const seededParty = await harness.seedJoinedParty({
+      fixture: createPartyFixture(),
+      memberParticipantId: defaultParticipants.blair.id,
+    });
+    sessionRequestCount = 0;
+
+    await harness.gotoParty(seededParty.partyId);
+    await partyPage.expectLoaded(seededParty.partyId, "Weekend trip");
+    await expect.poll(() => sessionRequestCount).toBeGreaterThan(0);
+
+    const requestsAfterRouteLoaded = sessionRequestCount;
+    await page.evaluate(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await expect.poll(() => sessionRequestCount).toBeGreaterThan(requestsAfterRouteLoaded);
+  });
+
   test("can reopen an existing persisted party from the home screen", async ({ harness, page }) => {
     const homePage = new HomePage(page);
     const seededParty = await harness.joinSeededParty({

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -35,11 +35,26 @@ test.describe("Browser harness", () => {
     const homePage = new HomePage(page);
 
     await harness.gotoHome();
+    const homeHeading = page.getByRole("heading", { name: "Split expenses, stay even." });
+    const headingBeforeSignIn = await homeHeading.boundingBox();
+    const homeHeadingElement = await homeHeading.elementHandle();
+    if (!homeHeadingElement) {
+      throw new Error("Expected the home heading to be mounted before opening sign-in");
+    }
+
     await homePage.openCloudSync();
 
     await expect(page).toHaveURL(/\/settings\/cloud-sync$/);
     await expect(page.getByRole("dialog", { name: "Sign in" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Sign in to trizum cloud" })).toBeVisible();
+    await expect(page.locator('button[aria-label="Profile and app menu"]')).toHaveCount(1);
+    await expect(page.locator("html")).toHaveCSS("scrollbar-gutter", "stable");
+
+    const headingBehindSignIn = await page.locator("main h2").boundingBox();
+    expect(headingBehindSignIn).toEqual(headingBeforeSignIn);
+    await expect(
+      homeHeadingElement.evaluate((element) => element === document.querySelector("main h2")),
+    ).resolves.toBe(true);
 
     await page.getByRole("button", { name: "Close sign-in" }).click();
     await expect(page).toHaveURL(/\/\?__internal_offline_only=true$/);

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -73,6 +73,97 @@ test.describe("Browser harness", () => {
     await expect(page).toHaveURL(/\/\?__internal_offline_only=true$/);
   });
 
+  test("returns straight to home after signing in", async ({ harness, page }) => {
+    const homePage = new HomePage(page);
+    const user = {
+      createdAt: new Date().toISOString(),
+      email: "alex@example.com",
+      emailVerified: true,
+      id: "test-user",
+      image: null,
+      name: "Alex",
+      updatedAt: new Date().toISOString(),
+    };
+    let isSignedIn = false;
+    let partyListId = "";
+
+    await page.route("**/api/auth/**", async (route) => {
+      const pathname = new URL(route.request().url()).pathname;
+
+      if (pathname.endsWith("/get-session")) {
+        await route.fulfill({
+          json: isSignedIn
+            ? {
+                session: {
+                  createdAt: new Date().toISOString(),
+                  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+                  id: "test-session",
+                  token: "test-token",
+                  updatedAt: new Date().toISOString(),
+                  userId: user.id,
+                },
+                user,
+              }
+            : null,
+        });
+        return;
+      }
+
+      if (pathname.endsWith("/sign-in/email")) {
+        isSignedIn = true;
+        await route.fulfill({ json: { redirect: false, token: "test-token", user } });
+        return;
+      }
+
+      if (pathname.endsWith("/list-accounts")) {
+        await route.fulfill({ json: [] });
+        return;
+      }
+
+      await route.fallback();
+    });
+    await page.route("**/api/cloud-sync/settings", async (route) => {
+      await route.fulfill({
+        json: {
+          settings: {
+            partyListDocumentId: partyListId,
+            updatedAt: Date.now(),
+          },
+        },
+      });
+    });
+
+    await harness.gotoHome();
+    partyListId = (await harness.readPartyList()).partyListId;
+    await homePage.openCloudSync();
+    await page.getByRole("button", { name: "Sign in with password" }).click();
+    await page.getByLabel("Email").fill(user.email);
+    await page.getByLabel("Password").fill("test-password");
+    await page.evaluate(() => {
+      const testWindow = window as Window & { __cloudSettingsRendered?: boolean };
+      testWindow.__cloudSettingsRendered = false;
+      new MutationObserver(() => {
+        const cloudSettingsHeading = [...document.querySelectorAll("h1")].some(
+          (heading) => heading.textContent?.trim() === "trizum cloud",
+        );
+        testWindow.__cloudSettingsRendered ||= cloudSettingsHeading;
+      }).observe(document.body, { childList: true, subtree: true });
+    });
+
+    await page.getByRole("button", { name: "Sign in with password" }).click();
+
+    await expect(page.locator("p").getByText("Signed in", { exact: true })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.location.pathname)).toBe("/");
+    await expect(homePage.welcomeHeading).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as Window & { __cloudSettingsRendered?: boolean }).__cloudSettingsRendered,
+        ),
+      )
+      .toBe(false);
+  });
+
   test("can reopen an existing persisted party from the home screen", async ({ harness, page }) => {
     const homePage = new HomePage(page);
     const seededParty = await harness.joinSeededParty({

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -39,6 +39,9 @@ test.describe("Browser harness", () => {
     const homeHeading = page.getByRole("heading", { name: "Split expenses, stay even." });
     await expect(homeHeading).toBeVisible();
     await page.evaluate(() => document.fonts.ready);
+    await page.addStyleTag({
+      content: "body::after { content: ''; display: block; height: 240px; }",
+    });
     await page.evaluate(() => {
       window.scrollTo(0, document.documentElement.scrollHeight);
     });

--- a/packages/pwa/e2e/harness.spec.ts
+++ b/packages/pwa/e2e/harness.spec.ts
@@ -195,7 +195,7 @@ test.describe("Browser harness", () => {
       .toBe(false);
   });
 
-  test("keeps the auth session active on party routes", async ({ harness, page }) => {
+  test("initializes the auth session on party routes", async ({ harness, page }) => {
     const partyPage = new PartyPage(page);
     let sessionRequestCount = 0;
 
@@ -213,13 +213,6 @@ test.describe("Browser harness", () => {
     await harness.gotoParty(seededParty.partyId);
     await partyPage.expectLoaded(seededParty.partyId, "Weekend trip");
     await expect.poll(() => sessionRequestCount).toBeGreaterThan(0);
-
-    const requestsAfterRouteLoaded = sessionRequestCount;
-    await page.evaluate(() => {
-      document.dispatchEvent(new Event("visibilitychange"));
-    });
-
-    await expect.poll(() => sessionRequestCount).toBeGreaterThan(requestsAfterRouteLoaded);
   });
 
   test("keeps an open party bound to the list that admitted it", async ({

--- a/packages/pwa/e2e/harness/trizum.fixture.ts
+++ b/packages/pwa/e2e/harness/trizum.fixture.ts
@@ -2,6 +2,9 @@ import { expect, test as base, type Page } from "@playwright/test";
 
 export interface InternalHarnessWindow extends Window {
   __internal_createPartyFromMigrationData: (data: unknown) => Promise<string>;
+  __internal_createInactivePartyListState: (seed: unknown) => {
+    partyListId: string;
+  };
   __internal_seedPartyListState: (seed: unknown) => Promise<{
     partyListId: string;
   }>;
@@ -71,6 +74,9 @@ export interface BrowserHarness {
   seedPartyList(seed: PartyListSeed): Promise<{
     partyListId: string;
   }>;
+  createInactivePartyList(seed: PartyListSeed): Promise<{
+    partyListId: string;
+  }>;
   seedJoinableParty(fixture: unknown): Promise<{
     joinCode: string;
     joinUrl: string;
@@ -108,6 +114,7 @@ function createBrowserHarness(page: Page): BrowserHarness {
         const internalWindow = window as Partial<InternalHarnessWindow>;
         return (
           typeof internalWindow.__internal_createPartyFromMigrationData === "function" &&
+          typeof internalWindow.__internal_createInactivePartyListState === "function" &&
           typeof internalWindow.__internal_seedPartyListState === "function" &&
           typeof internalWindow.__internal_readPartyListState === "function" &&
           typeof internalWindow.__internal_recalculatePartyBalances === "function"
@@ -191,6 +198,15 @@ function createBrowserHarness(page: Page): BrowserHarness {
   async function seedPartyList(seed: PartyListSeed) {
     await bootstrapForSeeding();
     return writePartyList(seed);
+  }
+
+  async function createInactivePartyList(seed: PartyListSeed) {
+    await bootstrapForSeeding();
+
+    return page.evaluate((nextSeed) => {
+      const internalWindow = window as unknown as InternalHarnessWindow;
+      return internalWindow.__internal_createInactivePartyListState(nextSeed);
+    }, seed);
   }
 
   async function seedJoinableParty(fixture: unknown) {
@@ -304,6 +320,7 @@ function createBrowserHarness(page: Page): BrowserHarness {
     seedParty,
     seedParties,
     seedPartyList,
+    createInactivePartyList,
     seedJoinableParty,
     joinSeededParty,
     seedJoinedParty,

--- a/packages/pwa/e2e/harness/trizum.fixture.ts
+++ b/packages/pwa/e2e/harness/trizum.fixture.ts
@@ -2,9 +2,11 @@ import { expect, test as base, type Page } from "@playwright/test";
 
 export interface InternalHarnessWindow extends Window {
   __internal_createPartyFromMigrationData: (data: unknown) => Promise<string>;
-  __internal_createInactivePartyListState: (seed: unknown) => {
+  __internal_createDeferredPartyListState: (seed: unknown) => Promise<{
     partyListId: string;
-  };
+  }>;
+  __internal_getDocumentState: (documentId: string) => string | undefined;
+  __internal_releaseDeferredPartyListState: (partyListId: string) => void;
   __internal_seedPartyListState: (seed: unknown) => Promise<{
     partyListId: string;
   }>;
@@ -74,9 +76,11 @@ export interface BrowserHarness {
   seedPartyList(seed: PartyListSeed): Promise<{
     partyListId: string;
   }>;
-  createInactivePartyList(seed: PartyListSeed): Promise<{
+  createDeferredPartyList(seed: PartyListSeed): Promise<{
     partyListId: string;
   }>;
+  getDocumentState(documentId: string): Promise<string | undefined>;
+  releaseDeferredPartyList(partyListId: string): Promise<void>;
   seedJoinableParty(fixture: unknown): Promise<{
     joinCode: string;
     joinUrl: string;
@@ -114,7 +118,9 @@ function createBrowserHarness(page: Page): BrowserHarness {
         const internalWindow = window as Partial<InternalHarnessWindow>;
         return (
           typeof internalWindow.__internal_createPartyFromMigrationData === "function" &&
-          typeof internalWindow.__internal_createInactivePartyListState === "function" &&
+          typeof internalWindow.__internal_createDeferredPartyListState === "function" &&
+          typeof internalWindow.__internal_getDocumentState === "function" &&
+          typeof internalWindow.__internal_releaseDeferredPartyListState === "function" &&
           typeof internalWindow.__internal_seedPartyListState === "function" &&
           typeof internalWindow.__internal_readPartyListState === "function" &&
           typeof internalWindow.__internal_recalculatePartyBalances === "function"
@@ -200,13 +206,31 @@ function createBrowserHarness(page: Page): BrowserHarness {
     return writePartyList(seed);
   }
 
-  async function createInactivePartyList(seed: PartyListSeed) {
+  async function createDeferredPartyList(seed: PartyListSeed) {
     await bootstrapForSeeding();
 
-    return page.evaluate((nextSeed) => {
+    return page.evaluate(async (nextSeed) => {
       const internalWindow = window as unknown as InternalHarnessWindow;
-      return internalWindow.__internal_createInactivePartyListState(nextSeed);
+      return internalWindow.__internal_createDeferredPartyListState(nextSeed);
     }, seed);
+  }
+
+  async function getDocumentState(documentId: string) {
+    await waitForInternalHooks();
+
+    return page.evaluate((nextDocumentId) => {
+      const internalWindow = window as unknown as InternalHarnessWindow;
+      return internalWindow.__internal_getDocumentState(nextDocumentId);
+    }, documentId);
+  }
+
+  async function releaseDeferredPartyList(partyListId: string) {
+    await waitForInternalHooks();
+
+    await page.evaluate((nextPartyListId) => {
+      const internalWindow = window as unknown as InternalHarnessWindow;
+      internalWindow.__internal_releaseDeferredPartyListState(nextPartyListId);
+    }, partyListId);
   }
 
   async function seedJoinableParty(fixture: unknown) {
@@ -320,7 +344,9 @@ function createBrowserHarness(page: Page): BrowserHarness {
     seedParty,
     seedParties,
     seedPartyList,
-    createInactivePartyList,
+    createDeferredPartyList,
+    getDocumentState,
+    releaseDeferredPartyList,
     seedJoinableParty,
     joinSeededParty,
     seedJoinedParty,

--- a/packages/pwa/e2e/pages/home.page.ts
+++ b/packages/pwa/e2e/pages/home.page.ts
@@ -4,6 +4,7 @@ export class HomePage {
   readonly page: Page;
   readonly welcomeHeading: Locator;
   readonly createPartyLink: Locator;
+  readonly cloudSyncLink: Locator;
   readonly joinPartyLink: Locator;
   readonly migrateFromTricountLink: Locator;
   readonly menuButton: Locator;
@@ -12,19 +13,22 @@ export class HomePage {
   constructor(page: Page) {
     this.page = page;
     this.welcomeHeading = page.getByRole("heading", {
-      name: "Welcome to trizum",
+      name: "Split expenses, stay even.",
     });
     this.createPartyLink = page.getByRole("link", {
-      name: "Create a new Party",
+      name: "Create a Party",
+    });
+    this.cloudSyncLink = page.getByRole("link", {
+      name: /Keep every party in sync/,
     });
     this.joinPartyLink = page.getByRole("link", {
-      name: "Join a Party",
+      name: "Join with a code",
     });
     this.migrateFromTricountLink = page.getByRole("link", {
-      name: "Migrate from Tricount",
+      name: "Import from Tricount",
     });
     this.menuButton = page.getByRole("button", {
-      name: "Menu",
+      name: "Profile and app menu",
     });
     this.archivedPartiesMenuItem = page.getByRole("menuitem", {
       name: "Archived parties",
@@ -38,6 +42,7 @@ export class HomePage {
   async expectLoaded() {
     await expect(this.welcomeHeading).toBeVisible();
     await expect(this.createPartyLink).toBeVisible();
+    await expect(this.cloudSyncLink).toBeVisible();
     await expect(this.joinPartyLink).toBeVisible();
     await expect(this.migrateFromTricountLink).toBeVisible();
   }
@@ -48,6 +53,10 @@ export class HomePage {
 
   async openJoinParty() {
     await this.joinPartyLink.click();
+  }
+
+  async openCloudSync() {
+    await this.cloudSyncLink.click();
   }
 
   async openArchivedParties() {

--- a/packages/pwa/e2e/smoke.spec.ts
+++ b/packages/pwa/e2e/smoke.spec.ts
@@ -12,6 +12,29 @@ test.describe("Home smoke @smoke", () => {
     await homePage.expectLoaded();
   });
 
+  test("fits the empty state in compact mobile viewports", async ({ page }) => {
+    const homePage = new HomePage(page);
+
+    for (const viewport of [
+      { width: 375, height: 667 },
+      { width: 320, height: 568 },
+    ]) {
+      await test.step(`${viewport.width} × ${viewport.height}`, async () => {
+        await page.setViewportSize(viewport);
+        await page.goto("/?__internal_offline_only=true");
+        await homePage.expectLoaded();
+        await page.evaluate(() => document.fonts.ready);
+
+        const { scrollHeight, viewportHeight } = await page.evaluate(() => ({
+          scrollHeight: document.documentElement.scrollHeight,
+          viewportHeight: window.innerHeight,
+        }));
+
+        expect(scrollHeight).toBeLessThanOrEqual(viewportHeight);
+      });
+    }
+  });
+
   test("navigates to create and join flows from the home screen", async ({ page }) => {
     const homePage = new HomePage(page);
     const newTrizumPage = new NewTrizumPage(page);

--- a/packages/pwa/e2e/smoke.spec.ts
+++ b/packages/pwa/e2e/smoke.spec.ts
@@ -14,14 +14,17 @@ test.describe("Home smoke @smoke", () => {
 
   test("fits the empty state in compact mobile viewports", async ({ page }) => {
     const homePage = new HomePage(page);
-
-    for (const viewport of [
+    const viewports = [
       { width: 375, height: 667 },
       { width: 320, height: 568 },
-    ]) {
+    ];
+
+    await page.setViewportSize(viewports[0]);
+    await page.goto("/?__internal_offline_only=true");
+
+    for (const viewport of viewports) {
       await test.step(`${viewport.width} × ${viewport.height}`, async () => {
         await page.setViewportSize(viewport);
-        await page.goto("/?__internal_offline_only=true");
         await homePage.expectLoaded();
         await page.evaluate(() => document.fonts.ready);
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -67,7 +67,7 @@ msgid "A name for the participant is required"
 msgstr "A name for the participant is required"
 
 #: src/routes/about/route.tsx:23
-#: src/routes/index/route.tsx:149
+#: src/routes/index/route.tsx:164
 msgid "About"
 msgstr "About"
 
@@ -75,7 +75,7 @@ msgstr "About"
 msgid "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 msgstr "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 
-#: src/routes/settings.tsx:444
+#: src/routes/settings.tsx:255
 msgid "Accent color"
 msgstr "Accent color"
 
@@ -124,7 +124,7 @@ msgstr "Add expenses to this party to unlock totals, rankings, and individual sp
 msgid "Add Google as a sign-in method"
 msgstr "Add Google as a sign-in method"
 
-#: src/routes/index/route.tsx:197
+#: src/routes/index/route.tsx:212
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Add or create"
@@ -214,7 +214,7 @@ msgstr "Archive a party from the home screen when you want to clear some space w
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archive participants who left to keep balances clean."
 
-#: src/routes/index/route.tsx:266
+#: src/routes/index/route.tsx:281
 msgid "Archive party"
 msgstr "Archive party"
 
@@ -226,7 +226,7 @@ msgstr "Archived"
 msgid "Archived participants"
 msgstr "Archived participants"
 
-#: src/routes/index/route.tsx:127
+#: src/routes/index/route.tsx:142
 msgid "Archived parties"
 msgstr "Archived parties"
 
@@ -284,15 +284,15 @@ msgid "Authentication failed"
 msgstr "Authentication failed"
 
 #: src/components/ExpenseEditor.tsx:369
-#: src/routes/settings.tsx:431
+#: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
 
-#: src/routes/settings.tsx:433
+#: src/routes/settings.tsx:244
 msgid "Automatically open the calculator when focusing amount fields"
 msgstr "Automatically open the calculator when focusing amount fields"
 
-#: src/routes/settings.tsx:420
+#: src/routes/settings.tsx:231
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Automatically open the last visited party when you open the app"
 
@@ -312,7 +312,6 @@ msgstr "Azerbaijani Manat"
 msgid "Back to home"
 msgstr "Back to home"
 
-#: src/components/CloudSyncDialogs.tsx:209
 #: src/routes/reset-password.tsx:102
 msgid "Back to settings"
 msgstr "Back to settings"
@@ -487,7 +486,7 @@ msgstr "CFP Franc"
 msgid "Changes sync automatically across all your devices"
 msgstr "Changes sync automatically across all your devices"
 
-#: src/routes/index/route.tsx:138
+#: src/routes/index/route.tsx:153
 msgid "Check for updates"
 msgstr "Check for updates"
 
@@ -559,6 +558,10 @@ msgstr "Close calculator"
 #: src/components/CalculatorToolbar.tsx:1495
 msgid "Close parenthesis"
 msgstr "Close parenthesis"
+
+#: src/components/CloudSyncDialogs.tsx:209
+msgid "Close sign-in"
+msgstr "Close sign-in"
 
 #: src/routes/settings.tsx:533
 msgid "Cloud settings applied"
@@ -714,7 +717,6 @@ msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
 #: src/hooks/useCloudSyncAccountState.ts:192
-#: src/routes/settings.tsx:487
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
 
@@ -742,10 +744,17 @@ msgstr "Could not sign out"
 msgid "Couldn't connect sign-in method"
 msgstr "Couldn't connect sign-in method"
 
-#: src/routes/index/-components/EmptyState.tsx:25
-#: src/routes/index/route.tsx:214
+#: src/routes/index/route.tsx:229
 msgid "Create a new Party"
 msgstr "Create a new Party"
+
+#: src/routes/index/-components/EmptyState.tsx:34
+msgid "Create a Party"
+msgstr "Create a Party"
+
+#: src/routes/index/-components/EmptyState.tsx:26
+msgid "Create a party in seconds, track who paid, and settle up without the awkward maths."
+msgstr "Create a party in seconds, track who paid, and settle up without the awkward maths."
 
 #: src/routes/settings_.cloud-sync.tsx:524
 #: src/routes/settings_.cloud-sync.tsx:564
@@ -960,7 +969,7 @@ msgstr "Emoji list"
 msgid "End date"
 msgstr "End date"
 
-#: src/routes/settings.tsx:119
+#: src/routes/settings.tsx:44
 msgid "English"
 msgstr "English"
 
@@ -980,7 +989,7 @@ msgstr "Enter the link or code of the trizum party you want to join"
 msgid "Eritrean Nakfa"
 msgstr "Eritrean Nakfa"
 
-#: src/routes/settings.tsx:120
+#: src/routes/settings.tsx:45
 msgid "Español"
 msgstr "Español"
 
@@ -1115,7 +1124,7 @@ msgstr "Filter totals and rankings"
 msgid "Finishing sign in"
 msgstr "Finishing sign in"
 
-#: src/routes/settings.tsx:382
+#: src/routes/settings.tsx:193
 msgid "For payments through Bizum or similar services"
 msgstr "For payments through Bizum or similar services"
 
@@ -1285,6 +1294,10 @@ msgstr "Impact on my balance: <0/>"
 msgid "Import attachments"
 msgstr "Import attachments"
 
+#: src/routes/index/-components/EmptyState.tsx:89
+msgid "Import from Tricount"
+msgstr "Import from Tricount"
+
 #: src/routes/index/-components/EmptyState.tsx:38
 msgid "Import your existing Tricount data"
 msgstr "Import your existing Tricount data"
@@ -1375,8 +1388,7 @@ msgstr "Join {partyName} on trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "Join {partyName} on trizum!"
 
-#: src/routes/index/-components/EmptyState.tsx:31
-#: src/routes/index/route.tsx:208
+#: src/routes/index/route.tsx:223
 msgid "Join a Party"
 msgstr "Join a Party"
 
@@ -1387,6 +1399,10 @@ msgstr "Join a trizum"
 #: src/lib/partySharePreviewMessages.ts:6
 msgid "Join party"
 msgstr "Join party"
+
+#: src/routes/index/-components/EmptyState.tsx:37
+msgid "Join with a code"
+msgstr "Join with a code"
 
 #: src/routes/party.$partyId.tsx:66
 msgid "Joined {0}!"
@@ -1403,6 +1419,10 @@ msgstr "Jump back into the groups you use most"
 #: src/routes/new/route.tsx:257
 msgid "Kazakhstani Tenge"
 msgstr "Kazakhstani Tenge"
+
+#: src/routes/index/-components/EmptyState.tsx:62
+msgid "Keep every party in sync"
+msgstr "Keep every party in sync"
 
 #: src/routes/settings_.cloud-sync.tsx:824
 msgid "Keep local data"
@@ -1424,7 +1444,7 @@ msgstr "Kuwaiti Dinar"
 msgid "Kyrgystani Som"
 msgstr "Kyrgystani Som"
 
-#: src/routes/settings.tsx:397
+#: src/routes/settings.tsx:208
 msgid "Language"
 msgstr "Language"
 
@@ -1512,9 +1532,17 @@ msgstr "Maldivian Rufiyaa"
 msgid "Malformed Party ID"
 msgstr "Malformed Party ID"
 
+#: src/routes/index/-components/EmptyState.tsx:73
+msgid "Manage"
+msgstr "Manage"
+
 #: src/routes/party_.$partyId.settings/-components/PartyParticipantsField.tsx:26
 msgid "Manage the participants list. Existing members can only be archived."
 msgstr "Manage the participants list. Existing members can only be archived."
+
+#: src/routes/index/-components/EmptyState.tsx:66
+msgid "Manage your cloud account and synced data."
+msgstr "Manage your cloud account and synced data."
 
 #: src/routes/party_.$partyId.pay/route.tsx:95
 #: src/routes/party_.$partyId.pay/route.tsx:120
@@ -1542,7 +1570,6 @@ msgid "Me"
 msgstr "Me"
 
 #: src/components/ExpenseEditor.tsx:362
-#: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1556,8 +1583,7 @@ msgstr "Mexican Investment Unit"
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
-#: src/routes/index/-components/EmptyState.tsx:37
-#: src/routes/index/route.tsx:220
+#: src/routes/index/route.tsx:235
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrate from Tricount"
@@ -1804,7 +1830,7 @@ msgstr "Open calculator when focusing amount fields"
 msgid "Open GitHub Issues"
 msgstr "Open GitHub Issues"
 
-#: src/routes/settings.tsx:418
+#: src/routes/settings.tsx:229
 msgid "Open last party on launch"
 msgstr "Open last party on launch"
 
@@ -1901,7 +1927,7 @@ msgstr "Participants"
 msgid "Party actions"
 msgstr "Party actions"
 
-#: src/routes/index/route.tsx:287
+#: src/routes/index/route.tsx:302
 msgid "Party archived"
 msgstr "Party archived"
 
@@ -1925,7 +1951,7 @@ msgstr "Party leaderboard"
 msgid "Party link copied to clipboard!"
 msgstr "Party link copied to clipboard!"
 
-#: src/routes/index/route.tsx:279
+#: src/routes/index/route.tsx:294
 msgid "Party pinned"
 msgstr "Party pinned"
 
@@ -1949,7 +1975,7 @@ msgstr "Party shared!"
 msgid "Party stats"
 msgstr "Party stats"
 
-#: src/routes/index/route.tsx:279
+#: src/routes/index/route.tsx:294
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
@@ -2019,7 +2045,7 @@ msgstr "Peruvian Sol"
 msgid "Philippine Peso"
 msgstr "Philippine Peso"
 
-#: src/routes/settings.tsx:381
+#: src/routes/settings.tsx:192
 msgid "Phone number"
 msgstr "Phone number"
 
@@ -2035,7 +2061,7 @@ msgstr "Phone number is required"
 msgid "Phone number must be less than 20 characters"
 msgstr "Phone number must be less than 20 characters"
 
-#: src/routes/index/route.tsx:260
+#: src/routes/index/route.tsx:275
 msgid "Pin party"
 msgstr "Pin party"
 
@@ -2094,6 +2120,10 @@ msgstr "Previous"
 #: src/routes/about/route.tsx:110
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
+
+#: src/routes/index/route.tsx:107
+msgid "Profile and app menu"
+msgstr "Profile and app menu"
 
 #: src/routes/new/route.tsx:289
 msgid "Qatari Rial"
@@ -2211,7 +2241,7 @@ msgstr "Saudi Riyal"
 #: src/routes/party_.$partyId.settings/route.tsx:120
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
-#: src/routes/settings.tsx:232
+#: src/routes/settings.tsx:98
 msgid "Save"
 msgstr "Save"
 
@@ -2231,6 +2261,10 @@ msgstr "Search emoji"
 #: src/components/EmojiPicker.tsx:182
 msgid "Search emoji..."
 msgstr "Search emoji..."
+
+#: src/routes/index/-components/EmptyState.tsx:68
+msgid "Securely access your data on all your devices."
+msgstr "Securely access your data on all your devices."
 
 #: src/components/CloudSyncAccountSettings.tsx:65
 msgid "Security"
@@ -2272,13 +2306,13 @@ msgstr "Set up password?"
 msgid "Set up your username, avatar, and preferences"
 msgstr "Set up your username, avatar, and preferences"
 
-#: src/routes/index/route.tsx:116
+#: src/routes/index/route.tsx:120
 #: src/routes/party.$partyId/route.tsx:259
-#: src/routes/settings.tsx:263
+#: src/routes/settings.tsx:121
 msgid "Settings"
 msgstr "Settings"
 
-#: src/routes/settings.tsx:190
+#: src/routes/settings.tsx:65
 msgid "Settings saved"
 msgstr "Settings saved"
 
@@ -2329,10 +2363,11 @@ msgid "Sierra Leonean Leone"
 msgstr "Sierra Leonean Leone"
 
 #: src/components/CloudSyncDialogs.tsx:205
+#: src/routes/index/-components/EmptyState.tsx:73
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/routes/settings_.cloud-sync.tsx:953
+#: src/routes/settings_.cloud-sync.tsx:971
 msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
@@ -2461,6 +2496,10 @@ msgstr "Split expenses and settle up together on trizum."
 msgid "Split expenses fairly among multiple participants"
 msgstr "Split expenses fairly among multiple participants"
 
+#: src/routes/index/-components/EmptyState.tsx:23
+msgid "Split expenses, stay even."
+msgstr "Split expenses, stay even."
+
 #: src/routes/new/route.tsx:260
 msgid "Sri Lankan Rupee"
 msgstr "Sri Lankan Rupee"
@@ -2492,7 +2531,7 @@ msgstr "Submit a Request"
 #: src/routes/party_.$partyId.settings/route.tsx:120
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
-#: src/routes/settings.tsx:232
+#: src/routes/settings.tsx:98
 msgid "Submitting..."
 msgstr "Submitting..."
 
@@ -2566,7 +2605,7 @@ msgstr "Syncing party information..."
 msgid "Syrian Pound"
 msgstr "Syrian Pound"
 
-#: src/routes/settings.tsx:118
+#: src/routes/settings.tsx:43
 msgid "System (fallbacks to {DEFAULT_LOCALE})"
 msgstr "System (fallbacks to {DEFAULT_LOCALE})"
 
@@ -2750,8 +2789,8 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
+#: src/routes/index/route.tsx:131
 #: src/routes/settings_.cloud-sync.tsx:828
-#: src/routes/settings.tsx:308
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
@@ -2838,7 +2877,7 @@ msgstr "Ukrainian Hryvnia"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/index/route.tsx:260
+#: src/routes/index/route.tsx:275
 msgid "Unpin party"
 msgstr "Unpin party"
 
@@ -2944,7 +2983,7 @@ msgstr "Use trizum cloud on this device?"
 msgid "Use your camera to scan a trizum invite"
 msgstr "Use your camera to scan a trizum invite"
 
-#: src/routes/settings.tsx:359
+#: src/routes/settings.tsx:170
 msgid "Username"
 msgstr "Username"
 
@@ -3038,7 +3077,7 @@ msgstr "Welcome to trizum"
 msgid "What is this party about?"
 msgstr "What is this party about?"
 
-#: src/routes/settings.tsx:360
+#: src/routes/settings.tsx:171
 msgid "What's your preferred way to be addressed?"
 msgstr "What's your preferred way to be addressed?"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -66,7 +66,7 @@ msgstr "<0>{fromName}</0> stops owing <1>{toName}</1>"
 msgid "A name for the participant is required"
 msgstr "A name for the participant is required"
 
-#: src/routes/_home/route.tsx:114
+#: src/routes/_home/route.tsx:117
 #: src/routes/about/route.tsx:23
 msgid "About"
 msgstr "About"
@@ -124,7 +124,7 @@ msgstr "Add expenses to this party to unlock totals, rankings, and individual sp
 msgid "Add Google as a sign-in method"
 msgstr "Add Google as a sign-in method"
 
-#: src/routes/_home/route.tsx:162
+#: src/routes/_home/route.tsx:165
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Add or create"
@@ -214,7 +214,7 @@ msgstr "Archive a party from the home screen when you want to clear some space w
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archive participants who left to keep balances clean."
 
-#: src/routes/_home/route.tsx:232
+#: src/routes/_home/route.tsx:235
 msgid "Archive party"
 msgstr "Archive party"
 
@@ -226,7 +226,7 @@ msgstr "Archived"
 msgid "Archived participants"
 msgstr "Archived participants"
 
-#: src/routes/_home/route.tsx:96
+#: src/routes/_home/route.tsx:99
 msgid "Archived parties"
 msgstr "Archived parties"
 
@@ -486,7 +486,7 @@ msgstr "CFP Franc"
 msgid "Changes sync automatically across all your devices"
 msgstr "Changes sync automatically across all your devices"
 
-#: src/routes/_home/route.tsx:107
+#: src/routes/_home/route.tsx:110
 msgid "Check for updates"
 msgstr "Check for updates"
 
@@ -744,7 +744,7 @@ msgstr "Could not sign out"
 msgid "Couldn't connect sign-in method"
 msgstr "Couldn't connect sign-in method"
 
-#: src/routes/_home/route.tsx:179
+#: src/routes/_home/route.tsx:182
 msgid "Create a new Party"
 msgstr "Create a new Party"
 
@@ -1294,7 +1294,7 @@ msgstr "Impact on my balance: <0/>"
 msgid "Import attachments"
 msgstr "Import attachments"
 
-#: src/routes/index/-components/EmptyState.tsx:89
+#: src/routes/index/-components/EmptyState.tsx:90
 msgid "Import from Tricount"
 msgstr "Import from Tricount"
 
@@ -1388,7 +1388,7 @@ msgstr "Join {partyName} on trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "Join {partyName} on trizum!"
 
-#: src/routes/_home/route.tsx:173
+#: src/routes/_home/route.tsx:176
 msgid "Join a Party"
 msgstr "Join a Party"
 
@@ -1420,7 +1420,7 @@ msgstr "Jump back into the groups you use most"
 msgid "Kazakhstani Tenge"
 msgstr "Kazakhstani Tenge"
 
-#: src/routes/index/-components/EmptyState.tsx:62
+#: src/routes/index/-components/EmptyState.tsx:63
 msgid "Keep every party in sync"
 msgstr "Keep every party in sync"
 
@@ -1532,7 +1532,7 @@ msgstr "Maldivian Rufiyaa"
 msgid "Malformed Party ID"
 msgstr "Malformed Party ID"
 
-#: src/routes/index/-components/EmptyState.tsx:73
+#: src/routes/index/-components/EmptyState.tsx:74
 msgid "Manage"
 msgstr "Manage"
 
@@ -1540,7 +1540,7 @@ msgstr "Manage"
 msgid "Manage the participants list. Existing members can only be archived."
 msgstr "Manage the participants list. Existing members can only be archived."
 
-#: src/routes/index/-components/EmptyState.tsx:66
+#: src/routes/index/-components/EmptyState.tsx:67
 msgid "Manage your cloud account and synced data."
 msgstr "Manage your cloud account and synced data."
 
@@ -1583,7 +1583,7 @@ msgstr "Mexican Investment Unit"
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
-#: src/routes/_home/route.tsx:185
+#: src/routes/_home/route.tsx:188
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrate from Tricount"
@@ -1927,7 +1927,7 @@ msgstr "Participants"
 msgid "Party actions"
 msgstr "Party actions"
 
-#: src/routes/_home/route.tsx:253
+#: src/routes/_home/route.tsx:256
 msgid "Party archived"
 msgstr "Party archived"
 
@@ -1951,7 +1951,7 @@ msgstr "Party leaderboard"
 msgid "Party link copied to clipboard!"
 msgstr "Party link copied to clipboard!"
 
-#: src/routes/_home/route.tsx:245
+#: src/routes/_home/route.tsx:248
 msgid "Party pinned"
 msgstr "Party pinned"
 
@@ -1975,7 +1975,7 @@ msgstr "Party shared!"
 msgid "Party stats"
 msgstr "Party stats"
 
-#: src/routes/_home/route.tsx:245
+#: src/routes/_home/route.tsx:248
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
@@ -2061,7 +2061,7 @@ msgstr "Phone number is required"
 msgid "Phone number must be less than 20 characters"
 msgstr "Phone number must be less than 20 characters"
 
-#: src/routes/_home/route.tsx:226
+#: src/routes/_home/route.tsx:229
 msgid "Pin party"
 msgstr "Pin party"
 
@@ -2262,7 +2262,7 @@ msgstr "Search emoji"
 msgid "Search emoji..."
 msgstr "Search emoji..."
 
-#: src/routes/index/-components/EmptyState.tsx:68
+#: src/routes/index/-components/EmptyState.tsx:69
 msgid "Securely access your data on all your devices."
 msgstr "Securely access your data on all your devices."
 
@@ -2363,7 +2363,7 @@ msgid "Sierra Leonean Leone"
 msgstr "Sierra Leonean Leone"
 
 #: src/components/CloudSyncDialogs.tsx:205
-#: src/routes/index/-components/EmptyState.tsx:73
+#: src/routes/index/-components/EmptyState.tsx:74
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -2789,7 +2789,7 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/_home/route.tsx:89
+#: src/routes/_home/route.tsx:92
 #: src/routes/_home/settings_.cloud-sync.tsx:821
 msgid "trizum cloud"
 msgstr "trizum cloud"
@@ -2877,7 +2877,7 @@ msgstr "Ukrainian Hryvnia"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/_home/route.tsx:226
+#: src/routes/_home/route.tsx:229
 msgid "Unpin party"
 msgstr "Unpin party"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -66,7 +66,7 @@ msgstr "<0>{fromName}</0> stops owing <1>{toName}</1>"
 msgid "A name for the participant is required"
 msgstr "A name for the participant is required"
 
-#: src/routes/_home/route.tsx:117
+#: src/routes/_home/route.tsx:113
 #: src/routes/about/route.tsx:23
 msgid "About"
 msgstr "About"
@@ -124,7 +124,7 @@ msgstr "Add expenses to this party to unlock totals, rankings, and individual sp
 msgid "Add Google as a sign-in method"
 msgstr "Add Google as a sign-in method"
 
-#: src/routes/_home/route.tsx:165
+#: src/routes/_home/route.tsx:161
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Add or create"
@@ -214,7 +214,7 @@ msgstr "Archive a party from the home screen when you want to clear some space w
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archive participants who left to keep balances clean."
 
-#: src/routes/_home/route.tsx:235
+#: src/routes/_home/route.tsx:231
 msgid "Archive party"
 msgstr "Archive party"
 
@@ -226,7 +226,7 @@ msgstr "Archived"
 msgid "Archived participants"
 msgstr "Archived participants"
 
-#: src/routes/_home/route.tsx:99
+#: src/routes/_home/route.tsx:95
 msgid "Archived parties"
 msgstr "Archived parties"
 
@@ -486,7 +486,7 @@ msgstr "CFP Franc"
 msgid "Changes sync automatically across all your devices"
 msgstr "Changes sync automatically across all your devices"
 
-#: src/routes/_home/route.tsx:110
+#: src/routes/_home/route.tsx:106
 msgid "Check for updates"
 msgstr "Check for updates"
 
@@ -744,7 +744,7 @@ msgstr "Could not sign out"
 msgid "Couldn't connect sign-in method"
 msgstr "Couldn't connect sign-in method"
 
-#: src/routes/_home/route.tsx:182
+#: src/routes/_home/route.tsx:178
 msgid "Create a new Party"
 msgstr "Create a new Party"
 
@@ -1388,7 +1388,7 @@ msgstr "Join {partyName} on trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "Join {partyName} on trizum!"
 
-#: src/routes/_home/route.tsx:176
+#: src/routes/_home/route.tsx:172
 msgid "Join a Party"
 msgstr "Join a Party"
 
@@ -1583,7 +1583,7 @@ msgstr "Mexican Investment Unit"
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
-#: src/routes/_home/route.tsx:188
+#: src/routes/_home/route.tsx:184
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrate from Tricount"
@@ -1927,7 +1927,7 @@ msgstr "Participants"
 msgid "Party actions"
 msgstr "Party actions"
 
-#: src/routes/_home/route.tsx:256
+#: src/routes/_home/route.tsx:252
 msgid "Party archived"
 msgstr "Party archived"
 
@@ -1951,7 +1951,7 @@ msgstr "Party leaderboard"
 msgid "Party link copied to clipboard!"
 msgstr "Party link copied to clipboard!"
 
-#: src/routes/_home/route.tsx:248
+#: src/routes/_home/route.tsx:244
 msgid "Party pinned"
 msgstr "Party pinned"
 
@@ -1975,7 +1975,7 @@ msgstr "Party shared!"
 msgid "Party stats"
 msgstr "Party stats"
 
-#: src/routes/_home/route.tsx:248
+#: src/routes/_home/route.tsx:244
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
@@ -2061,7 +2061,7 @@ msgstr "Phone number is required"
 msgid "Phone number must be less than 20 characters"
 msgstr "Phone number must be less than 20 characters"
 
-#: src/routes/_home/route.tsx:229
+#: src/routes/_home/route.tsx:225
 msgid "Pin party"
 msgstr "Pin party"
 
@@ -2121,7 +2121,7 @@ msgstr "Previous"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: src/routes/_home/route.tsx:73
+#: src/routes/_home/route.tsx:71
 msgid "Profile and app menu"
 msgstr "Profile and app menu"
 
@@ -2306,7 +2306,7 @@ msgstr "Set up password?"
 msgid "Set up your username, avatar, and preferences"
 msgstr "Set up your username, avatar, and preferences"
 
-#: src/routes/_home/route.tsx:82
+#: src/routes/_home/route.tsx:78
 #: src/routes/party.$partyId/route.tsx:259
 #: src/routes/settings.tsx:121
 msgid "Settings"
@@ -2789,7 +2789,7 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/_home/route.tsx:92
+#: src/routes/_home/route.tsx:88
 #: src/routes/_home/settings_.cloud-sync.tsx:821
 msgid "trizum cloud"
 msgstr "trizum cloud"
@@ -2877,7 +2877,7 @@ msgstr "Ukrainian Hryvnia"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/_home/route.tsx:229
+#: src/routes/_home/route.tsx:225
 msgid "Unpin party"
 msgstr "Unpin party"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -66,7 +66,7 @@ msgstr "<0>{fromName}</0> stops owing <1>{toName}</1>"
 msgid "A name for the participant is required"
 msgstr "A name for the participant is required"
 
-#: src/routes/_home/route.tsx:113
+#: src/routes/_home/route.tsx:125
 #: src/routes/about/route.tsx:23
 msgid "About"
 msgstr "About"
@@ -124,7 +124,7 @@ msgstr "Add expenses to this party to unlock totals, rankings, and individual sp
 msgid "Add Google as a sign-in method"
 msgstr "Add Google as a sign-in method"
 
-#: src/routes/_home/route.tsx:161
+#: src/routes/_home/route.tsx:173
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Add or create"
@@ -214,7 +214,7 @@ msgstr "Archive a party from the home screen when you want to clear some space w
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archive participants who left to keep balances clean."
 
-#: src/routes/_home/route.tsx:231
+#: src/routes/_home/route.tsx:243
 msgid "Archive party"
 msgstr "Archive party"
 
@@ -226,7 +226,7 @@ msgstr "Archived"
 msgid "Archived participants"
 msgstr "Archived participants"
 
-#: src/routes/_home/route.tsx:95
+#: src/routes/_home/route.tsx:107
 msgid "Archived parties"
 msgstr "Archived parties"
 
@@ -486,7 +486,7 @@ msgstr "CFP Franc"
 msgid "Changes sync automatically across all your devices"
 msgstr "Changes sync automatically across all your devices"
 
-#: src/routes/_home/route.tsx:106
+#: src/routes/_home/route.tsx:118
 msgid "Check for updates"
 msgstr "Check for updates"
 
@@ -744,7 +744,7 @@ msgstr "Could not sign out"
 msgid "Couldn't connect sign-in method"
 msgstr "Couldn't connect sign-in method"
 
-#: src/routes/_home/route.tsx:178
+#: src/routes/_home/route.tsx:190
 msgid "Create a new Party"
 msgstr "Create a new Party"
 
@@ -1388,7 +1388,7 @@ msgstr "Join {partyName} on trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "Join {partyName} on trizum!"
 
-#: src/routes/_home/route.tsx:172
+#: src/routes/_home/route.tsx:184
 msgid "Join a Party"
 msgstr "Join a Party"
 
@@ -1540,6 +1540,10 @@ msgstr "Manage"
 msgid "Manage the participants list. Existing members can only be archived."
 msgstr "Manage the participants list. Existing members can only be archived."
 
+#: src/routes/_home/route.tsx:97
+msgid "Manage trizum cloud"
+msgstr "Manage trizum cloud"
+
 #: src/routes/index/-components/EmptyState.tsx:67
 msgid "Manage your cloud account and synced data."
 msgstr "Manage your cloud account and synced data."
@@ -1583,7 +1587,7 @@ msgstr "Mexican Investment Unit"
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
-#: src/routes/_home/route.tsx:184
+#: src/routes/_home/route.tsx:196
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrate from Tricount"
@@ -1927,7 +1931,7 @@ msgstr "Participants"
 msgid "Party actions"
 msgstr "Party actions"
 
-#: src/routes/_home/route.tsx:252
+#: src/routes/_home/route.tsx:264
 msgid "Party archived"
 msgstr "Party archived"
 
@@ -1951,7 +1955,7 @@ msgstr "Party leaderboard"
 msgid "Party link copied to clipboard!"
 msgstr "Party link copied to clipboard!"
 
-#: src/routes/_home/route.tsx:244
+#: src/routes/_home/route.tsx:256
 msgid "Party pinned"
 msgstr "Party pinned"
 
@@ -1975,7 +1979,7 @@ msgstr "Party shared!"
 msgid "Party stats"
 msgstr "Party stats"
 
-#: src/routes/_home/route.tsx:244
+#: src/routes/_home/route.tsx:256
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
@@ -2061,7 +2065,7 @@ msgstr "Phone number is required"
 msgid "Phone number must be less than 20 characters"
 msgstr "Phone number must be less than 20 characters"
 
-#: src/routes/_home/route.tsx:225
+#: src/routes/_home/route.tsx:237
 msgid "Pin party"
 msgstr "Pin party"
 
@@ -2121,7 +2125,7 @@ msgstr "Previous"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: src/routes/_home/route.tsx:71
+#: src/routes/_home/route.tsx:74
 msgid "Profile and app menu"
 msgstr "Profile and app menu"
 
@@ -2306,7 +2310,7 @@ msgstr "Set up password?"
 msgid "Set up your username, avatar, and preferences"
 msgstr "Set up your username, avatar, and preferences"
 
-#: src/routes/_home/route.tsx:78
+#: src/routes/_home/route.tsx:81
 #: src/routes/party.$partyId/route.tsx:259
 #: src/routes/settings.tsx:121
 msgid "Settings"
@@ -2372,6 +2376,7 @@ msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
 #: src/components/CloudSyncDialogs.tsx:225
+#: src/routes/_home/route.tsx:99
 msgid "Sign in to trizum cloud"
 msgstr "Sign in to trizum cloud"
 
@@ -2789,7 +2794,6 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/_home/route.tsx:88
 #: src/routes/_home/settings_.cloud-sync.tsx:860
 msgid "trizum cloud"
 msgstr "trizum cloud"
@@ -2877,12 +2881,12 @@ msgstr "Ukrainian Hryvnia"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/_home/route.tsx:225
+#: src/routes/_home/route.tsx:237
 msgid "Unpin party"
 msgstr "Unpin party"
 
 #: src/components/UpdateController.tsx:28
-#: src/routes/_home/route.tsx:59
+#: src/routes/_home/route.tsx:62
 msgid "Update available"
 msgstr "Update available"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -66,8 +66,8 @@ msgstr "<0>{fromName}</0> stops owing <1>{toName}</1>"
 msgid "A name for the participant is required"
 msgstr "A name for the participant is required"
 
+#: src/routes/_home/route.tsx:114
 #: src/routes/about/route.tsx:23
-#: src/routes/index/route.tsx:164
 msgid "About"
 msgstr "About"
 
@@ -83,7 +83,7 @@ msgstr "Accent color"
 msgid "Account created"
 msgstr "Account created"
 
-#: src/routes/settings_.cloud-sync.tsx:664
+#: src/routes/_home/settings_.cloud-sync.tsx:663
 msgid "Account deleted"
 msgstr "Account deleted"
 
@@ -124,7 +124,7 @@ msgstr "Add expenses to this party to unlock totals, rankings, and individual sp
 msgid "Add Google as a sign-in method"
 msgstr "Add Google as a sign-in method"
 
-#: src/routes/index/route.tsx:212
+#: src/routes/_home/route.tsx:162
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Add or create"
@@ -214,7 +214,7 @@ msgstr "Archive a party from the home screen when you want to clear some space w
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archive participants who left to keep balances clean."
 
-#: src/routes/index/route.tsx:281
+#: src/routes/_home/route.tsx:232
 msgid "Archive party"
 msgstr "Archive party"
 
@@ -226,7 +226,7 @@ msgstr "Archived"
 msgid "Archived participants"
 msgstr "Archived participants"
 
-#: src/routes/index/route.tsx:142
+#: src/routes/_home/route.tsx:96
 msgid "Archived parties"
 msgstr "Archived parties"
 
@@ -276,10 +276,10 @@ msgstr "Australian Dollar"
 msgid "Authentication error"
 msgstr "Authentication error"
 
-#: src/routes/settings_.cloud-sync.tsx:458
-#: src/routes/settings_.cloud-sync.tsx:474
-#: src/routes/settings_.cloud-sync.tsx:498
-#: src/routes/settings_.cloud-sync.tsx:509
+#: src/routes/_home/settings_.cloud-sync.tsx:457
+#: src/routes/_home/settings_.cloud-sync.tsx:473
+#: src/routes/_home/settings_.cloud-sync.tsx:497
+#: src/routes/_home/settings_.cloud-sync.tsx:508
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
@@ -486,15 +486,15 @@ msgstr "CFP Franc"
 msgid "Changes sync automatically across all your devices"
 msgstr "Changes sync automatically across all your devices"
 
-#: src/routes/index/route.tsx:153
+#: src/routes/_home/route.tsx:107
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/routes/settings_.cloud-sync.tsx:559
+#: src/routes/_home/settings_.cloud-sync.tsx:558
 msgid "Check your email for the password link"
 msgstr "Check your email for the password link"
 
-#: src/routes/settings_.cloud-sync.tsx:419
+#: src/routes/_home/settings_.cloud-sync.tsx:418
 msgid "Check your email for the sign-in link"
 msgstr "Check your email for the sign-in link"
 
@@ -700,11 +700,11 @@ msgstr "Costa Rican Colón"
 msgid "Could not apply cloud settings"
 msgstr "Could not apply cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:535
+#: src/routes/_home/settings_.cloud-sync.tsx:534
 msgid "Could not connect sign-in method"
 msgstr "Could not connect sign-in method"
 
-#: src/routes/settings_.cloud-sync.tsx:673
+#: src/routes/_home/settings_.cloud-sync.tsx:672
 msgid "Could not delete account"
 msgstr "Could not delete account"
 
@@ -728,15 +728,15 @@ msgstr "Could not reset password"
 msgid "Could not save cloud settings"
 msgstr "Could not save cloud settings"
 
-#: src/routes/settings_.cloud-sync.tsx:564
+#: src/routes/_home/settings_.cloud-sync.tsx:563
 msgid "Could not send password email"
 msgstr "Could not send password email"
 
-#: src/routes/settings_.cloud-sync.tsx:424
+#: src/routes/_home/settings_.cloud-sync.tsx:423
 msgid "Could not send sign-in link"
 msgstr "Could not send sign-in link"
 
-#: src/routes/settings_.cloud-sync.tsx:595
+#: src/routes/_home/settings_.cloud-sync.tsx:594
 msgid "Could not sign out"
 msgstr "Could not sign out"
 
@@ -744,7 +744,7 @@ msgstr "Could not sign out"
 msgid "Couldn't connect sign-in method"
 msgstr "Couldn't connect sign-in method"
 
-#: src/routes/index/route.tsx:229
+#: src/routes/_home/route.tsx:179
 msgid "Create a new Party"
 msgstr "Create a new Party"
 
@@ -1388,7 +1388,7 @@ msgstr "Join {partyName} on trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "Join {partyName} on trizum!"
 
-#: src/routes/index/route.tsx:223
+#: src/routes/_home/route.tsx:173
 msgid "Join a Party"
 msgstr "Join a Party"
 
@@ -1583,7 +1583,7 @@ msgstr "Mexican Investment Unit"
 msgid "Mexican Peso"
 msgstr "Mexican Peso"
 
-#: src/routes/index/route.tsx:235
+#: src/routes/_home/route.tsx:185
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrate from Tricount"
@@ -1927,7 +1927,7 @@ msgstr "Participants"
 msgid "Party actions"
 msgstr "Party actions"
 
-#: src/routes/index/route.tsx:302
+#: src/routes/_home/route.tsx:253
 msgid "Party archived"
 msgstr "Party archived"
 
@@ -1951,7 +1951,7 @@ msgstr "Party leaderboard"
 msgid "Party link copied to clipboard!"
 msgstr "Party link copied to clipboard!"
 
-#: src/routes/index/route.tsx:294
+#: src/routes/_home/route.tsx:245
 msgid "Party pinned"
 msgstr "Party pinned"
 
@@ -1975,7 +1975,7 @@ msgstr "Party shared!"
 msgid "Party stats"
 msgstr "Party stats"
 
-#: src/routes/index/route.tsx:294
+#: src/routes/_home/route.tsx:245
 msgid "Party unpinned"
 msgstr "Party unpinned"
 
@@ -1984,7 +1984,7 @@ msgstr "Party unpinned"
 msgid "Password"
 msgstr "Password"
 
-#: src/routes/settings_.cloud-sync.tsx:562
+#: src/routes/_home/settings_.cloud-sync.tsx:561
 msgid "Password email sent"
 msgstr "Password email sent"
 
@@ -2061,7 +2061,7 @@ msgstr "Phone number is required"
 msgid "Phone number must be less than 20 characters"
 msgstr "Phone number must be less than 20 characters"
 
-#: src/routes/index/route.tsx:275
+#: src/routes/_home/route.tsx:226
 msgid "Pin party"
 msgstr "Pin party"
 
@@ -2121,7 +2121,7 @@ msgstr "Previous"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: src/routes/index/route.tsx:107
+#: src/routes/_home/route.tsx:73
 msgid "Profile and app menu"
 msgstr "Profile and app menu"
 
@@ -2306,7 +2306,7 @@ msgstr "Set up password?"
 msgid "Set up your username, avatar, and preferences"
 msgstr "Set up your username, avatar, and preferences"
 
-#: src/routes/index/route.tsx:120
+#: src/routes/_home/route.tsx:82
 #: src/routes/party.$partyId/route.tsx:259
 #: src/routes/settings.tsx:121
 msgid "Settings"
@@ -2367,7 +2367,7 @@ msgstr "Sierra Leonean Leone"
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/routes/settings_.cloud-sync.tsx:971
+#: src/routes/_home/settings_.cloud-sync.tsx:946
 msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
@@ -2402,15 +2402,15 @@ msgstr "Sign-in link expired"
 msgid "Sign-in link is invalid or expired"
 msgstr "Sign-in link is invalid or expired"
 
-#: src/routes/settings_.cloud-sync.tsx:422
+#: src/routes/_home/settings_.cloud-sync.tsx:421
 msgid "Sign-in link sent"
 msgstr "Sign-in link sent"
 
-#: src/routes/settings_.cloud-sync.tsx:532
+#: src/routes/_home/settings_.cloud-sync.tsx:531
 msgid "Sign-in method connected"
 msgstr "Sign-in method connected"
 
-#: src/routes/settings_.cloud-sync.tsx:471
+#: src/routes/_home/settings_.cloud-sync.tsx:470
 msgid "Sign-in method is not configured"
 msgstr "Sign-in method is not configured"
 
@@ -2420,11 +2420,11 @@ msgstr "Sign-in methods"
 
 #: src/components/CloudSyncAccountSettings.tsx:70
 #: src/components/CloudSyncDialogs.tsx:375
-#: src/routes/settings_.cloud-sync.tsx:383
+#: src/routes/_home/settings_.cloud-sync.tsx:382
 msgid "Signed in"
 msgstr "Signed in"
 
-#: src/routes/settings_.cloud-sync.tsx:592
+#: src/routes/_home/settings_.cloud-sync.tsx:591
 msgid "Signed out"
 msgstr "Signed out"
 
@@ -2789,8 +2789,8 @@ msgstr "Tricount URL or key"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
-#: src/routes/index/route.tsx:131
-#: src/routes/settings_.cloud-sync.tsx:828
+#: src/routes/_home/route.tsx:89
+#: src/routes/_home/settings_.cloud-sync.tsx:821
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
@@ -2877,12 +2877,12 @@ msgstr "Ukrainian Hryvnia"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/index/route.tsx:275
+#: src/routes/_home/route.tsx:226
 msgid "Unpin party"
 msgstr "Unpin party"
 
 #: src/components/UpdateController.tsx:28
-#: src/routes/index/route.tsx:93
+#: src/routes/_home/route.tsx:59
 msgid "Update available"
 msgstr "Update available"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -83,7 +83,7 @@ msgstr "Accent color"
 msgid "Account created"
 msgstr "Account created"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:663
+#: src/routes/_home/settings_.cloud-sync.tsx:683
 msgid "Account deleted"
 msgstr "Account deleted"
 
@@ -276,10 +276,10 @@ msgstr "Australian Dollar"
 msgid "Authentication error"
 msgstr "Authentication error"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:457
-#: src/routes/_home/settings_.cloud-sync.tsx:473
-#: src/routes/_home/settings_.cloud-sync.tsx:497
-#: src/routes/_home/settings_.cloud-sync.tsx:508
+#: src/routes/_home/settings_.cloud-sync.tsx:477
+#: src/routes/_home/settings_.cloud-sync.tsx:493
+#: src/routes/_home/settings_.cloud-sync.tsx:517
+#: src/routes/_home/settings_.cloud-sync.tsx:528
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
@@ -490,11 +490,11 @@ msgstr "Changes sync automatically across all your devices"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:558
+#: src/routes/_home/settings_.cloud-sync.tsx:578
 msgid "Check your email for the password link"
 msgstr "Check your email for the password link"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:418
+#: src/routes/_home/settings_.cloud-sync.tsx:438
 msgid "Check your email for the sign-in link"
 msgstr "Check your email for the sign-in link"
 
@@ -700,11 +700,11 @@ msgstr "Costa Rican Colón"
 msgid "Could not apply cloud settings"
 msgstr "Could not apply cloud settings"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:534
+#: src/routes/_home/settings_.cloud-sync.tsx:554
 msgid "Could not connect sign-in method"
 msgstr "Could not connect sign-in method"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:672
+#: src/routes/_home/settings_.cloud-sync.tsx:692
 msgid "Could not delete account"
 msgstr "Could not delete account"
 
@@ -716,7 +716,7 @@ msgstr "Could not load cloud settings"
 msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
-#: src/hooks/useCloudSyncAccountState.ts:192
+#: src/hooks/useCloudSyncAccountState.ts:218
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
 
@@ -728,15 +728,15 @@ msgstr "Could not reset password"
 msgid "Could not save cloud settings"
 msgstr "Could not save cloud settings"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:563
+#: src/routes/_home/settings_.cloud-sync.tsx:583
 msgid "Could not send password email"
 msgstr "Could not send password email"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:423
+#: src/routes/_home/settings_.cloud-sync.tsx:443
 msgid "Could not send sign-in link"
 msgstr "Could not send sign-in link"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:594
+#: src/routes/_home/settings_.cloud-sync.tsx:614
 msgid "Could not sign out"
 msgstr "Could not sign out"
 
@@ -1984,7 +1984,7 @@ msgstr "Party unpinned"
 msgid "Password"
 msgstr "Password"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:561
+#: src/routes/_home/settings_.cloud-sync.tsx:581
 msgid "Password email sent"
 msgstr "Password email sent"
 
@@ -2367,7 +2367,7 @@ msgstr "Sierra Leonean Leone"
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:946
+#: src/routes/_home/settings_.cloud-sync.tsx:985
 msgid "Sign in again before deleting your account"
 msgstr "Sign in again before deleting your account"
 
@@ -2402,15 +2402,15 @@ msgstr "Sign-in link expired"
 msgid "Sign-in link is invalid or expired"
 msgstr "Sign-in link is invalid or expired"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:421
+#: src/routes/_home/settings_.cloud-sync.tsx:441
 msgid "Sign-in link sent"
 msgstr "Sign-in link sent"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:531
+#: src/routes/_home/settings_.cloud-sync.tsx:551
 msgid "Sign-in method connected"
 msgstr "Sign-in method connected"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:470
+#: src/routes/_home/settings_.cloud-sync.tsx:490
 msgid "Sign-in method is not configured"
 msgstr "Sign-in method is not configured"
 
@@ -2420,11 +2420,11 @@ msgstr "Sign-in methods"
 
 #: src/components/CloudSyncAccountSettings.tsx:70
 #: src/components/CloudSyncDialogs.tsx:375
-#: src/routes/_home/settings_.cloud-sync.tsx:382
+#: src/routes/_home/settings_.cloud-sync.tsx:402
 msgid "Signed in"
 msgstr "Signed in"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:591
+#: src/routes/_home/settings_.cloud-sync.tsx:611
 msgid "Signed out"
 msgstr "Signed out"
 
@@ -2674,7 +2674,7 @@ msgstr "This debt is no longer available"
 msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 msgstr "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 
-#: src/hooks/useCloudSyncAccountState.ts:253
+#: src/hooks/useCloudSyncAccountState.ts:272
 msgid "This device is already using trizum cloud"
 msgstr "This device is already using trizum cloud"
 
@@ -2790,25 +2790,25 @@ msgid "Trinidad and Tobago Dollar"
 msgstr "Trinidad and Tobago Dollar"
 
 #: src/routes/_home/route.tsx:88
-#: src/routes/_home/settings_.cloud-sync.tsx:821
+#: src/routes/_home/settings_.cloud-sync.tsx:860
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/hooks/useCloudSyncAccountState.ts:168
-#: src/hooks/useCloudSyncAccountState.ts:248
+#: src/hooks/useCloudSyncAccountState.ts:192
+#: src/hooks/useCloudSyncAccountState.ts:267
 msgid "trizum cloud data is invalid"
 msgstr "trizum cloud data is invalid"
 
-#: src/hooks/useCloudSyncAccountState.ts:188
-#: src/hooks/useCloudSyncAccountState.ts:270
+#: src/hooks/useCloudSyncAccountState.ts:212
+#: src/hooks/useCloudSyncAccountState.ts:289
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud enabled on this device"
 
-#: src/hooks/useCloudSyncAccountState.ts:243
+#: src/hooks/useCloudSyncAccountState.ts:262
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud is not set up yet"
 
-#: src/hooks/useCloudSyncAccountState.ts:148
+#: src/hooks/useCloudSyncAccountState.ts:172
 msgid "trizum cloud started"
 msgstr "trizum cloud started"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -716,7 +716,8 @@ msgstr "Could not load cloud settings"
 msgid "Could not load sign-in methods"
 msgstr "Could not load sign-in methods"
 
-#: src/hooks/useCloudSyncAccountState.ts:218
+#: src/hooks/useCloudSyncAccountState.ts:240
+#: src/hooks/useCloudSyncAccountState.ts:301
 msgid "Could not load trizum cloud state"
 msgstr "Could not load trizum cloud state"
 
@@ -2679,7 +2680,7 @@ msgstr "This debt is no longer available"
 msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 msgstr "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 
-#: src/hooks/useCloudSyncAccountState.ts:272
+#: src/hooks/useCloudSyncAccountState.ts:294
 msgid "This device is already using trizum cloud"
 msgstr "This device is already using trizum cloud"
 
@@ -2798,21 +2799,21 @@ msgstr "Trinidad and Tobago Dollar"
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/hooks/useCloudSyncAccountState.ts:192
-#: src/hooks/useCloudSyncAccountState.ts:267
+#: src/hooks/useCloudSyncAccountState.ts:214
+#: src/hooks/useCloudSyncAccountState.ts:289
 msgid "trizum cloud data is invalid"
 msgstr "trizum cloud data is invalid"
 
-#: src/hooks/useCloudSyncAccountState.ts:212
-#: src/hooks/useCloudSyncAccountState.ts:289
+#: src/hooks/useCloudSyncAccountState.ts:234
+#: src/hooks/useCloudSyncAccountState.ts:318
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud enabled on this device"
 
-#: src/hooks/useCloudSyncAccountState.ts:262
+#: src/hooks/useCloudSyncAccountState.ts:284
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud is not set up yet"
 
-#: src/hooks/useCloudSyncAccountState.ts:172
+#: src/hooks/useCloudSyncAccountState.ts:175
 msgid "trizum cloud started"
 msgstr "trizum cloud started"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -79,7 +79,7 @@ msgstr "Color de acento"
 msgid "Account created"
 msgstr "Cuenta creada"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:663
+#: src/routes/_home/settings_.cloud-sync.tsx:683
 msgid "Account deleted"
 msgstr "Cuenta eliminada"
 
@@ -264,10 +264,10 @@ msgstr "Dólar Australiano"
 msgid "Authentication error"
 msgstr "Error de autenticación"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:457
-#: src/routes/_home/settings_.cloud-sync.tsx:473
-#: src/routes/_home/settings_.cloud-sync.tsx:497
-#: src/routes/_home/settings_.cloud-sync.tsx:508
+#: src/routes/_home/settings_.cloud-sync.tsx:477
+#: src/routes/_home/settings_.cloud-sync.tsx:493
+#: src/routes/_home/settings_.cloud-sync.tsx:517
+#: src/routes/_home/settings_.cloud-sync.tsx:528
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
@@ -470,11 +470,11 @@ msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:558
+#: src/routes/_home/settings_.cloud-sync.tsx:578
 msgid "Check your email for the password link"
 msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:418
+#: src/routes/_home/settings_.cloud-sync.tsx:438
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
@@ -676,11 +676,11 @@ msgstr "Colón Costarricense"
 msgid "Could not apply cloud settings"
 msgstr "No se pudo aplicar la configuración en la nube"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:534
+#: src/routes/_home/settings_.cloud-sync.tsx:554
 msgid "Could not connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:672
+#: src/routes/_home/settings_.cloud-sync.tsx:692
 msgid "Could not delete account"
 msgstr "No se pudo eliminar la cuenta"
 
@@ -692,7 +692,7 @@ msgstr "No se pudo cargar la configuración en la nube"
 msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
-#: src/hooks/useCloudSyncAccountState.ts:192
+#: src/hooks/useCloudSyncAccountState.ts:218
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
 
@@ -704,15 +704,15 @@ msgstr "No se pudo restablecer la contraseña"
 msgid "Could not save cloud settings"
 msgstr "No se pudo guardar la configuración en la nube"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:563
+#: src/routes/_home/settings_.cloud-sync.tsx:583
 msgid "Could not send password email"
 msgstr "No se pudo enviar el correo de contraseña"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:423
+#: src/routes/_home/settings_.cloud-sync.tsx:443
 msgid "Could not send sign-in link"
 msgstr "No se pudo enviar el enlace de inicio de sesión"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:594
+#: src/routes/_home/settings_.cloud-sync.tsx:614
 msgid "Could not sign out"
 msgstr "No se pudo cerrar sesión"
 
@@ -1916,7 +1916,7 @@ msgstr "Grupo desfijado"
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:561
+#: src/routes/_home/settings_.cloud-sync.tsx:581
 msgid "Password email sent"
 msgstr "Correo de contraseña enviado"
 
@@ -2295,7 +2295,7 @@ msgstr "Leone de Sierra Leona"
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:946
+#: src/routes/_home/settings_.cloud-sync.tsx:985
 msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
@@ -2330,15 +2330,15 @@ msgstr "El enlace de inicio de sesión ha caducado"
 msgid "Sign-in link is invalid or expired"
 msgstr "El enlace de inicio de sesión no es válido o ha caducado"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:421
+#: src/routes/_home/settings_.cloud-sync.tsx:441
 msgid "Sign-in link sent"
 msgstr "Enlace de inicio de sesión enviado"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:531
+#: src/routes/_home/settings_.cloud-sync.tsx:551
 msgid "Sign-in method connected"
 msgstr "Método de inicio de sesión conectado"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:470
+#: src/routes/_home/settings_.cloud-sync.tsx:490
 msgid "Sign-in method is not configured"
 msgstr "El método de inicio de sesión no está configurado"
 
@@ -2348,11 +2348,11 @@ msgstr "Métodos de inicio de sesión"
 
 #: src/components/CloudSyncAccountSettings.tsx:70
 #: src/components/CloudSyncDialogs.tsx:375
-#: src/routes/_home/settings_.cloud-sync.tsx:382
+#: src/routes/_home/settings_.cloud-sync.tsx:402
 msgid "Signed in"
 msgstr "Sesión iniciada"
 
-#: src/routes/_home/settings_.cloud-sync.tsx:591
+#: src/routes/_home/settings_.cloud-sync.tsx:611
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
@@ -2598,7 +2598,7 @@ msgstr "Esta deuda ya no está disponible"
 msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 msgstr "Este dispositivo ya tiene datos locales. Si usas trizum cloud aquí, este dispositivo cambiará a tus datos en la nube. Los datos locales de este dispositivo dejarán de usarse."
 
-#: src/hooks/useCloudSyncAccountState.ts:253
+#: src/hooks/useCloudSyncAccountState.ts:272
 msgid "This device is already using trizum cloud"
 msgstr "Este dispositivo ya usa trizum cloud"
 
@@ -2702,25 +2702,25 @@ msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
 #: src/routes/_home/route.tsx:88
-#: src/routes/_home/settings_.cloud-sync.tsx:821
+#: src/routes/_home/settings_.cloud-sync.tsx:860
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/hooks/useCloudSyncAccountState.ts:168
-#: src/hooks/useCloudSyncAccountState.ts:248
+#: src/hooks/useCloudSyncAccountState.ts:192
+#: src/hooks/useCloudSyncAccountState.ts:267
 msgid "trizum cloud data is invalid"
 msgstr "Los datos de trizum cloud no son válidos"
 
-#: src/hooks/useCloudSyncAccountState.ts:188
-#: src/hooks/useCloudSyncAccountState.ts:270
+#: src/hooks/useCloudSyncAccountState.ts:212
+#: src/hooks/useCloudSyncAccountState.ts:289
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud activado en este dispositivo"
 
-#: src/hooks/useCloudSyncAccountState.ts:243
+#: src/hooks/useCloudSyncAccountState.ts:262
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud todavía no está configurado"
 
-#: src/hooks/useCloudSyncAccountState.ts:148
+#: src/hooks/useCloudSyncAccountState.ts:172
 msgid "trizum cloud started"
 msgstr "trizum cloud iniciado"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -62,7 +62,7 @@ msgstr "<0>{fromName}</0> deja de deber dinero a <1>{toName}</1>"
 msgid "A name for the participant is required"
 msgstr "Se requiere un nombre para el participante"
 
-#: src/routes/_home/route.tsx:113
+#: src/routes/_home/route.tsx:125
 #: src/routes/about/route.tsx:23
 msgid "About"
 msgstr "Acerca de"
@@ -120,7 +120,7 @@ msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto in
 msgid "Add Google as a sign-in method"
 msgstr "Añadir Google como método de inicio de sesión"
 
-#: src/routes/_home/route.tsx:161
+#: src/routes/_home/route.tsx:173
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Añadir o crear"
@@ -206,7 +206,7 @@ msgstr "Archiva un grupo desde la pantalla de inicio cuando quieras despejar esp
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archiva a los participantes que se fueron para mantener el balance limpio."
 
-#: src/routes/_home/route.tsx:231
+#: src/routes/_home/route.tsx:243
 msgid "Archive party"
 msgstr "Archivar grupo"
 
@@ -218,7 +218,7 @@ msgstr "Archivado"
 msgid "Archived participants"
 msgstr "Participantes archivados"
 
-#: src/routes/_home/route.tsx:95
+#: src/routes/_home/route.tsx:107
 msgid "Archived parties"
 msgstr "Grupos archivados"
 
@@ -466,7 +466,7 @@ msgstr "Franco CFP"
 msgid "Changes sync automatically across all your devices"
 msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 
-#: src/routes/_home/route.tsx:106
+#: src/routes/_home/route.tsx:118
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
@@ -720,7 +720,7 @@ msgstr "No se pudo cerrar sesión"
 msgid "Couldn't connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/_home/route.tsx:178
+#: src/routes/_home/route.tsx:190
 msgid "Create a new Party"
 msgstr "Crear un nuevo Grupo"
 
@@ -1340,7 +1340,7 @@ msgstr "Únete a {partyName} en trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "¡Únete a {partyName} en trizum!"
 
-#: src/routes/_home/route.tsx:172
+#: src/routes/_home/route.tsx:184
 msgid "Join a Party"
 msgstr "Unirse a un Grupo"
 
@@ -1488,6 +1488,10 @@ msgstr "Gestionar"
 msgid "Manage the participants list. Existing members can only be archived."
 msgstr "Gestiona la lista de participantes. Los miembros existentes solo pueden ser archivados."
 
+#: src/routes/_home/route.tsx:97
+msgid "Manage trizum cloud"
+msgstr "Gestionar trizum cloud"
+
 #: src/routes/index/-components/EmptyState.tsx:67
 msgid "Manage your cloud account and synced data."
 msgstr "Gestiona tu cuenta en la nube y tus datos sincronizados."
@@ -1531,7 +1535,7 @@ msgstr "Unidad de Inversión Mexicana"
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
-#: src/routes/_home/route.tsx:184
+#: src/routes/_home/route.tsx:196
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrar desde Tricount"
@@ -1867,7 +1871,7 @@ msgstr "Participantes"
 msgid "Party actions"
 msgstr "Acciones del grupo"
 
-#: src/routes/_home/route.tsx:252
+#: src/routes/_home/route.tsx:264
 msgid "Party archived"
 msgstr "Grupo archivado"
 
@@ -1883,7 +1887,7 @@ msgstr "Clasificación del grupo"
 msgid "Party link copied to clipboard!"
 msgstr "¡Enlace del grupo copiado al portapapeles!"
 
-#: src/routes/_home/route.tsx:244
+#: src/routes/_home/route.tsx:256
 msgid "Party pinned"
 msgstr "Grupo fijado"
 
@@ -1907,7 +1911,7 @@ msgstr "¡Grupo compartido!"
 msgid "Party stats"
 msgstr "Estadísticas del grupo"
 
-#: src/routes/_home/route.tsx:244
+#: src/routes/_home/route.tsx:256
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
@@ -1993,7 +1997,7 @@ msgstr "Se requiere el número de teléfono"
 msgid "Phone number must be less than 20 characters"
 msgstr "El número de teléfono debe tener menos de 20 caracteres"
 
-#: src/routes/_home/route.tsx:225
+#: src/routes/_home/route.tsx:237
 msgid "Pin party"
 msgstr "Fijar grupo"
 
@@ -2053,7 +2057,7 @@ msgstr "Anterior"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: src/routes/_home/route.tsx:71
+#: src/routes/_home/route.tsx:74
 msgid "Profile and app menu"
 msgstr "Menú de perfil y aplicación"
 
@@ -2234,7 +2238,7 @@ msgstr "¿Configurar contraseña?"
 msgid "Set up your username, avatar, and preferences"
 msgstr "Configura tu nombre de usuario, avatar y preferencias"
 
-#: src/routes/_home/route.tsx:78
+#: src/routes/_home/route.tsx:81
 #: src/routes/party.$partyId/route.tsx:259
 #: src/routes/settings.tsx:121
 msgid "Settings"
@@ -2300,6 +2304,7 @@ msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
 #: src/components/CloudSyncDialogs.tsx:225
+#: src/routes/_home/route.tsx:99
 msgid "Sign in to trizum cloud"
 msgstr "Iniciar sesión en trizum cloud"
 
@@ -2701,7 +2706,6 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/_home/route.tsx:88
 #: src/routes/_home/settings_.cloud-sync.tsx:860
 msgid "trizum cloud"
 msgstr "trizum cloud"
@@ -2789,12 +2793,12 @@ msgstr "Grivna Ucraniana"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/_home/route.tsx:225
+#: src/routes/_home/route.tsx:237
 msgid "Unpin party"
 msgstr "Desfijar grupo"
 
 #: src/components/UpdateController.tsx:28
-#: src/routes/_home/route.tsx:59
+#: src/routes/_home/route.tsx:62
 msgid "Update available"
 msgstr "Actualización disponible"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -692,7 +692,8 @@ msgstr "No se pudo cargar la configuración en la nube"
 msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
-#: src/hooks/useCloudSyncAccountState.ts:218
+#: src/hooks/useCloudSyncAccountState.ts:240
+#: src/hooks/useCloudSyncAccountState.ts:301
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
 
@@ -2603,7 +2604,7 @@ msgstr "Esta deuda ya no está disponible"
 msgid "This device already has local data. Using trizum cloud here will switch this device to your cloud data. Your local data on this device will stop being used."
 msgstr "Este dispositivo ya tiene datos locales. Si usas trizum cloud aquí, este dispositivo cambiará a tus datos en la nube. Los datos locales de este dispositivo dejarán de usarse."
 
-#: src/hooks/useCloudSyncAccountState.ts:272
+#: src/hooks/useCloudSyncAccountState.ts:294
 msgid "This device is already using trizum cloud"
 msgstr "Este dispositivo ya usa trizum cloud"
 
@@ -2710,21 +2711,21 @@ msgstr "Dólar de Trinidad y Tobago"
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
-#: src/hooks/useCloudSyncAccountState.ts:192
-#: src/hooks/useCloudSyncAccountState.ts:267
+#: src/hooks/useCloudSyncAccountState.ts:214
+#: src/hooks/useCloudSyncAccountState.ts:289
 msgid "trizum cloud data is invalid"
 msgstr "Los datos de trizum cloud no son válidos"
 
-#: src/hooks/useCloudSyncAccountState.ts:212
-#: src/hooks/useCloudSyncAccountState.ts:289
+#: src/hooks/useCloudSyncAccountState.ts:234
+#: src/hooks/useCloudSyncAccountState.ts:318
 msgid "trizum cloud enabled on this device"
 msgstr "trizum cloud activado en este dispositivo"
 
-#: src/hooks/useCloudSyncAccountState.ts:262
+#: src/hooks/useCloudSyncAccountState.ts:284
 msgid "trizum cloud is not set up yet"
 msgstr "trizum cloud todavía no está configurado"
 
-#: src/hooks/useCloudSyncAccountState.ts:172
+#: src/hooks/useCloudSyncAccountState.ts:175
 msgid "trizum cloud started"
 msgstr "trizum cloud iniciado"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -62,8 +62,8 @@ msgstr "<0>{fromName}</0> deja de deber dinero a <1>{toName}</1>"
 msgid "A name for the participant is required"
 msgstr "Se requiere un nombre para el participante"
 
+#: src/routes/_home/route.tsx:114
 #: src/routes/about/route.tsx:23
-#: src/routes/index/route.tsx:164
 msgid "About"
 msgstr "Acerca de"
 
@@ -79,7 +79,7 @@ msgstr "Color de acento"
 msgid "Account created"
 msgstr "Cuenta creada"
 
-#: src/routes/settings_.cloud-sync.tsx:664
+#: src/routes/_home/settings_.cloud-sync.tsx:663
 msgid "Account deleted"
 msgstr "Cuenta eliminada"
 
@@ -120,7 +120,7 @@ msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto in
 msgid "Add Google as a sign-in method"
 msgstr "Añadir Google como método de inicio de sesión"
 
-#: src/routes/index/route.tsx:212
+#: src/routes/_home/route.tsx:162
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Añadir o crear"
@@ -206,7 +206,7 @@ msgstr "Archiva un grupo desde la pantalla de inicio cuando quieras despejar esp
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archiva a los participantes que se fueron para mantener el balance limpio."
 
-#: src/routes/index/route.tsx:281
+#: src/routes/_home/route.tsx:232
 msgid "Archive party"
 msgstr "Archivar grupo"
 
@@ -218,7 +218,7 @@ msgstr "Archivado"
 msgid "Archived participants"
 msgstr "Participantes archivados"
 
-#: src/routes/index/route.tsx:142
+#: src/routes/_home/route.tsx:96
 msgid "Archived parties"
 msgstr "Grupos archivados"
 
@@ -264,10 +264,10 @@ msgstr "Dólar Australiano"
 msgid "Authentication error"
 msgstr "Error de autenticación"
 
-#: src/routes/settings_.cloud-sync.tsx:458
-#: src/routes/settings_.cloud-sync.tsx:474
-#: src/routes/settings_.cloud-sync.tsx:498
-#: src/routes/settings_.cloud-sync.tsx:509
+#: src/routes/_home/settings_.cloud-sync.tsx:457
+#: src/routes/_home/settings_.cloud-sync.tsx:473
+#: src/routes/_home/settings_.cloud-sync.tsx:497
+#: src/routes/_home/settings_.cloud-sync.tsx:508
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
@@ -466,15 +466,15 @@ msgstr "Franco CFP"
 msgid "Changes sync automatically across all your devices"
 msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 
-#: src/routes/index/route.tsx:153
+#: src/routes/_home/route.tsx:107
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
-#: src/routes/settings_.cloud-sync.tsx:559
+#: src/routes/_home/settings_.cloud-sync.tsx:558
 msgid "Check your email for the password link"
 msgstr "Revisa tu correo para encontrar el enlace de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:419
+#: src/routes/_home/settings_.cloud-sync.tsx:418
 msgid "Check your email for the sign-in link"
 msgstr "Revisa tu correo para encontrar el enlace de inicio de sesión"
 
@@ -676,11 +676,11 @@ msgstr "Colón Costarricense"
 msgid "Could not apply cloud settings"
 msgstr "No se pudo aplicar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:535
+#: src/routes/_home/settings_.cloud-sync.tsx:534
 msgid "Could not connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:673
+#: src/routes/_home/settings_.cloud-sync.tsx:672
 msgid "Could not delete account"
 msgstr "No se pudo eliminar la cuenta"
 
@@ -704,15 +704,15 @@ msgstr "No se pudo restablecer la contraseña"
 msgid "Could not save cloud settings"
 msgstr "No se pudo guardar la configuración en la nube"
 
-#: src/routes/settings_.cloud-sync.tsx:564
+#: src/routes/_home/settings_.cloud-sync.tsx:563
 msgid "Could not send password email"
 msgstr "No se pudo enviar el correo de contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:424
+#: src/routes/_home/settings_.cloud-sync.tsx:423
 msgid "Could not send sign-in link"
 msgstr "No se pudo enviar el enlace de inicio de sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:595
+#: src/routes/_home/settings_.cloud-sync.tsx:594
 msgid "Could not sign out"
 msgstr "No se pudo cerrar sesión"
 
@@ -720,7 +720,7 @@ msgstr "No se pudo cerrar sesión"
 msgid "Couldn't connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/index/route.tsx:229
+#: src/routes/_home/route.tsx:179
 msgid "Create a new Party"
 msgstr "Crear un nuevo Grupo"
 
@@ -1340,7 +1340,7 @@ msgstr "Únete a {partyName} en trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "¡Únete a {partyName} en trizum!"
 
-#: src/routes/index/route.tsx:223
+#: src/routes/_home/route.tsx:173
 msgid "Join a Party"
 msgstr "Unirse a un Grupo"
 
@@ -1531,7 +1531,7 @@ msgstr "Unidad de Inversión Mexicana"
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
-#: src/routes/index/route.tsx:235
+#: src/routes/_home/route.tsx:185
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrar desde Tricount"
@@ -1867,7 +1867,7 @@ msgstr "Participantes"
 msgid "Party actions"
 msgstr "Acciones del grupo"
 
-#: src/routes/index/route.tsx:302
+#: src/routes/_home/route.tsx:253
 msgid "Party archived"
 msgstr "Grupo archivado"
 
@@ -1883,7 +1883,7 @@ msgstr "Clasificación del grupo"
 msgid "Party link copied to clipboard!"
 msgstr "¡Enlace del grupo copiado al portapapeles!"
 
-#: src/routes/index/route.tsx:294
+#: src/routes/_home/route.tsx:245
 msgid "Party pinned"
 msgstr "Grupo fijado"
 
@@ -1907,7 +1907,7 @@ msgstr "¡Grupo compartido!"
 msgid "Party stats"
 msgstr "Estadísticas del grupo"
 
-#: src/routes/index/route.tsx:294
+#: src/routes/_home/route.tsx:245
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
@@ -1916,7 +1916,7 @@ msgstr "Grupo desfijado"
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/routes/settings_.cloud-sync.tsx:562
+#: src/routes/_home/settings_.cloud-sync.tsx:561
 msgid "Password email sent"
 msgstr "Correo de contraseña enviado"
 
@@ -1993,7 +1993,7 @@ msgstr "Se requiere el número de teléfono"
 msgid "Phone number must be less than 20 characters"
 msgstr "El número de teléfono debe tener menos de 20 caracteres"
 
-#: src/routes/index/route.tsx:275
+#: src/routes/_home/route.tsx:226
 msgid "Pin party"
 msgstr "Fijar grupo"
 
@@ -2053,7 +2053,7 @@ msgstr "Anterior"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: src/routes/index/route.tsx:107
+#: src/routes/_home/route.tsx:73
 msgid "Profile and app menu"
 msgstr "Menú de perfil y aplicación"
 
@@ -2234,7 +2234,7 @@ msgstr "¿Configurar contraseña?"
 msgid "Set up your username, avatar, and preferences"
 msgstr "Configura tu nombre de usuario, avatar y preferencias"
 
-#: src/routes/index/route.tsx:120
+#: src/routes/_home/route.tsx:82
 #: src/routes/party.$partyId/route.tsx:259
 #: src/routes/settings.tsx:121
 msgid "Settings"
@@ -2295,7 +2295,7 @@ msgstr "Leone de Sierra Leona"
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:971
+#: src/routes/_home/settings_.cloud-sync.tsx:946
 msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
@@ -2330,15 +2330,15 @@ msgstr "El enlace de inicio de sesión ha caducado"
 msgid "Sign-in link is invalid or expired"
 msgstr "El enlace de inicio de sesión no es válido o ha caducado"
 
-#: src/routes/settings_.cloud-sync.tsx:422
+#: src/routes/_home/settings_.cloud-sync.tsx:421
 msgid "Sign-in link sent"
 msgstr "Enlace de inicio de sesión enviado"
 
-#: src/routes/settings_.cloud-sync.tsx:532
+#: src/routes/_home/settings_.cloud-sync.tsx:531
 msgid "Sign-in method connected"
 msgstr "Método de inicio de sesión conectado"
 
-#: src/routes/settings_.cloud-sync.tsx:471
+#: src/routes/_home/settings_.cloud-sync.tsx:470
 msgid "Sign-in method is not configured"
 msgstr "El método de inicio de sesión no está configurado"
 
@@ -2348,11 +2348,11 @@ msgstr "Métodos de inicio de sesión"
 
 #: src/components/CloudSyncAccountSettings.tsx:70
 #: src/components/CloudSyncDialogs.tsx:375
-#: src/routes/settings_.cloud-sync.tsx:383
+#: src/routes/_home/settings_.cloud-sync.tsx:382
 msgid "Signed in"
 msgstr "Sesión iniciada"
 
-#: src/routes/settings_.cloud-sync.tsx:592
+#: src/routes/_home/settings_.cloud-sync.tsx:591
 msgid "Signed out"
 msgstr "Sesión cerrada"
 
@@ -2701,8 +2701,8 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/index/route.tsx:131
-#: src/routes/settings_.cloud-sync.tsx:828
+#: src/routes/_home/route.tsx:89
+#: src/routes/_home/settings_.cloud-sync.tsx:821
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
@@ -2789,12 +2789,12 @@ msgstr "Grivna Ucraniana"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/index/route.tsx:275
+#: src/routes/_home/route.tsx:226
 msgid "Unpin party"
 msgstr "Desfijar grupo"
 
 #: src/components/UpdateController.tsx:28
-#: src/routes/index/route.tsx:93
+#: src/routes/_home/route.tsx:59
 msgid "Update available"
 msgstr "Actualización disponible"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -62,7 +62,7 @@ msgstr "<0>{fromName}</0> deja de deber dinero a <1>{toName}</1>"
 msgid "A name for the participant is required"
 msgstr "Se requiere un nombre para el participante"
 
-#: src/routes/_home/route.tsx:117
+#: src/routes/_home/route.tsx:113
 #: src/routes/about/route.tsx:23
 msgid "About"
 msgstr "Acerca de"
@@ -120,7 +120,7 @@ msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto in
 msgid "Add Google as a sign-in method"
 msgstr "Añadir Google como método de inicio de sesión"
 
-#: src/routes/_home/route.tsx:165
+#: src/routes/_home/route.tsx:161
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Añadir o crear"
@@ -206,7 +206,7 @@ msgstr "Archiva un grupo desde la pantalla de inicio cuando quieras despejar esp
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archiva a los participantes que se fueron para mantener el balance limpio."
 
-#: src/routes/_home/route.tsx:235
+#: src/routes/_home/route.tsx:231
 msgid "Archive party"
 msgstr "Archivar grupo"
 
@@ -218,7 +218,7 @@ msgstr "Archivado"
 msgid "Archived participants"
 msgstr "Participantes archivados"
 
-#: src/routes/_home/route.tsx:99
+#: src/routes/_home/route.tsx:95
 msgid "Archived parties"
 msgstr "Grupos archivados"
 
@@ -466,7 +466,7 @@ msgstr "Franco CFP"
 msgid "Changes sync automatically across all your devices"
 msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 
-#: src/routes/_home/route.tsx:110
+#: src/routes/_home/route.tsx:106
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
@@ -720,7 +720,7 @@ msgstr "No se pudo cerrar sesión"
 msgid "Couldn't connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/_home/route.tsx:182
+#: src/routes/_home/route.tsx:178
 msgid "Create a new Party"
 msgstr "Crear un nuevo Grupo"
 
@@ -1340,7 +1340,7 @@ msgstr "Únete a {partyName} en trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "¡Únete a {partyName} en trizum!"
 
-#: src/routes/_home/route.tsx:176
+#: src/routes/_home/route.tsx:172
 msgid "Join a Party"
 msgstr "Unirse a un Grupo"
 
@@ -1531,7 +1531,7 @@ msgstr "Unidad de Inversión Mexicana"
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
-#: src/routes/_home/route.tsx:188
+#: src/routes/_home/route.tsx:184
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrar desde Tricount"
@@ -1867,7 +1867,7 @@ msgstr "Participantes"
 msgid "Party actions"
 msgstr "Acciones del grupo"
 
-#: src/routes/_home/route.tsx:256
+#: src/routes/_home/route.tsx:252
 msgid "Party archived"
 msgstr "Grupo archivado"
 
@@ -1883,7 +1883,7 @@ msgstr "Clasificación del grupo"
 msgid "Party link copied to clipboard!"
 msgstr "¡Enlace del grupo copiado al portapapeles!"
 
-#: src/routes/_home/route.tsx:248
+#: src/routes/_home/route.tsx:244
 msgid "Party pinned"
 msgstr "Grupo fijado"
 
@@ -1907,7 +1907,7 @@ msgstr "¡Grupo compartido!"
 msgid "Party stats"
 msgstr "Estadísticas del grupo"
 
-#: src/routes/_home/route.tsx:248
+#: src/routes/_home/route.tsx:244
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
@@ -1993,7 +1993,7 @@ msgstr "Se requiere el número de teléfono"
 msgid "Phone number must be less than 20 characters"
 msgstr "El número de teléfono debe tener menos de 20 caracteres"
 
-#: src/routes/_home/route.tsx:229
+#: src/routes/_home/route.tsx:225
 msgid "Pin party"
 msgstr "Fijar grupo"
 
@@ -2053,7 +2053,7 @@ msgstr "Anterior"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: src/routes/_home/route.tsx:73
+#: src/routes/_home/route.tsx:71
 msgid "Profile and app menu"
 msgstr "Menú de perfil y aplicación"
 
@@ -2234,7 +2234,7 @@ msgstr "¿Configurar contraseña?"
 msgid "Set up your username, avatar, and preferences"
 msgstr "Configura tu nombre de usuario, avatar y preferencias"
 
-#: src/routes/_home/route.tsx:82
+#: src/routes/_home/route.tsx:78
 #: src/routes/party.$partyId/route.tsx:259
 #: src/routes/settings.tsx:121
 msgid "Settings"
@@ -2701,7 +2701,7 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/_home/route.tsx:92
+#: src/routes/_home/route.tsx:88
 #: src/routes/_home/settings_.cloud-sync.tsx:821
 msgid "trizum cloud"
 msgstr "trizum cloud"
@@ -2789,7 +2789,7 @@ msgstr "Grivna Ucraniana"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/_home/route.tsx:229
+#: src/routes/_home/route.tsx:225
 msgid "Unpin party"
 msgstr "Desfijar grupo"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -63,7 +63,7 @@ msgid "A name for the participant is required"
 msgstr "Se requiere un nombre para el participante"
 
 #: src/routes/about/route.tsx:23
-#: src/routes/index/route.tsx:149
+#: src/routes/index/route.tsx:164
 msgid "About"
 msgstr "Acerca de"
 
@@ -71,7 +71,7 @@ msgstr "Acerca de"
 msgid "Absolutely! trizum works without requiring any account or sign-up. Just create a group and start tracking expenses."
 msgstr "¡Por supuesto! trizum funciona sin necesidad de crear una cuenta o registrarte. Solo crea un grupo y empieza a registrar gastos."
 
-#: src/routes/settings.tsx:444
+#: src/routes/settings.tsx:255
 msgid "Accent color"
 msgstr "Color de acento"
 
@@ -120,7 +120,7 @@ msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto in
 msgid "Add Google as a sign-in method"
 msgstr "Añadir Google como método de inicio de sesión"
 
-#: src/routes/index/route.tsx:197
+#: src/routes/index/route.tsx:212
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Añadir o crear"
@@ -206,7 +206,7 @@ msgstr "Archiva un grupo desde la pantalla de inicio cuando quieras despejar esp
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archiva a los participantes que se fueron para mantener el balance limpio."
 
-#: src/routes/index/route.tsx:266
+#: src/routes/index/route.tsx:281
 msgid "Archive party"
 msgstr "Archivar grupo"
 
@@ -218,7 +218,7 @@ msgstr "Archivado"
 msgid "Archived participants"
 msgstr "Participantes archivados"
 
-#: src/routes/index/route.tsx:127
+#: src/routes/index/route.tsx:142
 msgid "Archived parties"
 msgstr "Grupos archivados"
 
@@ -272,15 +272,15 @@ msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
 #: src/components/ExpenseEditor.tsx:369
-#: src/routes/settings.tsx:431
+#: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
 
-#: src/routes/settings.tsx:433
+#: src/routes/settings.tsx:244
 msgid "Automatically open the calculator when focusing amount fields"
 msgstr "Abrir automáticamente la calculadora al enfocar campos de importe"
 
-#: src/routes/settings.tsx:420
+#: src/routes/settings.tsx:231
 msgid "Automatically open the last visited party when you open the app"
 msgstr "Abrir automáticamente el último grupo visitado cuando abras la app"
 
@@ -300,7 +300,6 @@ msgstr "Manat Azerbaiyano"
 msgid "Back to home"
 msgstr "Volver al inicio"
 
-#: src/components/CloudSyncDialogs.tsx:209
 #: src/routes/reset-password.tsx:102
 msgid "Back to settings"
 msgstr "Volver a configuración"
@@ -467,7 +466,7 @@ msgstr "Franco CFP"
 msgid "Changes sync automatically across all your devices"
 msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 
-#: src/routes/index/route.tsx:138
+#: src/routes/index/route.tsx:153
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
@@ -535,6 +534,10 @@ msgstr "Cerrar calculadora"
 #: src/components/CalculatorToolbar.tsx:1495
 msgid "Close parenthesis"
 msgstr "Cerrar paréntesis"
+
+#: src/components/CloudSyncDialogs.tsx:209
+msgid "Close sign-in"
+msgstr "Cerrar inicio de sesión"
 
 #: src/routes/settings.tsx:533
 msgid "Cloud settings applied"
@@ -690,7 +693,6 @@ msgid "Could not load sign-in methods"
 msgstr "No se pudieron cargar los métodos de inicio de sesión"
 
 #: src/hooks/useCloudSyncAccountState.ts:192
-#: src/routes/settings.tsx:487
 msgid "Could not load trizum cloud state"
 msgstr "No se pudo cargar el estado de trizum cloud"
 
@@ -718,10 +720,17 @@ msgstr "No se pudo cerrar sesión"
 msgid "Couldn't connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/index/-components/EmptyState.tsx:25
-#: src/routes/index/route.tsx:214
+#: src/routes/index/route.tsx:229
 msgid "Create a new Party"
 msgstr "Crear un nuevo Grupo"
+
+#: src/routes/index/-components/EmptyState.tsx:34
+msgid "Create a Party"
+msgstr "Crear un Grupo"
+
+#: src/routes/index/-components/EmptyState.tsx:26
+msgid "Create a party in seconds, track who paid, and settle up without the awkward maths."
+msgstr "Crea un grupo en segundos, registra quién pagó y salda cuentas sin cálculos incómodos."
 
 #: src/routes/settings_.cloud-sync.tsx:524
 #: src/routes/settings_.cloud-sync.tsx:564
@@ -932,7 +941,7 @@ msgstr "Lista de emojis"
 msgid "End date"
 msgstr "Fecha de fin"
 
-#: src/routes/settings.tsx:119
+#: src/routes/settings.tsx:44
 msgid "English"
 msgstr "Inglés"
 
@@ -948,7 +957,7 @@ msgstr "Introduce el enlace o código del grupo de trizum al que quieres unirte"
 msgid "Eritrean Nakfa"
 msgstr "Nakfa Eritreo"
 
-#: src/routes/settings.tsx:120
+#: src/routes/settings.tsx:45
 msgid "Español"
 msgstr "Español"
 
@@ -1071,7 +1080,7 @@ msgstr "Filtra totales y rankings"
 msgid "Finishing sign in"
 msgstr "Terminando el inicio de sesión"
 
-#: src/routes/settings.tsx:382
+#: src/routes/settings.tsx:193
 msgid "For payments through Bizum or similar services"
 msgstr "Para pagos mediante Bizum o servicios similares"
 
@@ -1237,6 +1246,10 @@ msgstr "Impacto en mi balance: <0/>"
 msgid "Import attachments"
 msgstr "Importar adjuntos"
 
+#: src/routes/index/-components/EmptyState.tsx:89
+msgid "Import from Tricount"
+msgstr "Importar desde Tricount"
+
 #: src/routes/index/-components/EmptyState.tsx:38
 msgid "Import your existing Tricount data"
 msgstr "Importa tu grupo de Tricount"
@@ -1327,8 +1340,7 @@ msgstr "Únete a {partyName} en trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "¡Únete a {partyName} en trizum!"
 
-#: src/routes/index/-components/EmptyState.tsx:31
-#: src/routes/index/route.tsx:208
+#: src/routes/index/route.tsx:223
 msgid "Join a Party"
 msgstr "Unirse a un Grupo"
 
@@ -1339,6 +1351,10 @@ msgstr "Unirse a un trizum"
 #: src/lib/partySharePreviewMessages.ts:6
 msgid "Join party"
 msgstr "Unirse"
+
+#: src/routes/index/-components/EmptyState.tsx:37
+msgid "Join with a code"
+msgstr "Unirse con un código"
 
 #: src/routes/new/route.tsx:249
 msgid "Jordanian Dinar"
@@ -1351,6 +1367,10 @@ msgstr "Vuelve a los grupos que más usas"
 #: src/routes/new/route.tsx:257
 msgid "Kazakhstani Tenge"
 msgstr "Tenge Kazajo"
+
+#: src/routes/index/-components/EmptyState.tsx:62
+msgid "Keep every party in sync"
+msgstr "Mantén todos tus grupos sincronizados"
 
 #: src/routes/settings_.cloud-sync.tsx:824
 msgid "Keep local data"
@@ -1372,7 +1392,7 @@ msgstr "Dinar Kuwaití"
 msgid "Kyrgystani Som"
 msgstr "Som Kirguís"
 
-#: src/routes/settings.tsx:397
+#: src/routes/settings.tsx:208
 msgid "Language"
 msgstr "Idioma"
 
@@ -1460,9 +1480,17 @@ msgstr "Rufiyaa Maldiva"
 msgid "Malformed Party ID"
 msgstr "ID de grupo mal formado"
 
+#: src/routes/index/-components/EmptyState.tsx:73
+msgid "Manage"
+msgstr "Gestionar"
+
 #: src/routes/party_.$partyId.settings/-components/PartyParticipantsField.tsx:26
 msgid "Manage the participants list. Existing members can only be archived."
 msgstr "Gestiona la lista de participantes. Los miembros existentes solo pueden ser archivados."
+
+#: src/routes/index/-components/EmptyState.tsx:66
+msgid "Manage your cloud account and synced data."
+msgstr "Gestiona tu cuenta en la nube y tus datos sincronizados."
 
 #: src/routes/party_.$partyId.pay/route.tsx:95
 #: src/routes/party_.$partyId.pay/route.tsx:120
@@ -1490,7 +1518,6 @@ msgid "Me"
 msgstr "Yo"
 
 #: src/components/ExpenseEditor.tsx:362
-#: src/routes/index/route.tsx:105
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1504,8 +1531,7 @@ msgstr "Unidad de Inversión Mexicana"
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
-#: src/routes/index/-components/EmptyState.tsx:37
-#: src/routes/index/route.tsx:220
+#: src/routes/index/route.tsx:235
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrar desde Tricount"
@@ -1748,7 +1774,7 @@ msgstr "Abrir calculadora al enfocar campos de importe"
 msgid "Open GitHub Issues"
 msgstr "Abrir GitHub Issues"
 
-#: src/routes/settings.tsx:418
+#: src/routes/settings.tsx:229
 msgid "Open last party on launch"
 msgstr "Abrir el último grupo al abrir la app"
 
@@ -1841,7 +1867,7 @@ msgstr "Participantes"
 msgid "Party actions"
 msgstr "Acciones del grupo"
 
-#: src/routes/index/route.tsx:287
+#: src/routes/index/route.tsx:302
 msgid "Party archived"
 msgstr "Grupo archivado"
 
@@ -1857,7 +1883,7 @@ msgstr "Clasificación del grupo"
 msgid "Party link copied to clipboard!"
 msgstr "¡Enlace del grupo copiado al portapapeles!"
 
-#: src/routes/index/route.tsx:279
+#: src/routes/index/route.tsx:294
 msgid "Party pinned"
 msgstr "Grupo fijado"
 
@@ -1881,7 +1907,7 @@ msgstr "¡Grupo compartido!"
 msgid "Party stats"
 msgstr "Estadísticas del grupo"
 
-#: src/routes/index/route.tsx:279
+#: src/routes/index/route.tsx:294
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
@@ -1951,7 +1977,7 @@ msgstr "Sol Peruano"
 msgid "Philippine Peso"
 msgstr "Peso Filipino"
 
-#: src/routes/settings.tsx:381
+#: src/routes/settings.tsx:192
 msgid "Phone number"
 msgstr "Número de teléfono"
 
@@ -1967,7 +1993,7 @@ msgstr "Se requiere el número de teléfono"
 msgid "Phone number must be less than 20 characters"
 msgstr "El número de teléfono debe tener menos de 20 caracteres"
 
-#: src/routes/index/route.tsx:260
+#: src/routes/index/route.tsx:275
 msgid "Pin party"
 msgstr "Fijar grupo"
 
@@ -2026,6 +2052,10 @@ msgstr "Anterior"
 #: src/routes/about/route.tsx:110
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
+
+#: src/routes/index/route.tsx:107
+msgid "Profile and app menu"
+msgstr "Menú de perfil y aplicación"
 
 #: src/routes/new/route.tsx:289
 msgid "Qatari Rial"
@@ -2139,7 +2169,7 @@ msgstr "Riyal Saudí"
 #: src/routes/party_.$partyId.settings/route.tsx:120
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
-#: src/routes/settings.tsx:232
+#: src/routes/settings.tsx:98
 msgid "Save"
 msgstr "Guardar"
 
@@ -2159,6 +2189,10 @@ msgstr "Buscar emoji"
 #: src/components/EmojiPicker.tsx:182
 msgid "Search emoji..."
 msgstr "Buscar emoji..."
+
+#: src/routes/index/-components/EmptyState.tsx:68
+msgid "Securely access your data on all your devices."
+msgstr "Accede de forma segura a tus datos en todos tus dispositivos."
 
 #: src/components/CloudSyncAccountSettings.tsx:65
 msgid "Security"
@@ -2200,13 +2234,13 @@ msgstr "¿Configurar contraseña?"
 msgid "Set up your username, avatar, and preferences"
 msgstr "Configura tu nombre de usuario, avatar y preferencias"
 
-#: src/routes/index/route.tsx:116
+#: src/routes/index/route.tsx:120
 #: src/routes/party.$partyId/route.tsx:259
-#: src/routes/settings.tsx:263
+#: src/routes/settings.tsx:121
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/routes/settings.tsx:190
+#: src/routes/settings.tsx:65
 msgid "Settings saved"
 msgstr "Configuración guardada"
 
@@ -2257,10 +2291,11 @@ msgid "Sierra Leonean Leone"
 msgstr "Leone de Sierra Leona"
 
 #: src/components/CloudSyncDialogs.tsx:205
+#: src/routes/index/-components/EmptyState.tsx:73
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/routes/settings_.cloud-sync.tsx:953
+#: src/routes/settings_.cloud-sync.tsx:971
 msgid "Sign in again before deleting your account"
 msgstr "Vuelve a iniciar sesión antes de eliminar tu cuenta"
 
@@ -2385,6 +2420,10 @@ msgstr "Divide gastos y salda cuentas juntos en trizum."
 msgid "Split expenses fairly among multiple participants"
 msgstr "Divide los gastos de forma justa entre múltiples participantes"
 
+#: src/routes/index/-components/EmptyState.tsx:23
+msgid "Split expenses, stay even."
+msgstr "Reparte gastos, mantén las cuentas claras."
+
 #: src/routes/new/route.tsx:260
 msgid "Sri Lankan Rupee"
 msgstr "Rupia de Sri Lanka"
@@ -2416,7 +2455,7 @@ msgstr "Enviar sugerencia"
 #: src/routes/party_.$partyId.settings/route.tsx:120
 #: src/routes/party_.$partyId.who.tsx:109
 #: src/routes/reset-password.tsx:79
-#: src/routes/settings.tsx:232
+#: src/routes/settings.tsx:98
 msgid "Submitting..."
 msgstr "Enviando..."
 
@@ -2490,7 +2529,7 @@ msgstr "Sincronizando información del grupo..."
 msgid "Syrian Pound"
 msgstr "Libra Siria"
 
-#: src/routes/settings.tsx:118
+#: src/routes/settings.tsx:43
 msgid "System (fallbacks to {DEFAULT_LOCALE})"
 msgstr "Sistema (por defecto {DEFAULT_LOCALE})"
 
@@ -2662,8 +2701,8 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
+#: src/routes/index/route.tsx:131
 #: src/routes/settings_.cloud-sync.tsx:828
-#: src/routes/settings.tsx:308
 msgid "trizum cloud"
 msgstr "trizum cloud"
 
@@ -2750,7 +2789,7 @@ msgstr "Grivna Ucraniana"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/index/route.tsx:260
+#: src/routes/index/route.tsx:275
 msgid "Unpin party"
 msgstr "Desfijar grupo"
 
@@ -2847,7 +2886,7 @@ msgstr "¿Usar trizum cloud en este dispositivo?"
 msgid "Use your camera to scan a trizum invite"
 msgstr "Usa tu cámara para escanear una invitación de trizum"
 
-#: src/routes/settings.tsx:359
+#: src/routes/settings.tsx:170
 msgid "Username"
 msgstr "Nombre de usuario"
 
@@ -2937,7 +2976,7 @@ msgstr "Bienvenid@ a trizum"
 msgid "What is this party about?"
 msgstr "¿De qué trata este grupo?"
 
-#: src/routes/settings.tsx:360
+#: src/routes/settings.tsx:171
 msgid "What's your preferred way to be addressed?"
 msgstr "¿Cuál es tu forma preferida de que te llamen?"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -62,7 +62,7 @@ msgstr "<0>{fromName}</0> deja de deber dinero a <1>{toName}</1>"
 msgid "A name for the participant is required"
 msgstr "Se requiere un nombre para el participante"
 
-#: src/routes/_home/route.tsx:114
+#: src/routes/_home/route.tsx:117
 #: src/routes/about/route.tsx:23
 msgid "About"
 msgstr "Acerca de"
@@ -120,7 +120,7 @@ msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto in
 msgid "Add Google as a sign-in method"
 msgstr "Añadir Google como método de inicio de sesión"
 
-#: src/routes/_home/route.tsx:162
+#: src/routes/_home/route.tsx:165
 #: src/routes/party.$partyId/-components/ExpenseLog.tsx:52
 msgid "Add or create"
 msgstr "Añadir o crear"
@@ -206,7 +206,7 @@ msgstr "Archiva un grupo desde la pantalla de inicio cuando quieras despejar esp
 msgid "Archive participants who left to keep balances clean."
 msgstr "Archiva a los participantes que se fueron para mantener el balance limpio."
 
-#: src/routes/_home/route.tsx:232
+#: src/routes/_home/route.tsx:235
 msgid "Archive party"
 msgstr "Archivar grupo"
 
@@ -218,7 +218,7 @@ msgstr "Archivado"
 msgid "Archived participants"
 msgstr "Participantes archivados"
 
-#: src/routes/_home/route.tsx:96
+#: src/routes/_home/route.tsx:99
 msgid "Archived parties"
 msgstr "Grupos archivados"
 
@@ -466,7 +466,7 @@ msgstr "Franco CFP"
 msgid "Changes sync automatically across all your devices"
 msgstr "Los cambios se sincronizan automáticamente en todos tus dispositivos"
 
-#: src/routes/_home/route.tsx:107
+#: src/routes/_home/route.tsx:110
 msgid "Check for updates"
 msgstr "Comprobar actualizaciones"
 
@@ -720,7 +720,7 @@ msgstr "No se pudo cerrar sesión"
 msgid "Couldn't connect sign-in method"
 msgstr "No se pudo conectar el método de inicio de sesión"
 
-#: src/routes/_home/route.tsx:179
+#: src/routes/_home/route.tsx:182
 msgid "Create a new Party"
 msgstr "Crear un nuevo Grupo"
 
@@ -1246,7 +1246,7 @@ msgstr "Impacto en mi balance: <0/>"
 msgid "Import attachments"
 msgstr "Importar adjuntos"
 
-#: src/routes/index/-components/EmptyState.tsx:89
+#: src/routes/index/-components/EmptyState.tsx:90
 msgid "Import from Tricount"
 msgstr "Importar desde Tricount"
 
@@ -1340,7 +1340,7 @@ msgstr "Únete a {partyName} en trizum"
 msgid "Join {partyName} on trizum!"
 msgstr "¡Únete a {partyName} en trizum!"
 
-#: src/routes/_home/route.tsx:173
+#: src/routes/_home/route.tsx:176
 msgid "Join a Party"
 msgstr "Unirse a un Grupo"
 
@@ -1368,7 +1368,7 @@ msgstr "Vuelve a los grupos que más usas"
 msgid "Kazakhstani Tenge"
 msgstr "Tenge Kazajo"
 
-#: src/routes/index/-components/EmptyState.tsx:62
+#: src/routes/index/-components/EmptyState.tsx:63
 msgid "Keep every party in sync"
 msgstr "Mantén todos tus grupos sincronizados"
 
@@ -1480,7 +1480,7 @@ msgstr "Rufiyaa Maldiva"
 msgid "Malformed Party ID"
 msgstr "ID de grupo mal formado"
 
-#: src/routes/index/-components/EmptyState.tsx:73
+#: src/routes/index/-components/EmptyState.tsx:74
 msgid "Manage"
 msgstr "Gestionar"
 
@@ -1488,7 +1488,7 @@ msgstr "Gestionar"
 msgid "Manage the participants list. Existing members can only be archived."
 msgstr "Gestiona la lista de participantes. Los miembros existentes solo pueden ser archivados."
 
-#: src/routes/index/-components/EmptyState.tsx:66
+#: src/routes/index/-components/EmptyState.tsx:67
 msgid "Manage your cloud account and synced data."
 msgstr "Gestiona tu cuenta en la nube y tus datos sincronizados."
 
@@ -1531,7 +1531,7 @@ msgstr "Unidad de Inversión Mexicana"
 msgid "Mexican Peso"
 msgstr "Peso Mexicano"
 
-#: src/routes/_home/route.tsx:185
+#: src/routes/_home/route.tsx:188
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:39
 msgid "Migrate from Tricount"
 msgstr "Migrar desde Tricount"
@@ -1867,7 +1867,7 @@ msgstr "Participantes"
 msgid "Party actions"
 msgstr "Acciones del grupo"
 
-#: src/routes/_home/route.tsx:253
+#: src/routes/_home/route.tsx:256
 msgid "Party archived"
 msgstr "Grupo archivado"
 
@@ -1883,7 +1883,7 @@ msgstr "Clasificación del grupo"
 msgid "Party link copied to clipboard!"
 msgstr "¡Enlace del grupo copiado al portapapeles!"
 
-#: src/routes/_home/route.tsx:245
+#: src/routes/_home/route.tsx:248
 msgid "Party pinned"
 msgstr "Grupo fijado"
 
@@ -1907,7 +1907,7 @@ msgstr "¡Grupo compartido!"
 msgid "Party stats"
 msgstr "Estadísticas del grupo"
 
-#: src/routes/_home/route.tsx:245
+#: src/routes/_home/route.tsx:248
 msgid "Party unpinned"
 msgstr "Grupo desfijado"
 
@@ -1993,7 +1993,7 @@ msgstr "Se requiere el número de teléfono"
 msgid "Phone number must be less than 20 characters"
 msgstr "El número de teléfono debe tener menos de 20 caracteres"
 
-#: src/routes/_home/route.tsx:226
+#: src/routes/_home/route.tsx:229
 msgid "Pin party"
 msgstr "Fijar grupo"
 
@@ -2190,7 +2190,7 @@ msgstr "Buscar emoji"
 msgid "Search emoji..."
 msgstr "Buscar emoji..."
 
-#: src/routes/index/-components/EmptyState.tsx:68
+#: src/routes/index/-components/EmptyState.tsx:69
 msgid "Securely access your data on all your devices."
 msgstr "Accede de forma segura a tus datos en todos tus dispositivos."
 
@@ -2291,7 +2291,7 @@ msgid "Sierra Leonean Leone"
 msgstr "Leone de Sierra Leona"
 
 #: src/components/CloudSyncDialogs.tsx:205
-#: src/routes/index/-components/EmptyState.tsx:73
+#: src/routes/index/-components/EmptyState.tsx:74
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
@@ -2701,7 +2701,7 @@ msgstr "URL o clave de Tricount"
 msgid "Trinidad and Tobago Dollar"
 msgstr "Dólar de Trinidad y Tobago"
 
-#: src/routes/_home/route.tsx:89
+#: src/routes/_home/route.tsx:92
 #: src/routes/_home/settings_.cloud-sync.tsx:821
 msgid "trizum cloud"
 msgstr "trizum cloud"
@@ -2789,7 +2789,7 @@ msgstr "Grivna Ucraniana"
 msgid "Unidad Previsional"
 msgstr "Unidad Previsional"
 
-#: src/routes/_home/route.tsx:226
+#: src/routes/_home/route.tsx:229
 msgid "Unpin party"
 msgstr "Desfijar grupo"
 

--- a/packages/pwa/src/components/AuthSessionController.tsx
+++ b/packages/pwa/src/components/AuthSessionController.tsx
@@ -1,0 +1,6 @@
+import { authClient } from "#src/lib/auth-client.ts";
+
+export function AuthSessionController() {
+  authClient.useSession();
+  return null;
+}

--- a/packages/pwa/src/components/CloudSyncDialogs.tsx
+++ b/packages/pwa/src/components/CloudSyncDialogs.tsx
@@ -206,7 +206,7 @@ export function CloudSyncSignInDialog({
           className="sm:border-accent-200 dark:bg-accent-950 dark:sm:border-accent-800 relative flex h-[100dvh] max-h-[100dvh] flex-col overflow-hidden bg-white shadow-2xl outline-hidden sm:h-auto sm:max-h-[calc(100dvh-2rem)] sm:rounded-lg sm:border"
         >
           <IconButton
-            aria-label={t`Back to settings`}
+            aria-label={t`Close sign-in`}
             className="right-safe-offset-2 top-safe-offset-2 absolute sm:top-2 sm:right-2"
             icon="lucide.x"
             onPress={onOpenChange}

--- a/packages/pwa/src/hooks/useCloudSyncAccountState.ts
+++ b/packages/pwa/src/hooks/useCloudSyncAccountState.ts
@@ -21,6 +21,7 @@ const CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS = 30_000;
 
 interface CloudSyncAccountState {
   cloudSettings: CloudUserSettings | null;
+  isAccountStateResolved: boolean;
   isCloudSyncSwitchOpen: boolean;
   linkedAccounts: LinkedAuthAccount[];
 }
@@ -28,16 +29,23 @@ interface CloudSyncAccountState {
 type CloudSyncAccountStateAction =
   | { type: "cleared" }
   | {
+      type: "accountChanged";
+      cloudSettings: CloudUserSettings | null;
+      linkedAccounts: LinkedAuthAccount[];
+    }
+  | {
       type: "accountDataLoaded";
       cloudSettings: CloudUserSettings | null;
       linkedAccounts: LinkedAuthAccount[];
     }
+  | { type: "accountDataResolved" }
   | { type: "cloudSettingsActivated"; cloudSettings: CloudUserSettings }
   | { type: "linkedAccountsSaved"; linkedAccounts: LinkedAuthAccount[] }
   | { type: "switchOpenChanged"; isOpen: boolean };
 
 const initialCloudSyncAccountState: CloudSyncAccountState = {
   cloudSettings: null,
+  isAccountStateResolved: false,
   isCloudSyncSwitchOpen: false,
   linkedAccounts: [],
 };
@@ -50,11 +58,27 @@ function cloudSyncAccountStateReducer(
     case "cleared":
       return initialCloudSyncAccountState;
 
+    case "accountChanged":
+      return {
+        ...state,
+        cloudSettings: action.cloudSettings,
+        isAccountStateResolved: false,
+        isCloudSyncSwitchOpen: false,
+        linkedAccounts: action.linkedAccounts,
+      };
+
     case "accountDataLoaded":
       return {
         ...state,
         cloudSettings: action.cloudSettings,
+        isAccountStateResolved: true,
         linkedAccounts: action.linkedAccounts,
+      };
+
+    case "accountDataResolved":
+      return {
+        ...state,
+        isAccountStateResolved: true,
       };
 
     case "cloudSettingsActivated":
@@ -90,7 +114,7 @@ export function useCloudSyncAccountState({
   userId: string | undefined;
 }) {
   const [state, dispatch] = useReducer(cloudSyncAccountStateReducer, initialCloudSyncAccountState);
-  const { cloudSettings, isCloudSyncSwitchOpen, linkedAccounts } = state;
+  const { cloudSettings, isAccountStateResolved, isCloudSyncSwitchOpen, linkedAccounts } = state;
   const partyListRef = useRef(partyList);
   const onCloudDataActivatedRef = useRef(onCloudDataActivated);
   const linkedProviderIds = new Set(linkedAccounts.map((account) => account.providerId));
@@ -188,25 +212,20 @@ export function useCloudSyncAccountState({
         toast.success(t`trizum cloud enabled on this device`);
         onCloudDataActivatedRef.current(isSignInSuccessVisibleRef.current);
       } catch {
-        if (!isCancelled && showErrorToast) {
-          toast.error(t`Could not load trizum cloud state`);
+        if (!isCancelled) {
+          dispatch({ type: "accountDataResolved" });
+          if (showErrorToast) {
+            toast.error(t`Could not load trizum cloud state`);
+          }
         }
       }
     }
 
-    if (cachedAccountState) {
-      dispatch({
-        type: "accountDataLoaded",
-        linkedAccounts: cachedAccountState.linkedAccounts,
-        cloudSettings: cachedAccountState.cloudSettings,
-      });
-    } else {
-      dispatch({
-        type: "accountDataLoaded",
-        linkedAccounts: [],
-        cloudSettings: null,
-      });
-    }
+    dispatch({
+      type: "accountChanged",
+      linkedAccounts: cachedAccountState?.linkedAccounts ?? [],
+      cloudSettings: cachedAccountState?.cloudSettings ?? null,
+    });
 
     void loadAccountState({
       showErrorToast: !cachedAccountState,
@@ -275,6 +294,7 @@ export function useCloudSyncAccountState({
     activateCloudSyncOnDevice,
     clearCloudSyncState,
     hasPasswordAccount,
+    isAccountStateResolved,
     isCloudSyncSwitchOpen,
     linkedProviderIds,
     saveLinkedAccounts,

--- a/packages/pwa/src/hooks/useCloudSyncAccountState.ts
+++ b/packages/pwa/src/hooks/useCloudSyncAccountState.ts
@@ -15,6 +15,8 @@ import {
   readCachedCloudAccountState,
   writeCachedCloudAccountState,
 } from "#src/lib/cloudSyncRouteState.ts";
+import { documentCache } from "#src/lib/automerge/suspense-hooks.ts";
+import { useRepo } from "#src/lib/automerge/useRepo.ts";
 import { setPartyListId, type PartyList } from "#src/models/partyList.js";
 
 const CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS = 30_000;
@@ -113,6 +115,7 @@ export function useCloudSyncAccountState({
   partyList: PartyList;
   userId: string | undefined;
 }) {
+  const repo = useRepo();
   const [state, dispatch] = useReducer(cloudSyncAccountStateReducer, initialCloudSyncAccountState);
   const { cloudSettings, isAccountStateResolved, isCloudSyncSwitchOpen, linkedAccounts } = state;
   const partyListRef = useRef(partyList);
@@ -170,6 +173,25 @@ export function useCloudSyncAccountState({
           activeSettings = savedSettings;
           if (showStartToast) {
             toast.success(t`trizum cloud started`);
+          }
+        }
+
+        if (
+          activeSettings &&
+          isValidDocumentId(activeSettings.partyListDocumentId) &&
+          activeSettings.partyListDocumentId !== currentPartyList.id
+        ) {
+          const cloudPartyList = await documentCache.readAsync(
+            repo,
+            activeSettings.partyListDocumentId,
+          );
+
+          if (isCancelled) {
+            return;
+          }
+
+          if (!cloudPartyList) {
+            throw new Error("Cloud party list is unavailable");
           }
         }
 
@@ -240,7 +262,7 @@ export function useCloudSyncAccountState({
       isCancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [isSignInSuccessVisibleRef, userId]);
+  }, [isSignInSuccessVisibleRef, repo, userId]);
 
   function saveLinkedAccounts(accounts: LinkedAuthAccount[]) {
     dispatch({ type: "linkedAccountsSaved", linkedAccounts: accounts });
@@ -257,7 +279,7 @@ export function useCloudSyncAccountState({
     dispatch({ type: "cleared" });
   }
 
-  function activateCloudSyncOnDevice(settings: CloudUserSettings | null = cloudSettings) {
+  async function activateCloudSyncOnDevice(settings: CloudUserSettings | null = cloudSettings) {
     if (!settings) {
       toast.message(t`trizum cloud is not set up yet`);
       return;
@@ -270,6 +292,13 @@ export function useCloudSyncAccountState({
 
     if (settings.partyListDocumentId === partyList.id) {
       toast.message(t`This device is already using trizum cloud`);
+      return;
+    }
+
+    const cloudPartyList = await documentCache.readAsync(repo, settings.partyListDocumentId);
+
+    if (!cloudPartyList) {
+      toast.error(t`Could not load trizum cloud state`);
       return;
     }
 

--- a/packages/pwa/src/hooks/useCloudSyncAccountState.ts
+++ b/packages/pwa/src/hooks/useCloudSyncAccountState.ts
@@ -15,7 +15,7 @@ import {
   readCachedCloudAccountState,
   writeCachedCloudAccountState,
 } from "#src/lib/cloudSyncRouteState.ts";
-import type { PartyList } from "#src/models/partyList.js";
+import { setPartyListId, type PartyList } from "#src/models/partyList.js";
 
 const CLOUD_ACCOUNT_STATE_POLL_INTERVAL_MS = 30_000;
 
@@ -202,7 +202,7 @@ export function useCloudSyncAccountState({
           return;
         }
 
-        localStorage.setItem("partyListId", activeSettings.partyListDocumentId);
+        setPartyListId(activeSettings.partyListDocumentId);
         dispatch({ type: "cloudSettingsActivated", cloudSettings: activeSettings });
         writeCachedCloudUserSettings(currentUserId, activeSettings);
         writeCachedCloudAccountState(currentUserId, {
@@ -273,7 +273,7 @@ export function useCloudSyncAccountState({
       return;
     }
 
-    localStorage.setItem("partyListId", settings.partyListDocumentId);
+    setPartyListId(settings.partyListDocumentId);
 
     if (userId) {
       dispatch({ type: "cloudSettingsActivated", cloudSettings: settings });

--- a/packages/pwa/src/hooks/usePartyList.ts
+++ b/packages/pwa/src/hooks/usePartyList.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getPartyListId, type PartyList } from "#src/models/partyList.js";
+import { getPartyListId, subscribeToPartyListId, type PartyList } from "#src/models/partyList.js";
 import type { DocHandle, DocumentId } from "@automerge/automerge-repo/slim";
 import type { Party, PartyParticipant } from "#src/models/party.js";
 import {
@@ -37,10 +37,14 @@ function ensureLastUsedAt(list: PartyList) {
 
 export function usePartyList() {
   const repo = useRepo();
-  const [partyListId] = useState<DocumentId>(() => getPartyListId(repo));
+  const [partyListId, setPartyListId] = useState<DocumentId>(() => getPartyListId(repo));
   const [partyList, partyListHandle] = useSuspenseDocument<PartyList>(partyListId, {
     required: true,
   });
+
+  useEffect(() => {
+    return subscribeToPartyListId(setPartyListId);
+  }, []);
 
   useEffect(() => {
     setLocale(partyList.locale ?? getBrowserLocale());

--- a/packages/pwa/src/icons/illustration/shared-expenses.svg
+++ b/packages/pwa/src/icons/illustration/shared-expenses.svg
@@ -1,64 +1,111 @@
-<svg viewBox="0 0 360 260" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="180" cy="130" r="102" stroke="currentColor" stroke-width="3" stroke-dasharray="7 9" opacity=".55"/>
+<svg viewBox="0 0 620 560" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="shared-expenses-green" x1="78" y1="68" x2="155" y2="157" gradientUnits="userSpaceOnUse">
+      <stop stop-color="var(--color-success-700, #047857)"/>
+      <stop offset=".52" stop-color="var(--color-success-500, #10b981)"/>
+      <stop offset="1" stop-color="var(--color-success-400, #34d399)"/>
+    </linearGradient>
+    <linearGradient id="shared-expenses-blue" x1="460" y1="66" x2="533" y2="157" gradientUnits="userSpaceOnUse">
+      <stop stop-color="var(--color-blue-700, #1d4ed8)"/>
+      <stop offset="1" stop-color="var(--color-blue-400, #60a5fa)"/>
+    </linearGradient>
+    <linearGradient id="shared-expenses-purple" x1="67" y1="372" x2="139" y2="454" gradientUnits="userSpaceOnUse">
+      <stop stop-color="var(--color-violet-700, #6d28d9)"/>
+      <stop offset="1" stop-color="var(--color-violet-400, #a78bfa)"/>
+    </linearGradient>
+    <linearGradient id="shared-expenses-yellow" x1="484" y1="370" x2="555" y2="456" gradientUnits="userSpaceOnUse">
+      <stop stop-color="var(--color-warning-600, #ca8a04)"/>
+      <stop offset="1" stop-color="var(--color-warning-300, #fde047)"/>
+    </linearGradient>
+    <linearGradient id="shared-expenses-check" x1="376" y1="417" x2="431" y2="472" gradientUnits="userSpaceOnUse">
+      <stop stop-color="var(--color-success-700, #047857)"/>
+      <stop offset="1" stop-color="var(--color-success-500, #10b981)"/>
+    </linearGradient>
+    <filter id="shared-expenses-shadow" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#020c17" flood-opacity=".42"/>
+    </filter>
+    <filter id="shared-expenses-glow" x="-40%" y="-40%" width="180%" height="180%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="15"/>
+    </filter>
+  </defs>
 
-  <circle cx="43" cy="122" r="4" fill="var(--color-success-500, #10b981)" opacity=".7"/>
-  <circle cx="314" cy="124" r="4" fill="currentColor" opacity=".55"/>
-  <circle cx="319" cy="166" r="3" fill="currentColor" opacity=".4"/>
-  <path d="M47 79h14M54 72v14" stroke="currentColor" stroke-width="3" stroke-linecap="round" opacity=".55"/>
-  <path d="M304 85h14M311 78v14" stroke="var(--color-success-500, #10b981)" stroke-width="3" stroke-linecap="round" opacity=".8"/>
+  <ellipse
+    cx="310"
+    cy="277"
+    rx="258"
+    ry="235"
+    stroke="currentColor"
+    stroke-width="4"
+    stroke-dasharray="9 8"
+    opacity=".58"
+  />
 
-  <rect x="125" y="45" width="110" height="166" rx="18" fill="currentColor" opacity=".07"/>
-  <rect x="125" y="45" width="110" height="166" rx="18" stroke="currentColor" stroke-width="2.5" opacity=".65"/>
+  <circle cx="117" cy="111" r="56" fill="var(--color-success-500, #10b981)" opacity=".1" filter="url(#shared-expenses-glow)"/>
+  <circle cx="494" cy="111" r="56" fill="var(--color-blue-500, #3b82f6)" opacity=".1" filter="url(#shared-expenses-glow)"/>
+  <circle cx="102" cy="409" r="56" fill="var(--color-violet-500, #8b5cf6)" opacity=".1" filter="url(#shared-expenses-glow)"/>
+  <circle cx="519" cy="409" r="56" fill="var(--color-warning-400, #facc15)" opacity=".1" filter="url(#shared-expenses-glow)"/>
 
-  <path d="M194 69c-3-4-7-6-12-6-9 0-16 8-16 19s7 19 16 19c5 0 9-2 12-6M162 77h24M162 88h22" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <circle cx="146" cy="121" r="5" fill="var(--color-success-500, #10b981)"/>
-  <circle cx="146" cy="140" r="5" fill="var(--color-blue-500, #3b82f6)"/>
-  <circle cx="146" cy="159" r="5" fill="var(--color-violet-500, #8b5cf6)"/>
-  <circle cx="146" cy="178" r="5" fill="var(--color-warning-400, #facc15)"/>
-  <path d="M158 121h31M158 140h31M158 159h31M158 178h31" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity=".42"/>
-  <g fill="currentColor" font-family="Inter, sans-serif" font-size="9" font-weight="500" text-anchor="end" opacity=".8">
-    <text x="219" y="124">28.40</text>
-    <text x="219" y="143">18.20</text>
-    <text x="219" y="162">14.60</text>
-    <text x="219" y="181">9.80</text>
-  </g>
-  <path d="M143 190h74" stroke="currentColor" stroke-width="1.5" opacity=".4"/>
-  <text x="219" y="204" fill="currentColor" font-family="Inter, sans-serif" font-size="13" font-weight="700" text-anchor="end">71.00</text>
-
-  <g>
-    <circle cx="69" cy="57" r="31" fill="var(--color-success-500, #10b981)" opacity=".82"/>
-    <circle cx="69" cy="57" r="31" stroke="var(--color-success-400, #34d399)" stroke-width="2"/>
-    <circle cx="59" cy="47" r="19" fill="white" opacity=".08"/>
-    <circle cx="69" cy="51" r="7" stroke="white" stroke-width="2.5"/>
-    <path d="M56 72c1-8 6-12 13-12s12 4 13 12" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-  </g>
-
-  <g>
-    <circle cx="291" cy="58" r="31" fill="var(--color-blue-500, #3b82f6)" opacity=".82"/>
-    <circle cx="291" cy="58" r="31" stroke="var(--color-blue-400, #60a5fa)" stroke-width="2"/>
-    <circle cx="281" cy="48" r="19" fill="white" opacity=".08"/>
-    <circle cx="291" cy="52" r="7" stroke="white" stroke-width="2.5"/>
-    <path d="M278 73c1-8 6-12 13-12s12 4 13 12" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-  </g>
-
-  <g>
-    <circle cx="61" cy="204" r="31" fill="var(--color-violet-500, #8b5cf6)" opacity=".82"/>
-    <circle cx="61" cy="204" r="31" stroke="var(--color-violet-400, #a78bfa)" stroke-width="2"/>
-    <circle cx="51" cy="194" r="19" fill="white" opacity=".08"/>
-    <circle cx="61" cy="198" r="7" stroke="white" stroke-width="2.5"/>
-    <path d="M48 219c1-8 6-12 13-12s12 4 13 12" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-  </g>
-
-  <g>
-    <circle cx="299" cy="204" r="31" fill="var(--color-warning-400, #facc15)" opacity=".88"/>
-    <circle cx="299" cy="204" r="31" stroke="var(--color-warning-300, #fde047)" stroke-width="2"/>
-    <circle cx="289" cy="194" r="19" fill="white" opacity=".1"/>
-    <circle cx="299" cy="198" r="7" stroke="white" stroke-width="2.5"/>
-    <path d="M286 219c1-8 6-12 13-12s12 4 13 12" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <g opacity=".75">
+    <circle cx="250" cy="83" r="5" stroke="currentColor" stroke-width="4"/>
+    <path d="M124 218h17M132.5 209.5v17" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="160" cy="284" r="6" fill="var(--color-success-500, #10b981)"/>
+    <circle cx="472" cy="218" r="5.5" fill="currentColor" opacity=".7"/>
+    <path d="M512 250h17M520.5 241.5v17" stroke="var(--color-success-400, #34d399)" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="451" cy="335" r="5" stroke="currentColor" stroke-width="4" opacity=".7"/>
   </g>
 
-  <circle cx="238" cy="199" r="19" fill="var(--color-success-600, #059669)" opacity=".94"/>
-  <circle cx="238" cy="199" r="19" stroke="var(--color-success-400, #34d399)" stroke-width="2"/>
-  <path d="m229 199 6 6 12-14" stroke="white" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <g filter="url(#shared-expenses-shadow)">
+    <rect x="196" y="122" width="220" height="316" rx="23" fill="var(--shared-expenses-surface, #09233a)"/>
+    <rect x="197.5" y="123.5" width="217" height="313" rx="21.5" stroke="currentColor" stroke-width="3" opacity=".42"/>
+
+    <path d="M322 154c-4-5-10-8-17-8-13 0-23 11-23 26s10 26 23 26c7 0 13-3 17-8M275 164h37M275 180h34" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <circle cx="230" cy="226" r="8" fill="var(--color-success-500, #10b981)"/>
+    <circle cx="230" cy="263" r="8" fill="var(--color-blue-400, #60a5fa)"/>
+    <circle cx="230" cy="299" r="8" fill="var(--color-violet-400, #a78bfa)"/>
+    <circle cx="230" cy="335" r="8" fill="var(--color-warning-400, #facc15)"/>
+    <path d="M255 226h65M255 263h65M255 299h65M255 335h65" stroke="currentColor" stroke-width="9" stroke-linecap="round" opacity=".36"/>
+    <g fill="currentColor" font-family="Inter, ui-sans-serif, sans-serif" font-size="16" font-weight="500" text-anchor="end" opacity=".88">
+      <text x="388" y="232">28.40</text>
+      <text x="388" y="269">18.20</text>
+      <text x="388" y="305">14.60</text>
+      <text x="388" y="341">9.80</text>
+    </g>
+    <path d="M215 366h180" stroke="currentColor" stroke-width="2.5" opacity=".35"/>
+    <text x="388" y="405" fill="currentColor" font-family="Inter, ui-sans-serif, sans-serif" font-size="24" font-weight="700" text-anchor="end">71.00</text>
+  </g>
+
+  <g filter="url(#shared-expenses-shadow)">
+    <circle cx="117" cy="111" r="49" fill="url(#shared-expenses-green)"/>
+    <circle cx="117" cy="111" r="48" stroke="var(--color-success-300, #6ee7b7)" stroke-width="2" opacity=".85"/>
+    <circle cx="117" cy="102" r="11" stroke="white" stroke-width="4"/>
+    <path d="M101 132c1-13 7-19 16-19s15 6 16 19" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  </g>
+
+  <g filter="url(#shared-expenses-shadow)">
+    <circle cx="494" cy="111" r="49" fill="url(#shared-expenses-blue)"/>
+    <circle cx="494" cy="111" r="48" stroke="var(--color-blue-300, #93c5fd)" stroke-width="2" opacity=".9"/>
+    <circle cx="494" cy="102" r="11" stroke="white" stroke-width="4"/>
+    <path d="M478 132c1-13 7-19 16-19s15 6 16 19" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  </g>
+
+  <g filter="url(#shared-expenses-shadow)">
+    <circle cx="102" cy="409" r="49" fill="url(#shared-expenses-purple)"/>
+    <circle cx="102" cy="409" r="48" stroke="var(--color-violet-300, #c4b5fd)" stroke-width="2" opacity=".88"/>
+    <circle cx="102" cy="400" r="11" stroke="white" stroke-width="4"/>
+    <path d="M86 430c1-13 7-19 16-19s15 6 16 19" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  </g>
+
+  <g filter="url(#shared-expenses-shadow)">
+    <circle cx="519" cy="409" r="49" fill="url(#shared-expenses-yellow)"/>
+    <circle cx="519" cy="409" r="48" stroke="var(--color-warning-300, #fde047)" stroke-width="2" opacity=".95"/>
+    <circle cx="519" cy="400" r="11" stroke="white" stroke-width="4"/>
+    <path d="M503 430c1-13 7-19 16-19s15 6 16 19" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  </g>
+
+  <g filter="url(#shared-expenses-shadow)">
+    <circle cx="402" cy="445" r="32" fill="url(#shared-expenses-check)"/>
+    <circle cx="402" cy="445" r="31" stroke="var(--color-success-400, #34d399)" stroke-width="2"/>
+    <path d="m387 445 10 10 20-23" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
 </svg>

--- a/packages/pwa/src/icons/illustration/shared-expenses.svg
+++ b/packages/pwa/src/icons/illustration/shared-expenses.svg
@@ -1,0 +1,23 @@
+<svg viewBox="0 0 320 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="160" cy="110" r="92" stroke="currentColor" stroke-width="3" stroke-dasharray="7 9" opacity=".35"/>
+  <rect x="112" y="48" width="96" height="124" rx="18" fill="currentColor" opacity=".12"/>
+  <rect x="112" y="48" width="96" height="124" rx="18" stroke="currentColor" stroke-width="3" opacity=".7"/>
+  <path d="M174 77c-3-4-7-6-12-6-9 0-16 8-16 19s7 19 16 19c5 0 9-2 12-6M142 85h24M142 96h22" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M132 128h56M132 143h38" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity=".55"/>
+  <circle cx="76" cy="72" r="28" fill="currentColor" opacity=".18"/>
+  <circle cx="76" cy="72" r="28" stroke="currentColor" stroke-width="3"/>
+  <circle cx="244" cy="72" r="28" fill="currentColor" opacity=".28"/>
+  <circle cx="244" cy="72" r="28" stroke="currentColor" stroke-width="3"/>
+  <circle cx="82" cy="162" r="28" fill="currentColor" opacity=".28"/>
+  <circle cx="82" cy="162" r="28" stroke="currentColor" stroke-width="3"/>
+  <circle cx="238" cy="162" r="28" fill="currentColor" opacity=".18"/>
+  <circle cx="238" cy="162" r="28" stroke="currentColor" stroke-width="3"/>
+  <g stroke="currentColor" stroke-width="3" stroke-linecap="round">
+    <circle cx="76" cy="67" r="7"/><path d="M63 84c2-7 7-10 13-10s11 3 13 10"/>
+    <circle cx="244" cy="67" r="7"/><path d="M231 84c2-7 7-10 13-10s11 3 13 10"/>
+    <circle cx="82" cy="157" r="7"/><path d="M69 174c2-7 7-10 13-10s11 3 13 10"/>
+    <circle cx="238" cy="157" r="7"/><path d="M225 174c2-7 7-10 13-10s11 3 13 10"/>
+  </g>
+  <circle cx="214" cy="128" r="16" fill="currentColor"/>
+  <path d="m207 128 5 5 9-11" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/pwa/src/icons/illustration/shared-expenses.svg
+++ b/packages/pwa/src/icons/illustration/shared-expenses.svg
@@ -1,23 +1,64 @@
-<svg viewBox="0 0 320 220" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="160" cy="110" r="92" stroke="currentColor" stroke-width="3" stroke-dasharray="7 9" opacity=".35"/>
-  <rect x="112" y="48" width="96" height="124" rx="18" fill="currentColor" opacity=".12"/>
-  <rect x="112" y="48" width="96" height="124" rx="18" stroke="currentColor" stroke-width="3" opacity=".7"/>
-  <path d="M174 77c-3-4-7-6-12-6-9 0-16 8-16 19s7 19 16 19c5 0 9-2 12-6M142 85h24M142 96h22" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M132 128h56M132 143h38" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity=".55"/>
-  <circle cx="76" cy="72" r="28" fill="currentColor" opacity=".18"/>
-  <circle cx="76" cy="72" r="28" stroke="currentColor" stroke-width="3"/>
-  <circle cx="244" cy="72" r="28" fill="currentColor" opacity=".28"/>
-  <circle cx="244" cy="72" r="28" stroke="currentColor" stroke-width="3"/>
-  <circle cx="82" cy="162" r="28" fill="currentColor" opacity=".28"/>
-  <circle cx="82" cy="162" r="28" stroke="currentColor" stroke-width="3"/>
-  <circle cx="238" cy="162" r="28" fill="currentColor" opacity=".18"/>
-  <circle cx="238" cy="162" r="28" stroke="currentColor" stroke-width="3"/>
-  <g stroke="currentColor" stroke-width="3" stroke-linecap="round">
-    <circle cx="76" cy="67" r="7"/><path d="M63 84c2-7 7-10 13-10s11 3 13 10"/>
-    <circle cx="244" cy="67" r="7"/><path d="M231 84c2-7 7-10 13-10s11 3 13 10"/>
-    <circle cx="82" cy="157" r="7"/><path d="M69 174c2-7 7-10 13-10s11 3 13 10"/>
-    <circle cx="238" cy="157" r="7"/><path d="M225 174c2-7 7-10 13-10s11 3 13 10"/>
+<svg viewBox="0 0 360 260" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="180" cy="130" r="102" stroke="currentColor" stroke-width="3" stroke-dasharray="7 9" opacity=".55"/>
+
+  <circle cx="43" cy="122" r="4" fill="var(--color-success-500, #10b981)" opacity=".7"/>
+  <circle cx="314" cy="124" r="4" fill="currentColor" opacity=".55"/>
+  <circle cx="319" cy="166" r="3" fill="currentColor" opacity=".4"/>
+  <path d="M47 79h14M54 72v14" stroke="currentColor" stroke-width="3" stroke-linecap="round" opacity=".55"/>
+  <path d="M304 85h14M311 78v14" stroke="var(--color-success-500, #10b981)" stroke-width="3" stroke-linecap="round" opacity=".8"/>
+
+  <rect x="125" y="45" width="110" height="166" rx="18" fill="currentColor" opacity=".07"/>
+  <rect x="125" y="45" width="110" height="166" rx="18" stroke="currentColor" stroke-width="2.5" opacity=".65"/>
+
+  <path d="M194 69c-3-4-7-6-12-6-9 0-16 8-16 19s7 19 16 19c5 0 9-2 12-6M162 77h24M162 88h22" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <circle cx="146" cy="121" r="5" fill="var(--color-success-500, #10b981)"/>
+  <circle cx="146" cy="140" r="5" fill="var(--color-blue-500, #3b82f6)"/>
+  <circle cx="146" cy="159" r="5" fill="var(--color-violet-500, #8b5cf6)"/>
+  <circle cx="146" cy="178" r="5" fill="var(--color-warning-400, #facc15)"/>
+  <path d="M158 121h31M158 140h31M158 159h31M158 178h31" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity=".42"/>
+  <g fill="currentColor" font-family="Inter, sans-serif" font-size="9" font-weight="500" text-anchor="end" opacity=".8">
+    <text x="219" y="124">28.40</text>
+    <text x="219" y="143">18.20</text>
+    <text x="219" y="162">14.60</text>
+    <text x="219" y="181">9.80</text>
   </g>
-  <circle cx="214" cy="128" r="16" fill="currentColor"/>
-  <path d="m207 128 5 5 9-11" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M143 190h74" stroke="currentColor" stroke-width="1.5" opacity=".4"/>
+  <text x="219" y="204" fill="currentColor" font-family="Inter, sans-serif" font-size="13" font-weight="700" text-anchor="end">71.00</text>
+
+  <g>
+    <circle cx="69" cy="57" r="31" fill="var(--color-success-500, #10b981)" opacity=".82"/>
+    <circle cx="69" cy="57" r="31" stroke="var(--color-success-400, #34d399)" stroke-width="2"/>
+    <circle cx="59" cy="47" r="19" fill="white" opacity=".08"/>
+    <circle cx="69" cy="51" r="7" stroke="white" stroke-width="2.5"/>
+    <path d="M56 72c1-8 6-12 13-12s12 4 13 12" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+
+  <g>
+    <circle cx="291" cy="58" r="31" fill="var(--color-blue-500, #3b82f6)" opacity=".82"/>
+    <circle cx="291" cy="58" r="31" stroke="var(--color-blue-400, #60a5fa)" stroke-width="2"/>
+    <circle cx="281" cy="48" r="19" fill="white" opacity=".08"/>
+    <circle cx="291" cy="52" r="7" stroke="white" stroke-width="2.5"/>
+    <path d="M278 73c1-8 6-12 13-12s12 4 13 12" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+
+  <g>
+    <circle cx="61" cy="204" r="31" fill="var(--color-violet-500, #8b5cf6)" opacity=".82"/>
+    <circle cx="61" cy="204" r="31" stroke="var(--color-violet-400, #a78bfa)" stroke-width="2"/>
+    <circle cx="51" cy="194" r="19" fill="white" opacity=".08"/>
+    <circle cx="61" cy="198" r="7" stroke="white" stroke-width="2.5"/>
+    <path d="M48 219c1-8 6-12 13-12s12 4 13 12" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+
+  <g>
+    <circle cx="299" cy="204" r="31" fill="var(--color-warning-400, #facc15)" opacity=".88"/>
+    <circle cx="299" cy="204" r="31" stroke="var(--color-warning-300, #fde047)" stroke-width="2"/>
+    <circle cx="289" cy="194" r="19" fill="white" opacity=".1"/>
+    <circle cx="299" cy="198" r="7" stroke="white" stroke-width="2.5"/>
+    <path d="M286 219c1-8 6-12 13-12s12 4 13 12" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+
+  <circle cx="238" cy="199" r="19" fill="var(--color-success-600, #059669)" opacity=".94"/>
+  <circle cx="238" cy="199" r="19" stroke="var(--color-success-400, #34d399)" stroke-width="2"/>
+  <path d="m229 199 6 6 12-14" stroke="white" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -78,6 +78,10 @@ body {
   @apply bg-accent-50 text-accent-950 dark:bg-accent-950 dark:text-accent-50 font-sans;
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 #root {
   height: 100%;
   width: 100%;

--- a/packages/pwa/src/lib/auth-client.ts
+++ b/packages/pwa/src/lib/auth-client.ts
@@ -10,6 +10,8 @@ import {
   setNativeAuthTokenFromResponse,
 } from "./nativeAuthSession";
 
+const AUTH_SESSION_REFETCH_INTERVAL_SECONDS = 60 * 60;
+
 export interface LinkedAuthAccount {
   accountId: string;
   createdAt: string | Date;
@@ -47,6 +49,11 @@ export const authClient = createAuthClient({
     },
   },
   plugins: [magicLinkClient()],
+  sessionOptions: {
+    refetchInterval: AUTH_SESSION_REFETCH_INTERVAL_SECONDS,
+    refetchOnWindowFocus: true,
+    refetchWhenOffline: false,
+  },
 });
 
 type AuthSession = ReturnType<typeof authClient.useSession>;

--- a/packages/pwa/src/lib/testing/browserHarness.ts
+++ b/packages/pwa/src/lib/testing/browserHarness.ts
@@ -121,6 +121,8 @@ export async function seedPartyListState({
     applyPartyListSeed(partyList, seed);
   });
 
+  await repo.flush([partyListId]);
+
   return {
     partyListId,
   };

--- a/packages/pwa/src/lib/testing/browserHarness.ts
+++ b/packages/pwa/src/lib/testing/browserHarness.ts
@@ -32,6 +32,81 @@ export interface InternalPartyListSnapshot {
   participantInParties: PartyList["participantInParties"];
 }
 
+function applyPartyListSeed(partyList: PartyList, seed: InternalPartyListSeed) {
+  partyList.username = seed.username ?? "";
+  partyList.phone = seed.phone ?? "";
+  partyList.parties = seed.parties ?? {};
+  partyList.pinnedParties = seed.pinnedParties ?? {};
+  partyList.archivedParties = seed.archivedParties ?? {};
+  partyList.lastUsedAt = seed.lastUsedAt ?? {};
+  partyList.participantInParties = seed.participantInParties ?? {};
+
+  if (seed.avatarId === undefined) {
+    delete partyList["avatarId"];
+  } else {
+    partyList.avatarId = seed.avatarId;
+  }
+
+  if (seed.locale === undefined) {
+    delete partyList["locale"];
+  } else {
+    partyList.locale = seed.locale;
+  }
+
+  if (seed.openLastPartyOnLaunch === undefined) {
+    delete partyList["openLastPartyOnLaunch"];
+  } else {
+    partyList.openLastPartyOnLaunch = seed.openLastPartyOnLaunch;
+  }
+
+  if (seed.autoOpenCalculator === undefined) {
+    delete partyList["autoOpenCalculator"];
+  } else {
+    partyList.autoOpenCalculator = seed.autoOpenCalculator;
+  }
+
+  if (seed.hue === undefined) {
+    delete partyList["hue"];
+  } else {
+    partyList.hue = seed.hue;
+  }
+
+  if (seed.lastOpenedPartyId === undefined) {
+    delete partyList["lastOpenedPartyId"];
+  } else {
+    partyList.lastOpenedPartyId = seed.lastOpenedPartyId;
+  }
+}
+
+export function createInactivePartyListState({
+  repo,
+  seed,
+}: {
+  repo: Repo;
+  seed: InternalPartyListSeed;
+}): InternalPartyListSeedResult {
+  const partyListHandle = repo.create<PartyList>({
+    id: "" as DocumentId,
+    type: "partyList",
+    username: "",
+    phone: "",
+    parties: {},
+    pinnedParties: {},
+    archivedParties: {},
+    lastUsedAt: {},
+    participantInParties: {},
+  });
+
+  partyListHandle.change((partyList) => {
+    partyList.id = partyListHandle.documentId;
+    applyPartyListSeed(partyList, seed);
+  });
+
+  return {
+    partyListId: partyListHandle.documentId,
+  };
+}
+
 export async function seedPartyListState({
   repo,
   seed,
@@ -43,49 +118,7 @@ export async function seedPartyListState({
   const partyListId = partyListHandle.documentId;
 
   partyListHandle.change((partyList) => {
-    partyList.username = seed.username ?? "";
-    partyList.phone = seed.phone ?? "";
-    partyList.parties = seed.parties ?? {};
-    partyList.pinnedParties = seed.pinnedParties ?? {};
-    partyList.archivedParties = seed.archivedParties ?? {};
-    partyList.lastUsedAt = seed.lastUsedAt ?? {};
-    partyList.participantInParties = seed.participantInParties ?? {};
-
-    if (seed.avatarId === undefined) {
-      delete partyList["avatarId"];
-    } else {
-      partyList.avatarId = seed.avatarId;
-    }
-
-    if (seed.locale === undefined) {
-      delete partyList["locale"];
-    } else {
-      partyList.locale = seed.locale;
-    }
-
-    if (seed.openLastPartyOnLaunch === undefined) {
-      delete partyList["openLastPartyOnLaunch"];
-    } else {
-      partyList.openLastPartyOnLaunch = seed.openLastPartyOnLaunch;
-    }
-
-    if (seed.autoOpenCalculator === undefined) {
-      delete partyList["autoOpenCalculator"];
-    } else {
-      partyList.autoOpenCalculator = seed.autoOpenCalculator;
-    }
-
-    if (seed.hue === undefined) {
-      delete partyList["hue"];
-    } else {
-      partyList.hue = seed.hue;
-    }
-
-    if (seed.lastOpenedPartyId === undefined) {
-      delete partyList["lastOpenedPartyId"];
-    } else {
-      partyList.lastOpenedPartyId = seed.lastOpenedPartyId;
-    }
+    applyPartyListSeed(partyList, seed);
   });
 
   return {

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -2,6 +2,7 @@ import "@fontsource-variable/inter";
 import "@fontsource-variable/fira-code";
 import * as ReactDOM from "react-dom/client";
 import { Repo } from "@automerge/automerge-repo"; // inits automerge
+import type { DocumentId } from "@automerge/automerge-repo/slim";
 import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-indexeddb";
 import {
@@ -152,6 +153,7 @@ const repo = new Repo({
   storage: new IndexedDBStorageAdapter("trizum"),
   network: [isOfflineOnly ? null : new BrowserWebSocketClientAdapter(WSS_URL)].filter(isNonNull),
 });
+const deferredPartyListImports = new Map<DocumentId, Uint8Array>();
 
 void initializeAppWorker({
   repo,
@@ -164,9 +166,11 @@ void initializeAppWorker({
 declare global {
   interface Window {
     __internal_createPartyFromMigrationData: (data: MigrationData) => Promise<string>;
-    __internal_createInactivePartyListState: (
+    __internal_createDeferredPartyListState: (
       seed: InternalPartyListSeed,
-    ) => InternalPartyListSeedResult;
+    ) => Promise<InternalPartyListSeedResult>;
+    __internal_getDocumentState: (documentId: DocumentId) => string | undefined;
+    __internal_releaseDeferredPartyListState: (partyListId: DocumentId) => void;
     __internal_seedPartyListState: (
       seed: InternalPartyListSeed,
     ) => Promise<InternalPartyListSeedResult>;
@@ -184,8 +188,33 @@ window.__internal_createPartyFromMigrationData = async (data: MigrationData) => 
   });
 };
 
-window.__internal_createInactivePartyListState = (seed: InternalPartyListSeed) => {
-  return createInactivePartyListState({ repo, seed });
+window.__internal_createDeferredPartyListState = async (seed: InternalPartyListSeed) => {
+  const detachedRepo = new Repo({ network: [] });
+  const result = createInactivePartyListState({ repo: detachedRepo, seed });
+  const binary = await detachedRepo.export(result.partyListId);
+  await detachedRepo.shutdown();
+
+  if (!binary) {
+    throw new Error("Expected the deferred party list to be exportable");
+  }
+
+  deferredPartyListImports.set(result.partyListId, binary);
+  return result;
+};
+
+window.__internal_getDocumentState = (documentId: DocumentId) => {
+  return repo.handles[documentId]?.state;
+};
+
+window.__internal_releaseDeferredPartyListState = (partyListId: DocumentId) => {
+  const binary = deferredPartyListImports.get(partyListId);
+
+  if (!binary) {
+    throw new Error(`No deferred party list found for ${partyListId}`);
+  }
+
+  repo.import(binary, { docId: partyListId });
+  deferredPartyListImports.delete(partyListId);
 };
 
 window.__internal_seedPartyListState = async (seed: InternalPartyListSeed) => {

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -29,6 +29,7 @@ import { Capacitor } from "@capacitor/core";
 import { App } from "@capacitor/app";
 import { UpdateControllerNative } from "./components/UpdateControllerNative.tsx";
 import { AppRecoveryDialog } from "./components/AppRecoveryDialog.tsx";
+import { AuthSessionController } from "./components/AuthSessionController.tsx";
 import { useEffect } from "react";
 import { SplashScreen } from "@capacitor/splash-screen";
 import * as Sentry from "@sentry/react";
@@ -285,6 +286,7 @@ if (!rootElement.innerHTML) {
         <AriaProviders>
           <RepoContext value={repo}>
             <MediaGalleryController>
+              <AuthSessionController />
               <RouterProvider router={router} InnerWrap={InnerWrap} />
               <AppRecoveryDialog />
               <Toaster />

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -181,11 +181,14 @@ declare global {
 
 // For internal use only, like UI testing or screenshots
 window.__internal_createPartyFromMigrationData = async (data: MigrationData) => {
-  return createPartyFromMigrationData({
+  const partyId = await createPartyFromMigrationData({
     repo,
     data,
     importAttachments: false,
   });
+
+  await repo.flush();
+  return partyId;
 };
 
 window.__internal_createDeferredPartyListState = async (seed: InternalPartyListSeed) => {

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -47,6 +47,7 @@ import {
 import { createPartyFromMigrationData, type MigrationData } from "./models/migration.ts";
 import type { Party } from "./models/party.ts";
 import {
+  createInactivePartyListState,
   readPartyListState,
   seedPartyListState,
   type InternalPartyListSeed,
@@ -163,6 +164,9 @@ void initializeAppWorker({
 declare global {
   interface Window {
     __internal_createPartyFromMigrationData: (data: MigrationData) => Promise<string>;
+    __internal_createInactivePartyListState: (
+      seed: InternalPartyListSeed,
+    ) => InternalPartyListSeedResult;
     __internal_seedPartyListState: (
       seed: InternalPartyListSeed,
     ) => Promise<InternalPartyListSeedResult>;
@@ -178,6 +182,10 @@ window.__internal_createPartyFromMigrationData = async (data: MigrationData) => 
     data,
     importAttachments: false,
   });
+};
+
+window.__internal_createInactivePartyListState = (seed: InternalPartyListSeed) => {
+  return createInactivePartyListState({ repo, seed });
 };
 
 window.__internal_seedPartyListState = async (seed: InternalPartyListSeed) => {

--- a/packages/pwa/src/models/partyList.ts
+++ b/packages/pwa/src/models/partyList.ts
@@ -3,6 +3,7 @@ import type { SupportedLocale } from "#src/lib/locales.js";
 import type { Party, PartyParticipant } from "./party";
 
 const PARTY_LIST_ID_STORAGE_KEY = "partyListId";
+const PARTY_LIST_ID_CHANGED_EVENT = "trizum:party-list-id-changed";
 
 export interface PartyList {
   id: DocumentId;
@@ -65,4 +66,33 @@ export function getPartyListId(repo: Repo) {
   }
 
   return createPartyListHandle(repo).documentId;
+}
+
+export function setPartyListId(id: DocumentId) {
+  localStorage.setItem(PARTY_LIST_ID_STORAGE_KEY, id);
+  window.dispatchEvent(new CustomEvent<DocumentId>(PARTY_LIST_ID_CHANGED_EVENT, { detail: id }));
+}
+
+export function subscribeToPartyListId(onPartyListIdChanged: (partyListId: DocumentId) => void) {
+  function handlePartyListIdChanged(event: Event) {
+    onPartyListIdChanged((event as CustomEvent<DocumentId>).detail);
+  }
+
+  function handleStorage(event: StorageEvent) {
+    if (
+      event.key === PARTY_LIST_ID_STORAGE_KEY &&
+      event.newValue &&
+      isValidDocumentId(event.newValue)
+    ) {
+      onPartyListIdChanged(event.newValue);
+    }
+  }
+
+  window.addEventListener(PARTY_LIST_ID_CHANGED_EVENT, handlePartyListIdChanged);
+  window.addEventListener("storage", handleStorage);
+
+  return () => {
+    window.removeEventListener(PARTY_LIST_ID_CHANGED_EVENT, handlePartyListIdChanged);
+    window.removeEventListener("storage", handleStorage);
+  };
 }

--- a/packages/pwa/src/models/partyList.ts
+++ b/packages/pwa/src/models/partyList.ts
@@ -78,21 +78,9 @@ export function subscribeToPartyListId(onPartyListIdChanged: (partyListId: Docum
     onPartyListIdChanged((event as CustomEvent<DocumentId>).detail);
   }
 
-  function handleStorage(event: StorageEvent) {
-    if (
-      event.key === PARTY_LIST_ID_STORAGE_KEY &&
-      event.newValue &&
-      isValidDocumentId(event.newValue)
-    ) {
-      onPartyListIdChanged(event.newValue);
-    }
-  }
-
   window.addEventListener(PARTY_LIST_ID_CHANGED_EVENT, handlePartyListIdChanged);
-  window.addEventListener("storage", handleStorage);
 
   return () => {
     window.removeEventListener(PARTY_LIST_ID_CHANGED_EVENT, handlePartyListIdChanged);
-    window.removeEventListener("storage", handleStorage);
   };
 }

--- a/packages/pwa/src/routeTree.gen.ts
+++ b/packages/pwa/src/routeTree.gen.ts
@@ -17,8 +17,8 @@ import { Route as ArchivedRouteImport } from './routes/archived'
 import { Route as SupportRouteRouteImport } from './routes/support/route'
 import { Route as NewRouteRouteImport } from './routes/new/route'
 import { Route as AboutRouteRouteImport } from './routes/about/route'
-import { Route as IndexRouteRouteImport } from './routes/index/route'
-import { Route as SettingsCloudSyncRouteImport } from './routes/settings_.cloud-sync'
+import { Route as HomeRouteRouteImport } from './routes/_home/route'
+import { Route as HomeIndexRouteImport } from './routes/_home/index'
 import { Route as AboutThirdPartyLicensesRouteImport } from './routes/about_.third-party-licenses'
 import { Route as PartyPartyIdRouteRouteImport } from './routes/party.$partyId/route'
 import { Route as MigrateTricountRouteRouteImport } from './routes/migrate_.tricount/route'
@@ -26,6 +26,7 @@ import { Route as PartyPartyIdWhoRouteImport } from './routes/party_.$partyId.wh
 import { Route as PartyPartyIdStatsRouteImport } from './routes/party_.$partyId.stats'
 import { Route as PartyPartyIdShareRouteImport } from './routes/party_.$partyId.share'
 import { Route as PartyPartyIdAddRouteImport } from './routes/party_.$partyId.add'
+import { Route as HomeSettingsCloudSyncRouteImport } from './routes/_home/settings_.cloud-sync'
 import { Route as PartyPartyIdTransferDebtRouteRouteImport } from './routes/party_.$partyId.transfer-debt/route'
 import { Route as PartyPartyIdSettingsRouteRouteImport } from './routes/party_.$partyId.settings/route'
 import { Route as PartyPartyIdPayRouteRouteImport } from './routes/party_.$partyId.pay/route'
@@ -72,15 +73,14 @@ const AboutRouteRoute = AboutRouteRouteImport.update({
   path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRouteRoute = IndexRouteRouteImport.update({
-  id: '/',
-  path: '',
+const HomeRouteRoute = HomeRouteRouteImport.update({
+  id: '/_home',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SettingsCloudSyncRoute = SettingsCloudSyncRouteImport.update({
-  id: '/settings_/cloud-sync',
-  path: '/settings/cloud-sync',
-  getParentRoute: () => rootRouteImport,
+const HomeIndexRoute = HomeIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => HomeRouteRoute,
 } as any)
 const AboutThirdPartyLicensesRoute = AboutThirdPartyLicensesRouteImport.update({
   id: '/about_/third-party-licenses',
@@ -117,6 +117,11 @@ const PartyPartyIdAddRoute = PartyPartyIdAddRouteImport.update({
   path: '/party/$partyId/add',
   getParentRoute: () => rootRouteImport,
 } as any)
+const HomeSettingsCloudSyncRoute = HomeSettingsCloudSyncRouteImport.update({
+  id: '/settings_/cloud-sync',
+  path: '/settings/cloud-sync',
+  getParentRoute: () => HomeRouteRoute,
+} as any)
 const PartyPartyIdTransferDebtRouteRoute =
   PartyPartyIdTransferDebtRouteRouteImport.update({
     id: '/party_/$partyId/transfer-debt',
@@ -148,7 +153,7 @@ const PartyPartyIdExpenseExpenseIdEditRouteRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRouteRoute
+  '/': typeof HomeIndexRoute
   '/about': typeof AboutRouteRoute
   '/new': typeof NewRouteRoute
   '/support': typeof SupportRouteRoute
@@ -160,10 +165,10 @@ export interface FileRoutesByFullPath {
   '/migrate/tricount': typeof MigrateTricountRouteRoute
   '/party/$partyId': typeof PartyPartyIdRouteRoute
   '/about/third-party-licenses': typeof AboutThirdPartyLicensesRoute
-  '/settings/cloud-sync': typeof SettingsCloudSyncRoute
   '/party/$partyId/pay': typeof PartyPartyIdPayRouteRoute
   '/party/$partyId/settings': typeof PartyPartyIdSettingsRouteRoute
   '/party/$partyId/transfer-debt': typeof PartyPartyIdTransferDebtRouteRoute
+  '/settings/cloud-sync': typeof HomeSettingsCloudSyncRoute
   '/party/$partyId/add': typeof PartyPartyIdAddRoute
   '/party/$partyId/share': typeof PartyPartyIdShareRoute
   '/party/$partyId/stats': typeof PartyPartyIdStatsRoute
@@ -172,7 +177,6 @@ export interface FileRoutesByFullPath {
   '/party/$partyId/expense/$expenseId/edit': typeof PartyPartyIdExpenseExpenseIdEditRouteRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRouteRoute
   '/about': typeof AboutRouteRoute
   '/new': typeof NewRouteRoute
   '/support': typeof SupportRouteRoute
@@ -184,10 +188,11 @@ export interface FileRoutesByTo {
   '/migrate/tricount': typeof MigrateTricountRouteRoute
   '/party/$partyId': typeof PartyPartyIdRouteRoute
   '/about/third-party-licenses': typeof AboutThirdPartyLicensesRoute
-  '/settings/cloud-sync': typeof SettingsCloudSyncRoute
+  '/': typeof HomeIndexRoute
   '/party/$partyId/pay': typeof PartyPartyIdPayRouteRoute
   '/party/$partyId/settings': typeof PartyPartyIdSettingsRouteRoute
   '/party/$partyId/transfer-debt': typeof PartyPartyIdTransferDebtRouteRoute
+  '/settings/cloud-sync': typeof HomeSettingsCloudSyncRoute
   '/party/$partyId/add': typeof PartyPartyIdAddRoute
   '/party/$partyId/share': typeof PartyPartyIdShareRoute
   '/party/$partyId/stats': typeof PartyPartyIdStatsRoute
@@ -197,7 +202,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
-  '/': typeof IndexRouteRoute
+  '/_home': typeof HomeRouteRouteWithChildren
   '/about': typeof AboutRouteRoute
   '/new': typeof NewRouteRoute
   '/support': typeof SupportRouteRoute
@@ -209,10 +214,11 @@ export interface FileRoutesById {
   '/migrate_/tricount': typeof MigrateTricountRouteRoute
   '/party/$partyId': typeof PartyPartyIdRouteRoute
   '/about_/third-party-licenses': typeof AboutThirdPartyLicensesRoute
-  '/settings_/cloud-sync': typeof SettingsCloudSyncRoute
+  '/_home/': typeof HomeIndexRoute
   '/party_/$partyId/pay': typeof PartyPartyIdPayRouteRoute
   '/party_/$partyId/settings': typeof PartyPartyIdSettingsRouteRoute
   '/party_/$partyId/transfer-debt': typeof PartyPartyIdTransferDebtRouteRoute
+  '/_home/settings_/cloud-sync': typeof HomeSettingsCloudSyncRoute
   '/party_/$partyId/add': typeof PartyPartyIdAddRoute
   '/party_/$partyId/share': typeof PartyPartyIdShareRoute
   '/party_/$partyId/stats': typeof PartyPartyIdStatsRoute
@@ -235,10 +241,10 @@ export interface FileRouteTypes {
     | '/migrate/tricount'
     | '/party/$partyId'
     | '/about/third-party-licenses'
-    | '/settings/cloud-sync'
     | '/party/$partyId/pay'
     | '/party/$partyId/settings'
     | '/party/$partyId/transfer-debt'
+    | '/settings/cloud-sync'
     | '/party/$partyId/add'
     | '/party/$partyId/share'
     | '/party/$partyId/stats'
@@ -247,7 +253,6 @@ export interface FileRouteTypes {
     | '/party/$partyId/expense/$expenseId/edit'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | '/'
     | '/about'
     | '/new'
     | '/support'
@@ -259,10 +264,11 @@ export interface FileRouteTypes {
     | '/migrate/tricount'
     | '/party/$partyId'
     | '/about/third-party-licenses'
-    | '/settings/cloud-sync'
+    | '/'
     | '/party/$partyId/pay'
     | '/party/$partyId/settings'
     | '/party/$partyId/transfer-debt'
+    | '/settings/cloud-sync'
     | '/party/$partyId/add'
     | '/party/$partyId/share'
     | '/party/$partyId/stats'
@@ -271,7 +277,7 @@ export interface FileRouteTypes {
     | '/party/$partyId/expense/$expenseId/edit'
   id:
     | '__root__'
-    | '/'
+    | '/_home'
     | '/about'
     | '/new'
     | '/support'
@@ -283,10 +289,11 @@ export interface FileRouteTypes {
     | '/migrate_/tricount'
     | '/party/$partyId'
     | '/about_/third-party-licenses'
-    | '/settings_/cloud-sync'
+    | '/_home/'
     | '/party_/$partyId/pay'
     | '/party_/$partyId/settings'
     | '/party_/$partyId/transfer-debt'
+    | '/_home/settings_/cloud-sync'
     | '/party_/$partyId/add'
     | '/party_/$partyId/share'
     | '/party_/$partyId/stats'
@@ -296,7 +303,7 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRouteRoute: typeof IndexRouteRoute
+  HomeRouteRoute: typeof HomeRouteRouteWithChildren
   AboutRouteRoute: typeof AboutRouteRoute
   NewRouteRoute: typeof NewRouteRoute
   SupportRouteRoute: typeof SupportRouteRoute
@@ -308,7 +315,6 @@ export interface RootRouteChildren {
   MigrateTricountRouteRoute: typeof MigrateTricountRouteRoute
   PartyPartyIdRouteRoute: typeof PartyPartyIdRouteRoute
   AboutThirdPartyLicensesRoute: typeof AboutThirdPartyLicensesRoute
-  SettingsCloudSyncRoute: typeof SettingsCloudSyncRoute
   PartyPartyIdPayRouteRoute: typeof PartyPartyIdPayRouteRoute
   PartyPartyIdSettingsRouteRoute: typeof PartyPartyIdSettingsRouteRoute
   PartyPartyIdTransferDebtRouteRoute: typeof PartyPartyIdTransferDebtRouteRoute
@@ -378,19 +384,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AboutRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
+    '/_home': {
+      id: '/_home'
       path: ''
       fullPath: '/'
-      preLoaderRoute: typeof IndexRouteRouteImport
+      preLoaderRoute: typeof HomeRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/settings_/cloud-sync': {
-      id: '/settings_/cloud-sync'
-      path: '/settings/cloud-sync'
-      fullPath: '/settings/cloud-sync'
-      preLoaderRoute: typeof SettingsCloudSyncRouteImport
-      parentRoute: typeof rootRouteImport
+    '/_home/': {
+      id: '/_home/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof HomeIndexRouteImport
+      parentRoute: typeof HomeRouteRoute
     }
     '/about_/third-party-licenses': {
       id: '/about_/third-party-licenses'
@@ -441,6 +447,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PartyPartyIdAddRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_home/settings_/cloud-sync': {
+      id: '/_home/settings_/cloud-sync'
+      path: '/settings/cloud-sync'
+      fullPath: '/settings/cloud-sync'
+      preLoaderRoute: typeof HomeSettingsCloudSyncRouteImport
+      parentRoute: typeof HomeRouteRoute
+    }
     '/party_/$partyId/transfer-debt': {
       id: '/party_/$partyId/transfer-debt'
       path: '/party/$partyId/transfer-debt'
@@ -479,8 +492,22 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface HomeRouteRouteChildren {
+  HomeIndexRoute: typeof HomeIndexRoute
+  HomeSettingsCloudSyncRoute: typeof HomeSettingsCloudSyncRoute
+}
+
+const HomeRouteRouteChildren: HomeRouteRouteChildren = {
+  HomeIndexRoute: HomeIndexRoute,
+  HomeSettingsCloudSyncRoute: HomeSettingsCloudSyncRoute,
+}
+
+const HomeRouteRouteWithChildren = HomeRouteRoute._addFileChildren(
+  HomeRouteRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
-  IndexRouteRoute: IndexRouteRoute,
+  HomeRouteRoute: HomeRouteRouteWithChildren,
   AboutRouteRoute: AboutRouteRoute,
   NewRouteRoute: NewRouteRoute,
   SupportRouteRoute: SupportRouteRoute,
@@ -492,7 +519,6 @@ const rootRouteChildren: RootRouteChildren = {
   MigrateTricountRouteRoute: MigrateTricountRouteRoute,
   PartyPartyIdRouteRoute: PartyPartyIdRouteRoute,
   AboutThirdPartyLicensesRoute: AboutThirdPartyLicensesRoute,
-  SettingsCloudSyncRoute: SettingsCloudSyncRoute,
   PartyPartyIdPayRouteRoute: PartyPartyIdPayRouteRoute,
   PartyPartyIdSettingsRouteRoute: PartyPartyIdSettingsRouteRoute,
   PartyPartyIdTransferDebtRouteRoute: PartyPartyIdTransferDebtRouteRoute,

--- a/packages/pwa/src/routes/_home/index.tsx
+++ b/packages/pwa/src/routes/_home/index.tsx
@@ -1,0 +1,46 @@
+import type { PartyList } from "#src/models/partyList.js";
+import { documentCache } from "#src/lib/automerge/suspense-hooks.js";
+import { isValidDocumentId } from "@automerge/automerge-repo/slim";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+let hasRedirectedThisSession = false;
+
+export const Route = createFileRoute("/_home/")({
+  beforeLoad: async ({ context }) => {
+    // Only redirect once per session (on app launch)
+    if (hasRedirectedThisSession) {
+      return;
+    }
+
+    const partyListId = localStorage.getItem("partyListId");
+    if (!partyListId || !isValidDocumentId(partyListId)) {
+      return;
+    }
+
+    const partyList = (await documentCache.readAsync(context.repo, partyListId)) as
+      | PartyList
+      | undefined;
+
+    if (!partyList) {
+      return;
+    }
+
+    const { openLastPartyOnLaunch, lastOpenedPartyId, parties } = partyList;
+
+    if (
+      openLastPartyOnLaunch &&
+      lastOpenedPartyId &&
+      isValidDocumentId(lastOpenedPartyId) &&
+      parties[lastOpenedPartyId] &&
+      partyList.archivedParties?.[lastOpenedPartyId] !== true
+    ) {
+      hasRedirectedThisSession = true;
+      throw redirect({
+        to: "/party/$partyId",
+        params: { partyId: lastOpenedPartyId },
+        search: { tab: "expenses" },
+        replace: true,
+      });
+    }
+  },
+});

--- a/packages/pwa/src/routes/_home/route.tsx
+++ b/packages/pwa/src/routes/_home/route.tsx
@@ -83,7 +83,10 @@ function Home() {
                   </span>
                 </MenuItem>
 
-                <MenuItem href={{ to: "/settings/cloud-sync" }}>
+                <MenuItem
+                  href={{ to: "/settings/cloud-sync" }}
+                  routerOptions={{ resetScroll: false }}
+                >
                   <Icon icon="lucide.cloud" width={20} height={20} className="mr-3" />
                   <span className="h-3.5 leading-none">
                     <Trans>trizum cloud</Trans>

--- a/packages/pwa/src/routes/_home/route.tsx
+++ b/packages/pwa/src/routes/_home/route.tsx
@@ -19,6 +19,7 @@ import { showUpdateResultFeedback } from "#src/lib/updateResultFeedback.ts";
 import { EmptyState } from "#src/routes/index/-components/EmptyState.js";
 import { NoActivePartiesCard } from "#src/routes/index/-components/NoActivePartiesCard.js";
 import { ProfileSetupCard } from "#src/routes/index/-components/ProfileSetupCard.js";
+import { authClient } from "#src/lib/auth-client.ts";
 
 export const Route = createFileRoute("/_home")({
   component: Home,
@@ -28,11 +29,13 @@ function Home() {
   const { partyList, setPartyArchived, setPartyPinned } = usePartyList();
   const { activePartyIds, activeCount, archivedCount } = usePartySections(partyList);
   const { update, isUpdateAvailable, isUpdating, checkForUpdate } = use(UpdateContext);
+  const session = authClient.useSession();
   const location = useLocation();
 
   const showPartyHub = activeCount > 0 || archivedCount > 0;
   const needsProfileSetup = !partyList.username || partyList.username.trim() === "";
   const hasCloudSyncChild = location.pathname === "/settings/cloud-sync";
+  const isSignedIn = Boolean(session.data?.user);
 
   return (
     <>
@@ -83,9 +86,18 @@ function Home() {
                   href={{ to: "/settings/cloud-sync" }}
                   routerOptions={{ resetScroll: false }}
                 >
-                  <Icon icon="lucide.cloud" width={20} height={20} className="mr-3" />
+                  <Icon
+                    icon={isSignedIn ? "lucide.cloud-cog" : "lucide.log-in"}
+                    width={20}
+                    height={20}
+                    className="mr-3"
+                  />
                   <span className="h-3.5 leading-none">
-                    <Trans>trizum cloud</Trans>
+                    {isSignedIn ? (
+                      <Trans>Manage trizum cloud</Trans>
+                    ) : (
+                      <Trans>Sign in to trizum cloud</Trans>
+                    )}
                   </span>
                 </MenuItem>
 

--- a/packages/pwa/src/routes/_home/route.tsx
+++ b/packages/pwa/src/routes/_home/route.tsx
@@ -1,15 +1,14 @@
-import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
-import type { PartyList } from "#src/models/partyList.js";
+import { Trans } from "@lingui/react/macro";
+import { createFileRoute, Outlet, useLocation } from "@tanstack/react-router";
 import type { Party } from "#src/models/party.js";
+import type { PartyList } from "#src/models/partyList.js";
 import { PartyListCard, type PartyListCardAction } from "#src/components/PartyListCard.tsx";
 import { getOrderedPartySections, isPartyPinned } from "#src/lib/partyListOrdering.ts";
 import { Icon } from "#src/ui/Icon.js";
 import { IconButton } from "#src/ui/IconButton.js";
 import { Menu, MenuItem } from "#src/ui/Menu.js";
 import { useRepo } from "#src/lib/automerge/useRepo.ts";
-import { isValidDocumentId } from "@automerge/automerge-repo/slim";
-import { createFileRoute, redirect } from "@tanstack/react-router";
 import { MenuTrigger, Popover } from "react-aria-components";
 import { usePartyList } from "#src/hooks/usePartyList.js";
 import { documentCache } from "#src/lib/automerge/suspense-hooks.js";
@@ -17,64 +16,31 @@ import { use } from "react";
 import { toast } from "sonner";
 import { UpdateContext } from "#src/components/UpdateContext.tsx";
 import { showUpdateResultFeedback } from "#src/lib/updateResultFeedback.ts";
-import { EmptyState } from "./-components/EmptyState.js";
-import { NoActivePartiesCard } from "./-components/NoActivePartiesCard.js";
-import { ProfileSetupCard } from "./-components/ProfileSetupCard.js";
+import { EmptyState } from "#src/routes/index/-components/EmptyState.js";
+import { NoActivePartiesCard } from "#src/routes/index/-components/NoActivePartiesCard.js";
+import { ProfileSetupCard } from "#src/routes/index/-components/ProfileSetupCard.js";
 
-let hasRedirectedThisSession = false;
-
-export const Route = createFileRoute("/")({
-  component: Index,
-  beforeLoad: async ({ context }) => {
-    // Only redirect once per session (on app launch)
-    if (hasRedirectedThisSession) {
-      return;
-    }
-
-    const partyListId = localStorage.getItem("partyListId");
-    if (!partyListId || !isValidDocumentId(partyListId)) {
-      return;
-    }
-
-    const partyList = (await documentCache.readAsync(context.repo, partyListId)) as
-      | PartyList
-      | undefined;
-
-    if (!partyList) {
-      return;
-    }
-
-    const { openLastPartyOnLaunch, lastOpenedPartyId, parties } = partyList;
-
-    if (
-      openLastPartyOnLaunch &&
-      lastOpenedPartyId &&
-      isValidDocumentId(lastOpenedPartyId) &&
-      parties[lastOpenedPartyId] &&
-      partyList.archivedParties?.[lastOpenedPartyId] !== true
-    ) {
-      hasRedirectedThisSession = true;
-      throw redirect({
-        to: "/party/$partyId",
-        params: { partyId: lastOpenedPartyId },
-        search: { tab: "expenses" },
-        replace: true,
-      });
-    }
-  },
+export const Route = createFileRoute("/_home")({
+  component: Home,
 });
 
-function Index() {
+function Home() {
   const { partyList, setPartyArchived, setPartyPinned } = usePartyList();
   const { activePartyIds, activeCount, archivedCount } = usePartySections(partyList);
   const { update, isUpdateAvailable, isUpdating, checkForUpdate } = use(UpdateContext);
+  const location = useLocation();
 
   const showPartyHub = activeCount > 0 || archivedCount > 0;
   const needsProfileSetup = !partyList.username || partyList.username.trim() === "";
+  const hasCloudSyncChild = location.pathname === "/settings/cloud-sync";
 
   return (
     <>
-      <div className="flex min-h-full flex-col">
+      <div
+        aria-hidden={hasCloudSyncChild || undefined}
+        inert={hasCloudSyncChild || undefined}
+        className="flex min-h-full flex-col"
+      >
         <div className="mt-safe container flex h-16 items-center pr-2">
           <h1 className="pl-4 text-2xl font-bold">trizum</h1>
 
@@ -110,33 +76,21 @@ function Index() {
 
             <Popover placement="bottom end">
               <Menu>
-                <MenuItem
-                  href={{
-                    to: "/settings",
-                  }}
-                >
+                <MenuItem href={{ to: "/settings" }}>
                   <Icon icon="lucide.settings" width={20} height={20} className="mr-3" />
                   <span className="h-3.5 leading-none">
                     <Trans>Settings</Trans>
                   </span>
                 </MenuItem>
 
-                <MenuItem
-                  href={{
-                    to: "/settings/cloud-sync",
-                  }}
-                >
+                <MenuItem href={{ to: "/settings/cloud-sync" }}>
                   <Icon icon="lucide.cloud" width={20} height={20} className="mr-3" />
                   <span className="h-3.5 leading-none">
                     <Trans>trizum cloud</Trans>
                   </span>
                 </MenuItem>
 
-                <MenuItem
-                  href={{
-                    to: "/archived",
-                  }}
-                >
+                <MenuItem href={{ to: "/archived" }}>
                   <Icon icon="lucide.folder-archive" width={20} height={20} className="mr-3" />
                   <span className="h-3.5 leading-none">
                     <Trans>Archived parties</Trans>
@@ -154,11 +108,7 @@ function Index() {
                   </span>
                 </MenuItem>
 
-                <MenuItem
-                  href={{
-                    to: "/about",
-                  }}
-                >
+                <MenuItem href={{ to: "/about" }}>
                   <Icon icon="lucide.info" width={20} height={20} className="mr-3" />
                   <span className="h-3.5 leading-none">
                     <Trans>About</Trans>
@@ -244,6 +194,7 @@ function Index() {
           <EmptyState />
         )}
       </div>
+      <Outlet />
     </>
   );
 }

--- a/packages/pwa/src/routes/_home/route.tsx
+++ b/packages/pwa/src/routes/_home/route.tsx
@@ -68,11 +68,7 @@ function Home() {
           ) : null}
 
           <MenuTrigger>
-            <IconButton
-              icon="lucide.circle-user-round"
-              aria-label={t`Profile and app menu`}
-              className="bg-accent-100 text-accent-700 dark:bg-accent-900 dark:text-accent-200"
-            />
+            <IconButton icon="lucide.ellipsis-vertical" aria-label={t`Profile and app menu`} />
 
             <Popover placement="bottom end">
               <Menu>

--- a/packages/pwa/src/routes/_home/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/_home/settings_.cloud-sync.tsx
@@ -73,6 +73,7 @@ interface CloudSyncRouteState {
   isPasswordLoginMode: boolean;
   isPasswordResetMode: boolean;
   isPasswordSignInEnabled: boolean;
+  isSignInSuccessAnimationComplete: boolean;
   isSignInSuccessVisible: boolean;
   magicLinkMessage: string | null;
   passwordResetMessage: string | null;
@@ -113,6 +114,7 @@ function createInitialCloudSyncRouteState({
     isPasswordLoginMode: false,
     isPasswordResetMode: false,
     isPasswordSignInEnabled: true,
+    isSignInSuccessAnimationComplete: false,
     isSignInSuccessVisible: auth === "success",
     magicLinkMessage: null,
     passwordResetMessage: null,
@@ -193,6 +195,7 @@ function cloudSyncRouteReducer(
       return {
         ...state,
         optimisticAuthUser: action.user ?? state.optimisticAuthUser,
+        isSignInSuccessAnimationComplete: false,
         isSignInSuccessVisible: true,
       };
     case "deleteAccountDialogOpened":
@@ -252,6 +255,7 @@ function useCloudSyncSettingsView() {
     isPasswordLoginMode,
     isPasswordResetMode,
     isPasswordSignInEnabled,
+    isSignInSuccessAnimationComplete,
     magicLinkMessage,
     passwordResetMessage,
     authPendingAction,
@@ -280,6 +284,7 @@ function useCloudSyncSettingsView() {
     activateCloudSyncOnDevice,
     clearCloudSyncState,
     hasPasswordAccount,
+    isAccountStateResolved,
     isCloudSyncSwitchOpen,
     linkedProviderIds,
     saveLinkedAccounts,
@@ -310,19 +315,34 @@ function useCloudSyncSettingsView() {
       dispatchRouteState({
         type: "patch",
         values: {
-          isSignInSuccessVisible: false,
+          isSignInSuccessAnimationComplete: true,
         },
       });
-
-      if (auth === "success") {
-        void navigate({ to: "/settings/cloud-sync", replace: true });
-      }
     }, SIGN_IN_SUCCESS_ANIMATION_MS);
 
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [auth, isSignInSuccessVisible, navigate, userId]);
+  }, [isSignInSuccessVisible, userId]);
+
+  useEffect(() => {
+    if (
+      !isSignInSuccessVisible ||
+      !isSignInSuccessAnimationComplete ||
+      !isAccountStateResolved ||
+      isCloudSyncSwitchOpen
+    ) {
+      return;
+    }
+
+    void navigate({ to: "/", replace: true });
+  }, [
+    isAccountStateResolved,
+    isCloudSyncSwitchOpen,
+    isSignInSuccessAnimationComplete,
+    isSignInSuccessVisible,
+    navigate,
+  ]);
 
   useEffect(() => {
     if (!isPasswordLoginMode) {
@@ -698,9 +718,6 @@ function useCloudSyncSettingsView() {
 
   function onCloudDataActivated(shouldDelay: boolean) {
     if (shouldDelay) {
-      window.setTimeout(() => {
-        void navigate({ to: "/", replace: true });
-      }, SIGN_IN_SUCCESS_ANIMATION_MS + SIGN_IN_SUCCESS_EXIT_ANIMATION_MS);
       return;
     }
 
@@ -809,6 +826,28 @@ function useCloudSyncSettingsView() {
           }}
         />
       </CloudSyncSignInDialog>
+    );
+  }
+
+  if (isSignInSuccessVisible) {
+    return (
+      <>
+        <AnimatePresence>
+          {!isSignInSuccessAnimationComplete ||
+          !isAccountStateResolved ||
+          !isCloudSyncSwitchOpen ? (
+            <SignInSuccessOverlay exitAnimationMs={SIGN_IN_SUCCESS_EXIT_ANIMATION_MS} />
+          ) : null}
+        </AnimatePresence>
+
+        <CloudSyncSwitchDialog
+          isOpen={isCloudSyncSwitchOpen}
+          onSignOut={onSignOut}
+          onUseCloudData={() => {
+            activateCloudSyncOnDevice();
+          }}
+        />
+      </>
     );
   }
 

--- a/packages/pwa/src/routes/_home/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/_home/settings_.cloud-sync.tsx
@@ -844,7 +844,7 @@ function useCloudSyncSettingsView() {
           isOpen={isCloudSyncSwitchOpen}
           onSignOut={onSignOut}
           onUseCloudData={() => {
-            activateCloudSyncOnDevice();
+            void activateCloudSyncOnDevice();
           }}
         />
       </>
@@ -973,7 +973,7 @@ function useCloudSyncSettingsView() {
         isOpen={isCloudSyncSwitchOpen}
         onSignOut={onSignOut}
         onUseCloudData={() => {
-          activateCloudSyncOnDevice();
+          void activateCloudSyncOnDevice();
         }}
       />
     </div>

--- a/packages/pwa/src/routes/_home/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/_home/settings_.cloud-sync.tsx
@@ -42,10 +42,9 @@ import {
 } from "#src/lib/cloudSyncRouteState.ts";
 import { useCloudSyncAccountState } from "#src/hooks/useCloudSyncAccountState.ts";
 import { usePartyList } from "#src/hooks/usePartyList.js";
-import { EmptyState } from "#src/routes/index/-components/EmptyState.tsx";
 import { closeRouteState } from "#src/lib/navigationHistory.ts";
 
-export const Route = createFileRoute("/settings_/cloud-sync")({
+export const Route = createFileRoute("/_home/settings_/cloud-sync")({
   validateSearch: (search: Record<string, unknown>): CloudSyncSearchParams => ({
     auth: search.auth === "success" ? "success" : undefined,
     error: typeof search.error === "string" ? search.error : undefined,
@@ -710,117 +709,111 @@ function useCloudSyncSettingsView() {
 
   if (!user) {
     return (
-      <div className="relative min-h-full">
-        <div aria-hidden="true" className="min-h-full blur-[2px]">
-          <CloudSyncHomeBackdrop />
-        </div>
-
-        <CloudSyncSignInDialog
-          isOpen={isSignInDialogOpen}
-          onOpenChange={closeSignInDialog}
-          showHeader={!magicLinkMessage && auth !== "success" && !isSignInSuccessVisible}
-        >
-          <CloudSyncSignInForm
-            authState={{
-              auth,
-              email: authEmail,
-              emailError: authEmailError,
-              error: authError,
-              magicLinkMessage,
-              password: authPassword,
-              passwordError: authPasswordError,
-              passwordResetMessage,
-              pendingAction: authPendingAction,
-            }}
-            mode={signInFormMode}
-            onAuthEmailChange={onAuthEmailChange}
-            onAuthPasswordChange={onAuthPasswordChange}
-            onBackToSignIn={() => {
-              dispatchRouteState({
-                type: "patch",
-                values: {
-                  authError: null,
-                  authEmailError: null,
-                  authPasswordError: null,
-                  isPasswordResetMode: false,
-                  magicLinkMessage: null,
-                  passwordResetMessage: null,
-                },
-              });
-            }}
-            onForgotPassword={() => {
-              dispatchRouteState({
-                type: "patch",
-                values: {
-                  authError: null,
-                  authEmailError: null,
-                  authPasswordError: null,
-                  isPasswordResetMode: true,
-                  magicLinkMessage: null,
-                  passwordResetMessage: null,
-                },
-              });
-            }}
-            onMagicLinkSubmit={onMagicLinkSubmit}
-            onPasswordResetSubmit={onPasswordResetSubmit}
-            onPasswordSignInSubmit={onPasswordSignInSubmit}
-            onSocialSignIn={(provider) => {
-              void onSocialSignIn(provider);
-            }}
-            onTryAnotherEmail={() => {
-              dispatchRouteState({
-                type: "patch",
-                values: {
-                  authError: null,
-                  authEmailError: null,
-                  authPasswordError: null,
-                  isPasswordLoginMode: false,
-                  magicLinkMessage: null,
-                  passwordResetMessage: null,
-                },
-              });
-            }}
-            onUseMagicLink={() => {
-              dispatchRouteState({
-                type: "patch",
-                values: {
-                  authError: null,
-                  authEmailError: null,
-                  authPasswordError: null,
-                  isPasswordLoginMode: false,
-                  isPasswordSignInEnabled: true,
-                  magicLinkMessage: null,
-                  passwordResetMessage: null,
-                },
-              });
-            }}
-            onUsePassword={() => {
-              dispatchRouteState({
-                type: "patch",
-                values: {
-                  authError: null,
-                  authEmailError: null,
-                  authPasswordError: null,
-                  isPasswordLoginMode: true,
-                  isPasswordSignInEnabled: false,
-                  magicLinkMessage: null,
-                  passwordResetMessage: null,
-                },
-              });
-            }}
-            status={{
-              isPending: isAuthPending,
-              isPasswordSignInEnabled,
-              isSignInSuccessVisible,
-            }}
-          />
-        </CloudSyncSignInDialog>
-      </div>
+      <CloudSyncSignInDialog
+        isOpen={isSignInDialogOpen}
+        onOpenChange={closeSignInDialog}
+        showHeader={!magicLinkMessage && auth !== "success" && !isSignInSuccessVisible}
+      >
+        <CloudSyncSignInForm
+          authState={{
+            auth,
+            email: authEmail,
+            emailError: authEmailError,
+            error: authError,
+            magicLinkMessage,
+            password: authPassword,
+            passwordError: authPasswordError,
+            passwordResetMessage,
+            pendingAction: authPendingAction,
+          }}
+          mode={signInFormMode}
+          onAuthEmailChange={onAuthEmailChange}
+          onAuthPasswordChange={onAuthPasswordChange}
+          onBackToSignIn={() => {
+            dispatchRouteState({
+              type: "patch",
+              values: {
+                authError: null,
+                authEmailError: null,
+                authPasswordError: null,
+                isPasswordResetMode: false,
+                magicLinkMessage: null,
+                passwordResetMessage: null,
+              },
+            });
+          }}
+          onForgotPassword={() => {
+            dispatchRouteState({
+              type: "patch",
+              values: {
+                authError: null,
+                authEmailError: null,
+                authPasswordError: null,
+                isPasswordResetMode: true,
+                magicLinkMessage: null,
+                passwordResetMessage: null,
+              },
+            });
+          }}
+          onMagicLinkSubmit={onMagicLinkSubmit}
+          onPasswordResetSubmit={onPasswordResetSubmit}
+          onPasswordSignInSubmit={onPasswordSignInSubmit}
+          onSocialSignIn={(provider) => {
+            void onSocialSignIn(provider);
+          }}
+          onTryAnotherEmail={() => {
+            dispatchRouteState({
+              type: "patch",
+              values: {
+                authError: null,
+                authEmailError: null,
+                authPasswordError: null,
+                isPasswordLoginMode: false,
+                magicLinkMessage: null,
+                passwordResetMessage: null,
+              },
+            });
+          }}
+          onUseMagicLink={() => {
+            dispatchRouteState({
+              type: "patch",
+              values: {
+                authError: null,
+                authEmailError: null,
+                authPasswordError: null,
+                isPasswordLoginMode: false,
+                isPasswordSignInEnabled: true,
+                magicLinkMessage: null,
+                passwordResetMessage: null,
+              },
+            });
+          }}
+          onUsePassword={() => {
+            dispatchRouteState({
+              type: "patch",
+              values: {
+                authError: null,
+                authEmailError: null,
+                authPasswordError: null,
+                isPasswordLoginMode: true,
+                isPasswordSignInEnabled: false,
+                magicLinkMessage: null,
+                passwordResetMessage: null,
+              },
+            });
+          }}
+          status={{
+            isPending: isAuthPending,
+            isPasswordSignInEnabled,
+            isSignInSuccessVisible,
+          }}
+        />
+      </CloudSyncSignInDialog>
     );
   }
 
   return (
-    <div className="flex min-h-full flex-col">
+    <div className="bg-accent-50 dark:bg-accent-950 fixed inset-0 z-40 flex min-h-full flex-col overflow-y-auto">
       <div className="mt-safe container flex h-16 items-center px-2">
         <BackButton fallbackOptions={{ to: "/" }} />
 
@@ -944,24 +937,6 @@ function useCloudSyncSettingsView() {
           activateCloudSyncOnDevice();
         }}
       />
-    </div>
-  );
-}
-
-function CloudSyncHomeBackdrop() {
-  return (
-    <div className="flex min-h-full flex-col">
-      <div className="mt-safe container flex h-16 items-center px-4">
-        <h1 className="text-2xl font-bold">trizum</h1>
-        <span
-          aria-label="Beta"
-          className="text-accent-600 dark:text-accent-400 mb-4 ml-0.5 font-mono text-xs leading-none font-semibold"
-        >
-          βeta
-        </span>
-      </div>
-      <div className="h-2" />
-      <EmptyState />
     </div>
   );
 }

--- a/packages/pwa/src/routes/index/-components/EmptyState.tsx
+++ b/packages/pwa/src/routes/index/-components/EmptyState.tsx
@@ -40,6 +40,7 @@ export function EmptyState() {
 
         <Link
           href={{ to: "/settings/cloud-sync" }}
+          routerOptions={{ resetScroll: false }}
           className={({ isPressed, isFocusVisible, isHovered, defaultClassName }) =>
             cn(
               defaultClassName,

--- a/packages/pwa/src/routes/index/-components/EmptyState.tsx
+++ b/packages/pwa/src/routes/index/-components/EmptyState.tsx
@@ -9,27 +9,27 @@ export function EmptyState() {
   const isSignedIn = Boolean(session.data?.user);
 
   return (
-    <main className="pb-safe-offset-8 container flex flex-1 flex-col items-center px-4">
-      <div className="flex w-full max-w-md flex-1 flex-col items-center justify-center gap-6">
+    <main className="pb-safe-offset-8 container flex flex-1 flex-col items-center px-4 [@media(max-height:600px)]:pb-0! [@media(max-height:720px)]:pb-2">
+      <div className="flex w-full max-w-md flex-1 flex-col items-center justify-center gap-6 [@media(max-height:600px)]:gap-2! [@media(max-height:720px)]:gap-3">
         <Icon
           icon="illustration.shared-expenses"
-          className="text-accent-600 dark:text-accent-400 h-auto w-full max-w-72 [--shared-expenses-surface:var(--color-accent-100)] dark:[--shared-expenses-surface:var(--color-accent-950)]"
+          className="text-accent-600 dark:text-accent-400 h-auto w-full max-w-72 [--shared-expenses-surface:var(--color-accent-100)] dark:[--shared-expenses-surface:var(--color-accent-950)] [@media(max-height:600px)]:max-w-40! [@media(max-height:720px)]:max-w-48"
           width={620}
           height={560}
         />
 
-        <div className="flex flex-col items-center gap-3 text-center">
-          <h2 className="text-3xl font-bold tracking-tight">
+        <div className="flex flex-col items-center gap-3 text-center [@media(max-height:720px)]:gap-2">
+          <h2 className="text-3xl font-bold tracking-tight [@media(max-height:720px)]:text-2xl">
             <Trans>Split expenses, stay even.</Trans>
           </h2>
-          <p className="text-accent-700 dark:text-accent-300 max-w-sm text-base leading-relaxed">
+          <p className="text-accent-700 dark:text-accent-300 max-w-sm text-base leading-relaxed [@media(max-height:600px)]:hidden [@media(max-height:720px)]:text-sm [@media(max-height:720px)]:leading-snug">
             <Trans>
               Create a party in seconds, track who paid, and settle up without the awkward maths.
             </Trans>
           </p>
         </div>
 
-        <div className="flex w-full flex-col gap-3">
+        <div className="flex w-full flex-col gap-3 [@media(max-height:720px)]:gap-2">
           <ActionLink href={{ to: "/new" }} icon="lucide.list-plus" color="accent">
             <Trans>Create a Party</Trans>
           </ActionLink>
@@ -44,14 +44,14 @@ export function EmptyState() {
           className={({ isPressed, isFocusVisible, isHovered, defaultClassName }) =>
             cn(
               defaultClassName,
-              "border-accent-200 bg-accent-100/60 dark:border-accent-800 dark:bg-accent-900 flex w-full scale-100 items-center gap-3 rounded-2xl border p-4 text-start outline-hidden transition-all duration-200",
+              "border-accent-200 bg-accent-100/60 dark:border-accent-800 dark:bg-accent-900 flex w-full scale-100 items-center gap-3 rounded-2xl border p-4 text-start outline-hidden transition-all duration-200 [@media(max-height:720px)]:gap-2 [@media(max-height:720px)]:p-3 [@media(max-height:600px)]:p-2!",
               (isHovered || isFocusVisible) &&
                 "border-accent-400 bg-accent-100 dark:border-accent-600 dark:bg-accent-800",
               isPressed && "scale-[0.98]",
             )
           }
         >
-          <span className="bg-accent-200 text-accent-700 dark:bg-accent-800 dark:text-accent-200 flex size-11 shrink-0 items-center justify-center rounded-full">
+          <span className="bg-accent-200 text-accent-700 dark:bg-accent-800 dark:text-accent-200 flex size-11 shrink-0 items-center justify-center rounded-full [@media(max-height:720px)]:size-10">
             <Icon
               icon={isSignedIn ? "lucide.cloud-check" : "lucide.cloud"}
               width={22}
@@ -62,7 +62,7 @@ export function EmptyState() {
             <span className="font-semibold">
               <Trans>Keep every party in sync</Trans>
             </span>
-            <span className="text-accent-700 dark:text-accent-300 text-sm leading-snug">
+            <span className="text-accent-700 dark:text-accent-300 text-sm leading-snug [@media(max-height:600px)]:hidden">
               {isSignedIn ? (
                 <Trans>Manage your cloud account and synced data.</Trans>
               ) : (

--- a/packages/pwa/src/routes/index/-components/EmptyState.tsx
+++ b/packages/pwa/src/routes/index/-components/EmptyState.tsx
@@ -13,9 +13,9 @@ export function EmptyState() {
       <div className="flex w-full max-w-md flex-1 flex-col items-center justify-center gap-6">
         <Icon
           icon="illustration.shared-expenses"
-          className="text-accent-600 dark:text-accent-400 h-auto w-full max-w-80"
-          width={360}
-          height={260}
+          className="text-accent-600 dark:text-accent-400 h-auto w-full max-w-72 [--shared-expenses-surface:var(--color-accent-100)] dark:[--shared-expenses-surface:var(--color-accent-950)]"
+          width={620}
+          height={560}
         />
 
         <div className="flex flex-col items-center gap-3 text-center">

--- a/packages/pwa/src/routes/index/-components/EmptyState.tsx
+++ b/packages/pwa/src/routes/index/-components/EmptyState.tsx
@@ -1,63 +1,108 @@
 import { Trans } from "@lingui/react/macro";
 import { Link } from "react-aria-components";
+import { authClient } from "#src/lib/auth-client.ts";
 import { Icon } from "#src/ui/Icon.js";
 import { cn } from "#src/ui/utils.js";
 
 export function EmptyState() {
-  return (
-    <div className="container flex flex-1 flex-col items-center justify-center gap-8 px-4">
-      <div className="flex max-w-md flex-col items-center gap-4 text-center">
-        <h1 className="text-3xl font-bold">
-          <Trans>Welcome to trizum</Trans>
-        </h1>
-        <p className="text-accent-700 dark:text-accent-300 text-lg">
-          <Trans>
-            Split bills with friends and family. Track expenses, calculate balances, and settle up
-            together.
-          </Trans>
-        </p>
-      </div>
+  const session = authClient.useSession();
+  const isSignedIn = Boolean(session.data?.user);
 
-      <div className="flex w-full max-w-md flex-col gap-4">
-        <EmptyStateLink
-          href={{ to: "/new" }}
-          icon="lucide.list-plus"
-          title={<Trans>Create a new Party</Trans>}
-          description={<Trans>Start tracking expenses with your group</Trans>}
+  return (
+    <main className="pb-safe-offset-8 container flex flex-1 flex-col items-center px-4">
+      <div className="flex w-full max-w-md flex-1 flex-col items-center justify-center gap-6">
+        <Icon
+          icon="illustration.shared-expenses"
+          className="text-accent-500 dark:text-accent-400 h-auto w-full max-w-72"
+          width={320}
+          height={220}
         />
-        <EmptyStateLink
-          href={{ to: "/join" }}
-          icon="lucide.ampersand"
-          title={<Trans>Join a Party</Trans>}
-          description={<Trans>Enter a party link or code to join</Trans>}
-        />
-        <EmptyStateLink
+
+        <div className="flex flex-col items-center gap-3 text-center">
+          <h2 className="text-3xl font-bold tracking-tight">
+            <Trans>Split expenses, stay even.</Trans>
+          </h2>
+          <p className="text-accent-700 dark:text-accent-300 max-w-sm text-base leading-relaxed">
+            <Trans>
+              Create a party in seconds, track who paid, and settle up without the awkward maths.
+            </Trans>
+          </p>
+        </div>
+
+        <div className="flex w-full flex-col gap-3">
+          <ActionLink href={{ to: "/new" }} icon="lucide.list-plus" color="accent">
+            <Trans>Create a Party</Trans>
+          </ActionLink>
+          <ActionLink href={{ to: "/join" }} icon="lucide.ampersand">
+            <Trans>Join with a code</Trans>
+          </ActionLink>
+        </div>
+
+        <Link
+          href={{ to: "/settings/cloud-sync" }}
+          className={({ isPressed, isFocusVisible, isHovered, defaultClassName }) =>
+            cn(
+              defaultClassName,
+              "border-accent-200 bg-accent-100/60 dark:border-accent-800 dark:bg-accent-900 flex w-full scale-100 items-center gap-3 rounded-2xl border p-4 text-start outline-hidden transition-all duration-200",
+              (isHovered || isFocusVisible) &&
+                "border-accent-400 bg-accent-100 dark:border-accent-600 dark:bg-accent-800",
+              isPressed && "scale-[0.98]",
+            )
+          }
+        >
+          <span className="bg-accent-200 text-accent-700 dark:bg-accent-800 dark:text-accent-200 flex size-11 shrink-0 items-center justify-center rounded-full">
+            <Icon
+              icon={isSignedIn ? "lucide.cloud-check" : "lucide.cloud"}
+              width={22}
+              height={22}
+            />
+          </span>
+          <span className="flex min-w-0 flex-1 flex-col gap-1">
+            <span className="font-semibold">
+              <Trans>Keep every party in sync</Trans>
+            </span>
+            <span className="text-accent-700 dark:text-accent-300 text-sm leading-snug">
+              {isSignedIn ? (
+                <Trans>Manage your cloud account and synced data.</Trans>
+              ) : (
+                <Trans>Securely access your data on all your devices.</Trans>
+              )}
+            </span>
+          </span>
+          <span className="border-accent-400 text-accent-700 dark:border-accent-600 dark:text-accent-300 shrink-0 rounded-full border px-3 py-1.5 text-sm font-semibold">
+            {isSignedIn ? <Trans>Manage</Trans> : <Trans>Sign in</Trans>}
+          </span>
+        </Link>
+
+        <Link
           href={{ to: "/migrate/tricount" }}
-          icon="lucide.import"
-          title={<Trans>Migrate from Tricount</Trans>}
-          description={<Trans>Import your existing Tricount data</Trans>}
-        />
-        <EmptyStateLink
-          href={{ to: "/settings" }}
-          icon="lucide.user"
-          title={<Trans>Configure Profile</Trans>}
-          description={<Trans>Set up your username, avatar, and preferences</Trans>}
-        />
+          className={({ isPressed, isFocusVisible, isHovered, defaultClassName }) =>
+            cn(
+              defaultClassName,
+              "text-accent-700 dark:text-accent-300 flex scale-100 items-center gap-2 rounded-full px-4 py-2 text-sm font-medium outline-hidden transition-all",
+              (isHovered || isFocusVisible) && "bg-accent-950/5 dark:bg-accent-50/5",
+              isPressed && "scale-95",
+            )
+          }
+        >
+          <Icon icon="lucide.import" width={18} height={18} />
+          <Trans>Import from Tricount</Trans>
+        </Link>
       </div>
-    </div>
+    </main>
   );
 }
 
-function EmptyStateLink({
+function ActionLink({
   href,
   icon,
-  title,
-  description,
+  color = "input-like",
+  children,
 }: {
   href: React.ComponentProps<typeof Link>["href"];
   icon: React.ComponentProps<typeof Icon>["icon"];
-  title: React.ReactNode;
-  description: React.ReactNode;
+  color?: "accent" | "input-like";
+  children: React.ReactNode;
 }) {
   return (
     <Link
@@ -65,18 +110,20 @@ function EmptyStateLink({
       className={({ isPressed, isFocusVisible, isHovered, defaultClassName }) =>
         cn(
           defaultClassName,
-          "flex scale-100 items-start gap-4 rounded-xl border border-accent-200 bg-white p-4 text-start outline-hidden transition-all duration-200 ease-in-out dark:border-accent-800 dark:bg-accent-900",
+          "flex h-12 w-full scale-100 items-center justify-center gap-2 rounded-full border font-semibold outline-hidden transition-all duration-200",
+          color === "accent"
+            ? "border-accent-500 bg-accent-500 text-accent-50"
+            : "border-accent-500 bg-white dark:border-accent-700 dark:bg-accent-900",
           (isHovered || isFocusVisible) &&
-            "shadow-md dark:border-accent-700 dark:bg-accent-800 dark:shadow-none",
-          isPressed && "scale-95 bg-white/90 shadow-lg dark:bg-accent-700/90 dark:shadow-none",
+            (color === "accent"
+              ? "border-accent-600 bg-accent-600 dark:border-accent-400 dark:bg-accent-400"
+              : "ring-accent-500 dark:ring-accent-400 ring-2"),
+          isPressed && "scale-95",
         )
       }
     >
-      <Icon icon={icon} width={24} height={24} className="text-accent-600 dark:text-accent-400" />
-      <div className="flex flex-1 flex-col">
-        <span className="text-accent-950 dark:text-accent-50 text-lg font-semibold">{title}</span>
-        <span className="text-accent-600 dark:text-accent-400 text-sm">{description}</span>
-      </div>
+      <Icon icon={icon} width={20} height={20} />
+      {children}
     </Link>
   );
 }

--- a/packages/pwa/src/routes/index/-components/EmptyState.tsx
+++ b/packages/pwa/src/routes/index/-components/EmptyState.tsx
@@ -13,9 +13,9 @@ export function EmptyState() {
       <div className="flex w-full max-w-md flex-1 flex-col items-center justify-center gap-6">
         <Icon
           icon="illustration.shared-expenses"
-          className="text-accent-500 dark:text-accent-400 h-auto w-full max-w-72"
-          width={320}
-          height={220}
+          className="text-accent-600 dark:text-accent-400 h-auto w-full max-w-80"
+          width={360}
+          height={260}
         />
 
         <div className="flex flex-col items-center gap-3 text-center">

--- a/packages/pwa/src/routes/index/route.tsx
+++ b/packages/pwa/src/routes/index/route.tsx
@@ -102,7 +102,11 @@ function Index() {
           ) : null}
 
           <MenuTrigger>
-            <IconButton icon="lucide.ellipsis-vertical" aria-label={t`Menu`} />
+            <IconButton
+              icon="lucide.circle-user-round"
+              aria-label={t`Profile and app menu`}
+              className="bg-accent-100 text-accent-700 dark:bg-accent-900 dark:text-accent-200"
+            />
 
             <Popover placement="bottom end">
               <Menu>
@@ -114,6 +118,17 @@ function Index() {
                   <Icon icon="lucide.settings" width={20} height={20} className="mr-3" />
                   <span className="h-3.5 leading-none">
                     <Trans>Settings</Trans>
+                  </span>
+                </MenuItem>
+
+                <MenuItem
+                  href={{
+                    to: "/settings/cloud-sync",
+                  }}
+                >
+                  <Icon icon="lucide.cloud" width={20} height={20} className="mr-3" />
+                  <span className="h-3.5 leading-none">
+                    <Trans>trizum cloud</Trans>
                   </span>
                 </MenuItem>
 

--- a/packages/pwa/src/routes/settings.tsx
+++ b/packages/pwa/src/routes/settings.tsx
@@ -2,25 +2,15 @@ import { Trans } from "@lingui/react/macro";
 import { t } from "@lingui/core/macro";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Suspense, useEffect, useId, useReducer } from "react";
+import { Suspense, useId } from "react";
 import { toast } from "sonner";
 import { BackButton } from "#src/components/BackButton.js";
 import { AvatarPicker } from "#src/components/AvatarPicker.js";
 import { SwitchField } from "#src/components/SwitchField.tsx";
-import { authClient } from "#src/lib/auth-client.ts";
-import {
-  fetchCloudUserSettings,
-  readCachedCloudUserSettings,
-  readLastCachedCloudUserSettings,
-  writeCachedCloudUserSettings,
-  type CloudUserSettings,
-} from "#src/lib/cloudSyncSettings.ts";
 import { DEFAULT_LOCALE, type SupportedLocale } from "#src/lib/locales.js";
 import { validatePartyParticipantName, validatePhoneNumber } from "#src/lib/validation.js";
 import type { MediaFile } from "#src/models/media.ts";
-import { Button } from "#src/ui/Button.tsx";
 import { ColorSlider, ColorThumb, SliderTrack } from "#src/ui/Color.tsx";
-import { Icon } from "#src/ui/Icon.tsx";
 import { IconButton } from "#src/ui/IconButton.js";
 import { AppSelect, SelectItem } from "#src/ui/Select.tsx";
 import { Label } from "#src/ui/fields/Field.js";
@@ -48,71 +38,6 @@ interface LocaleOption {
   name: string;
 }
 
-type TrizumCloudStatus = "idle" | "loading" | "error";
-
-interface TrizumCloudState {
-  cloudSettings: CloudUserSettings | null;
-  hasCachedCloudSettings: boolean;
-  status: TrizumCloudStatus;
-}
-
-type TrizumCloudAction =
-  | { type: "sessionPending" }
-  | { type: "signedOut" }
-  | { type: "cachedSettingsLoaded"; settings: CloudUserSettings | null }
-  | { type: "cachedSettingsMissing" }
-  | { type: "fetchSucceeded"; settings: CloudUserSettings | null }
-  | { type: "fetchFailed" };
-
-function getInitialTrizumCloudState(): TrizumCloudState {
-  const cachedCloudSettings = readLastCachedCloudUserSettings();
-
-  return {
-    cloudSettings: cachedCloudSettings?.settings ?? null,
-    hasCachedCloudSettings: Boolean(cachedCloudSettings),
-    status: cachedCloudSettings ? "idle" : "loading",
-  };
-}
-
-function trizumCloudReducer(state: TrizumCloudState, action: TrizumCloudAction): TrizumCloudState {
-  switch (action.type) {
-    case "sessionPending":
-      return {
-        ...state,
-        status: state.hasCachedCloudSettings ? "idle" : "loading",
-      };
-    case "signedOut":
-      return {
-        cloudSettings: null,
-        hasCachedCloudSettings: false,
-        status: "idle",
-      };
-    case "cachedSettingsLoaded":
-      return {
-        cloudSettings: action.settings,
-        hasCachedCloudSettings: true,
-        status: "idle",
-      };
-    case "cachedSettingsMissing":
-      return {
-        cloudSettings: null,
-        hasCachedCloudSettings: false,
-        status: "loading",
-      };
-    case "fetchSucceeded":
-      return {
-        cloudSettings: action.settings,
-        hasCachedCloudSettings: true,
-        status: "idle",
-      };
-    case "fetchFailed":
-      return {
-        ...state,
-        status: state.hasCachedCloudSettings ? "idle" : "error",
-      };
-  }
-}
-
 function getLocaleOptions(): LocaleOption[] {
   return [
     { id: "system", name: t`System (fallbacks to ${DEFAULT_LOCALE})` },
@@ -124,57 +49,7 @@ function getLocaleOptions(): LocaleOption[] {
 export function Settings() {
   const { partyList, updateSettings } = usePartyList();
   const navigate = useNavigate();
-  const session = authClient.useSession();
-  const userId = session.data?.user?.id;
-  const isSessionPending = session.isPending;
-  const [trizumCloudState, dispatchTrizumCloud] = useReducer(
-    trizumCloudReducer,
-    undefined,
-    getInitialTrizumCloudState,
-  );
-  const { cloudSettings, hasCachedCloudSettings, status: trizumCloudStatus } = trizumCloudState;
   const localeOptions = getLocaleOptions();
-
-  useEffect(() => {
-    if (!userId) {
-      if (isSessionPending) {
-        dispatchTrizumCloud({ type: "sessionPending" });
-        return;
-      }
-
-      dispatchTrizumCloud({ type: "signedOut" });
-      return;
-    }
-
-    let isCancelled = false;
-    const cachedCloudSettings = readCachedCloudUserSettings(userId);
-
-    if (cachedCloudSettings) {
-      dispatchTrizumCloud({
-        type: "cachedSettingsLoaded",
-        settings: cachedCloudSettings.settings,
-      });
-    } else {
-      dispatchTrizumCloud({ type: "cachedSettingsMissing" });
-    }
-
-    void fetchCloudUserSettings()
-      .then(({ settings }) => {
-        if (!isCancelled) {
-          writeCachedCloudUserSettings(userId, settings);
-          dispatchTrizumCloud({ type: "fetchSucceeded", settings });
-        }
-      })
-      .catch(() => {
-        if (!isCancelled) {
-          dispatchTrizumCloud({ type: "fetchFailed" });
-        }
-      });
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [isSessionPending, userId]);
 
   function onSaveSettings(values: SettingsFormValues) {
     updateSettings({
@@ -207,15 +82,6 @@ export function Settings() {
   });
 
   const formId = useId();
-  const trizumCloudLabel = getTrizumCloudLabel({
-    cloudSettings,
-    currentPartyListId: partyList.id,
-    isSignedIn: Boolean(userId) || isSessionPending,
-    status: trizumCloudStatus,
-  });
-  const isTrizumCloudActive =
-    (Boolean(userId) || (isSessionPending && hasCachedCloudSettings)) &&
-    cloudSettings?.partyListDocumentId === partyList.id;
 
   return (
     <div className="flex min-h-full flex-col">
@@ -241,14 +107,6 @@ export function Settings() {
         }
       />
 
-      <CloudSyncSettingsButton
-        isActive={isTrizumCloudActive}
-        label={trizumCloudLabel}
-        onPress={() => {
-          void navigate({ to: "/settings/cloud-sync" });
-        }}
-      />
-
       <SettingsFormFields form={form} formId={formId} localeOptions={localeOptions} />
     </div>
   );
@@ -265,53 +123,6 @@ function SettingsHeader({ submitButton }: { submitButton: React.ReactNode }) {
 
       <div className="flex-1" />
       {submitButton}
-    </div>
-  );
-}
-
-function CloudSyncSettingsButton({
-  isActive,
-  label,
-  onPress,
-}: {
-  isActive: boolean;
-  label: string;
-  onPress: () => void;
-}) {
-  return (
-    <div className="container mt-4 px-4">
-      <Button
-        color="input-like"
-        className="relative h-auto min-h-16 justify-start rounded-lg px-4 py-3 text-left"
-        onPress={onPress}
-      >
-        <span className="flex w-full items-center gap-3">
-          <span className="bg-accent-100 text-accent-700 dark:bg-accent-800 dark:text-accent-50 relative flex size-9 shrink-0 items-center justify-center rounded-full">
-            {isActive ? (
-              <span
-                aria-hidden="true"
-                className="absolute -top-0.5 -right-0.5 flex size-3 items-center justify-center"
-              >
-                <span className="bg-accent-500/25 absolute size-3 animate-pulse rounded-full" />
-                <span className="bg-accent-500 dark:ring-accent-900 relative size-2 rounded-full ring-2 ring-white" />
-              </span>
-            ) : null}
-            <Icon
-              className="relative"
-              icon={isActive ? "lucide.cloud-check" : "lucide.cloud"}
-              width={20}
-              height={20}
-            />
-          </span>
-          <span className="flex min-w-0 flex-1 flex-col gap-1">
-            <span className="leading-none font-medium">
-              <Trans>trizum cloud</Trans>
-            </span>
-            <span className="text-accent-700 dark:text-accent-50 truncate text-sm">{label}</span>
-          </span>
-          <Icon icon="lucide.chevron-right" width={20} height={20} />
-        </span>
-      </Button>
     </div>
   );
 }
@@ -462,38 +273,4 @@ function SettingsFormFields({
       </form.Field>
     </form>
   );
-}
-
-function getTrizumCloudLabel({
-  cloudSettings,
-  currentPartyListId,
-  isSignedIn,
-  status,
-}: {
-  cloudSettings: CloudUserSettings | null;
-  currentPartyListId: string;
-  isSignedIn: boolean;
-  status: TrizumCloudStatus;
-}) {
-  if (!isSignedIn) {
-    return t`Not signed in`;
-  }
-
-  if (status === "loading") {
-    return t`Checking...`;
-  }
-
-  if (status === "error") {
-    return t`Could not load trizum cloud state`;
-  }
-
-  if (!cloudSettings) {
-    return t`Not set up`;
-  }
-
-  if (cloudSettings.partyListDocumentId === currentPartyListId) {
-    return t`Active on this device`;
-  }
-
-  return t`Ready on another device`;
 }

--- a/packages/pwa/src/routes/settings_.cloud-sync.tsx
+++ b/packages/pwa/src/routes/settings_.cloud-sync.tsx
@@ -42,7 +42,7 @@ import {
 } from "#src/lib/cloudSyncRouteState.ts";
 import { useCloudSyncAccountState } from "#src/hooks/useCloudSyncAccountState.ts";
 import { usePartyList } from "#src/hooks/usePartyList.js";
-import { Settings } from "#src/routes/settings.tsx";
+import { EmptyState } from "#src/routes/index/-components/EmptyState.tsx";
 import { closeRouteState } from "#src/lib/navigationHistory.ts";
 
 export const Route = createFileRoute("/settings_/cloud-sync")({
@@ -590,7 +590,7 @@ function useCloudSyncSettingsView() {
       clearCloudSyncState();
       await session.refetch();
       toast.success(t`Signed out`);
-      void navigate({ to: "/settings", replace: true });
+      void navigate({ to: "/", replace: true });
     } catch {
       toast.error(t`Could not sign out`);
     }
@@ -662,7 +662,7 @@ function useCloudSyncSettingsView() {
       });
       await session.refetch();
       toast.success(t`Account deleted`);
-      void navigate({ to: "/settings", replace: true });
+      void navigate({ to: "/", replace: true });
     } catch (error) {
       dispatchRouteState({
         type: "patch",
@@ -692,7 +692,7 @@ function useCloudSyncSettingsView() {
     });
     window.setTimeout(() => {
       closeRouteState(currentLocation, router.history, () => {
-        void navigate({ to: "/settings", replace: true });
+        void navigate({ to: "/", replace: true });
       });
     }, DIALOG_EXIT_ANIMATION_MS);
   }
@@ -712,7 +712,7 @@ function useCloudSyncSettingsView() {
     return (
       <div className="relative min-h-full">
         <div aria-hidden="true" className="min-h-full blur-[2px]">
-          <Settings />
+          <CloudSyncHomeBackdrop />
         </div>
 
         <CloudSyncSignInDialog
@@ -822,7 +822,7 @@ function useCloudSyncSettingsView() {
   return (
     <div className="flex min-h-full flex-col">
       <div className="mt-safe container flex h-16 items-center px-2">
-        <BackButton fallbackOptions={{ to: "/settings" }} />
+        <BackButton fallbackOptions={{ to: "/" }} />
 
         <h1 className="max-h-12 truncate px-4 text-xl font-medium">
           <Trans>trizum cloud</Trans>
@@ -944,6 +944,24 @@ function useCloudSyncSettingsView() {
           activateCloudSyncOnDevice();
         }}
       />
+    </div>
+  );
+}
+
+function CloudSyncHomeBackdrop() {
+  return (
+    <div className="flex min-h-full flex-col">
+      <div className="mt-safe container flex h-16 items-center px-4">
+        <h1 className="text-2xl font-bold">trizum</h1>
+        <span
+          aria-label="Beta"
+          className="text-accent-600 dark:text-accent-400 mb-4 ml-0.5 font-mono text-xs leading-none font-semibold"
+        >
+          βeta
+        </span>
+      </div>
+      <div className="h-2" />
+      <EmptyState />
     </div>
   );
 }


### PR DESCRIPTION
## Description

Redesigns the first-run home screen around the primary create and join actions, with a custom responsive SVG illustration traced on the approved concept's exact 620 × 560 coordinate system: four colored participants orbit a detailed shared-expense receipt with item amounts, a total, and a completion badge. Tricount import becomes a quieter tertiary action.

Moves trizum cloud discovery out of profile settings. Signed-out users can launch the existing sign-in dialog directly from the first-run screen, while the profile/app menu keeps cloud account management accessible after parties exist. The menu action uses a login icon and "Sign in to trizum cloud" while signed out, then switches to a cloud-management icon and "Manage trizum cloud" for signed-in users. Cloud sign-out, account deletion, and dialog dismissal now return to home.

Uses the original screen's vertical-ellipsis treatment for the Home app menu, avoiding a nested circular profile glyph while preserving the standard 40px icon-button target and existing focus/pressed feedback.

Implements `/settings/cloud-sync` as a child of a pathless Home route. Opening sign-in therefore keeps the real Home tree mounted beneath the modal instead of rendering a duplicate backdrop. The underlying Home is made inert while the dialog is open, a stable scrollbar gutter prevents modal scroll locking from shifting the layout, and both cloud entry points opt out of the router's default scroll reset.

Keeps successful Home-launched authentication on the Home-backed success surface while cloud state initializes, then replaces the child route directly with Home. The cloud account settings screen is never mounted during that transition; it remains available when an already-signed-in user opens it intentionally.

Preloads and awaits the selected cloud party-list document before publishing its active ID. The sign-in success surface therefore remains stable while uncached cloud data syncs, and same-tab consumers rebind only after the Automerge document is ready. Cross-tab storage changes do not invalidate a party route that was admitted by a different list.

Mounts Better Auth session maintenance for the full app lifetime instead of only on Home and cloud routes. Signed-in sessions refresh hourly while online, whenever the app regains focus, and after reconnecting, preventing regular use inside a party from allowing the seven-day session to expire.

Adds height-aware compact layouts for phones with limited vertical space. The illustration, typography, and spacing step down at short viewport heights; only supporting copy is hidden at the smallest size, so create, join, cloud sync, and import remain visible with their normal touch targets.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [x] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Reviewed locally in dark mode at 390 × 844, 375 × 667, and 320 × 568 mobile viewports after a direct reference comparison. The two compact viewports fit the full action set without page overflow. The modal transition was also captured at 1280 × 800; Home retains the exact same heading, illustration, and profile-button geometry before and after sign-in opens. The Cloudflare PR preview provides the interactive review surface.

## Additional Notes

- Keeps `/settings/cloud-sync` stable for existing OAuth and magic-link callbacks while making the route visually and behaviorally home-owned.
- The route regression test starts Home at a nonzero mobile scroll position, then verifies that the original heading DOM node, scroll position, and geometry remain unchanged after opening the modal.
- The password sign-in regression test observes every DOM mutation and verifies that cloud account settings never render between the success state and Home.
- The sign-in journey holds a distinct cloud party list outside the app repo, verifies the success state remains visible and the local list stays active while that document is unavailable, then releases it and pins its party to prove Home reads and writes target the cloud document.
- A second-tab regression changes the stored party-list ID while a party route is open and verifies membership remains tied to the list that admitted the route.
- The same sign-in journey verifies that the Home menu changes its icon and copy after authentication.
- An app-lifetime session regression test loads a party directly and verifies that returning focus still triggers a Better Auth session refresh.
- A responsive smoke test verifies that the empty state does not overflow at 375 × 667 or 320 × 568.
- The shared-expenses illustration is a repo-native SVG rendered through the existing icon sprite and colored with the dynamic `accent` scale.
- All 100 Playwright journeys pass in Chromium and WebKit.
- React Doctor reports 100/100 for the changed React code.
