### PR TITLE
fix(pwa): restore native safe area insets

### DIFF
--- a/.changeset/safe-viewports-fit.md
+++ b/.changeset/safe-viewports-fit.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Restore native safe-area spacing by enabling edge-to-edge viewport insets in mobile WebViews.

--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -2,7 +2,10 @@
 <html class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
     <title>trizum</title>
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/maskable.svg" sizes="any" type="image/svg+xml" />

--- a/packages/pwa/src/indexHtml.test.ts
+++ b/packages/pwa/src/indexHtml.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vite-plus/test";
+
+const indexHtml = readFileSync(new URL("../index.html", import.meta.url), "utf8");
+
+describe("index.html", () => {
+  it("lets native WebViews expose system-bar safe areas to CSS", () => {
+    expect(indexHtml).toContain("viewport-fit=cover");
+  });
+});


### PR DESCRIPTION
## Description

- Restore Android edge-to-edge safe-area insets by declaring `viewport-fit=cover` in the app viewport.
- Keep the setting in the production mobile bundle with a regression test.
- Add a patch changeset for the user-visible layout fix.

Capacitor Android 8.4 introduced a `SystemBars` inset handler that checks this viewport setting. Without it, Capacitor pads the WebView at the native layer and injects zero-valued `--safe-area-inset-*` variables, producing the system-bar gutters shown in the report. The previous mobile releases already used `capacitor-plugin-safe-area@5.0.0`, and the Tailwind v4 production build still emits the expected safe-area utilities.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

The before state is captured in the attached bug report. The after state requires the labeled Android internal-testing build because browser previews do not reproduce native system-bar inset handling.

## Additional Notes

- `vp run --filter @trizum/mobile check:android` passed, including clean Capacitor sync, Android lint/tests, debug APK assembly, and release AAB bundling.
- The draft PR is labeled `android:internal-testing` to generate the signed APK and AAB for device verification.
