### PR TITLE
fix(pwa): keep expense attachment gallery in sync

### DIFF
--- a/.changeset/fresh-expense-attachments.md
+++ b/.changeset/fresh-expense-attachments.md
@@ -2,4 +2,4 @@
 "@trizum/pwa": patch
 ---
 
-Show newly added expense attachments before saving, open the gallery on the selected attachment, keep gallery controls available while media loads, and prevent expired edit drafts from restoring discarded attachments.
+Show newly added expense attachments before saving, open the gallery on the selected attachment, keep gallery controls available while media loads, restore the backdrop after gesture dismissal, and prevent expired edit drafts from restoring discarded attachments.

--- a/.changeset/fresh-expense-attachments.md
+++ b/.changeset/fresh-expense-attachments.md
@@ -2,4 +2,4 @@
 "@trizum/pwa": patch
 ---
 
-Show newly added expense attachments before saving and open the gallery on the selected attachment.
+Show newly added expense attachments before saving, open the gallery on the selected attachment, and keep gallery controls available while media loads.

--- a/.changeset/fresh-expense-attachments.md
+++ b/.changeset/fresh-expense-attachments.md
@@ -2,4 +2,4 @@
 "@trizum/pwa": patch
 ---
 
-Show newly added expense attachments before saving, open the gallery on the selected attachment, and keep gallery controls available while media loads.
+Show newly added expense attachments before saving, open the gallery on the selected attachment, keep gallery controls available while media loads, and prevent expired edit drafts from restoring discarded attachments.

--- a/.changeset/fresh-expense-attachments.md
+++ b/.changeset/fresh-expense-attachments.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Show newly added expense attachments in the gallery before the edited expense is saved.

--- a/.changeset/fresh-expense-attachments.md
+++ b/.changeset/fresh-expense-attachments.md
@@ -2,4 +2,4 @@
 "@trizum/pwa": patch
 ---
 
-Show newly added expense attachments in the gallery before the edited expense is saved.
+Show newly added expense attachments before saving and open the gallery on the selected attachment.

--- a/packages/pwa/e2e/expense-log.spec.ts
+++ b/packages/pwa/e2e/expense-log.spec.ts
@@ -241,6 +241,57 @@ test.describe("Expense log", () => {
     await expect(page).not.toHaveURL(/[?&]media=/);
   });
 
+  test("restores the gallery backdrop after closing with a drag gesture", async ({
+    harness,
+    page,
+  }) => {
+    const partyPage = new PartyPage(page);
+    const expenseEditorPage = new ExpenseEditorPage(page);
+    const expenseDetailPage = new ExpenseDetailPage(page);
+    const title = "Cabin groceries";
+    const seededAmountText = formatAmountText(90);
+
+    const seededParty = await harness.joinSeededParty({
+      fixture: createImbalancedPartyFixture(),
+      participantName: defaultParticipants.blair.name,
+    });
+
+    await partyPage.openExpenseInLog(title);
+    await expenseDetailPage.expectLoaded(seededParty.partyId, title, seededAmountText);
+    await expenseDetailPage.openEdit();
+    await expenseEditorPage.expectEditLoaded(seededParty.partyId, title);
+
+    await page.locator('input[aria-label="Upload photo"]').setInputFiles("public/pwa-192x192.png");
+
+    const attachmentButton = page.getByRole("button", { name: "View photo" });
+    await attachmentButton.click();
+
+    const overlay = page.locator("[data-media-gallery-overlay]");
+    const image = page.locator("[data-media-gallery-image]");
+    await expect(overlay).toHaveCSS("background-color", "rgba(0, 0, 0, 0.25)");
+    await expect(image).toBeVisible();
+
+    const imageBox = await image.boundingBox();
+    if (!imageBox) {
+      throw new Error("Expected the gallery image to have a bounding box");
+    }
+
+    const centerX = imageBox.x + imageBox.width / 2;
+    const centerY = imageBox.y + imageBox.height / 2;
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.down();
+    await page.mouse.move(centerX, centerY + 200, { steps: 10 });
+    await page.mouse.up();
+
+    await expect(page).not.toHaveURL(/[?&]media=/);
+    await expect(overlay).toBeHidden();
+
+    await attachmentButton.click();
+
+    await expect(page).toHaveURL(/\?media=0$/);
+    await expect(overlay).toHaveCSS("background-color", "rgba(0, 0, 0, 0.25)");
+  });
+
   test("keeps expense draft values when validation fails", async ({ harness, page }) => {
     const partyPage = new PartyPage(page);
     const expenseEditorPage = new ExpenseEditorPage(page);

--- a/packages/pwa/e2e/expense-log.spec.ts
+++ b/packages/pwa/e2e/expense-log.spec.ts
@@ -268,6 +268,13 @@ test.describe("Expense log", () => {
 
     const overlay = page.locator("[data-media-gallery-overlay]");
     const image = page.locator("[data-media-gallery-image]");
+    const slowExitAnimation = await page.addStyleTag({
+      content: `
+        [data-media-gallery-overlay][data-exiting] {
+          animation-duration: 1s !important;
+        }
+      `,
+    });
     await expect(overlay).toHaveCSS("background-color", "rgba(0, 0, 0, 0.25)");
     await expect(image).toBeVisible();
 
@@ -284,7 +291,11 @@ test.describe("Expense log", () => {
     await page.mouse.up();
 
     await expect(page).not.toHaveURL(/[?&]media=/);
+    await expect(overlay).toHaveAttribute("data-exiting", "true");
+    await expect(overlay).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+
     await expect(overlay).toBeHidden();
+    await slowExitAnimation.evaluate((element) => element.parentNode?.removeChild(element));
 
     await attachmentButton.click();
 

--- a/packages/pwa/e2e/expense-log.spec.ts
+++ b/packages/pwa/e2e/expense-log.spec.ts
@@ -162,6 +162,35 @@ test.describe("Expense log", () => {
     await expenseDetailPage.expectLoaded(seededParty.partyId, title, seededAmountText);
   });
 
+  test("opens the selected attachment on the first gallery render", async ({ harness, page }) => {
+    const partyPage = new PartyPage(page);
+    const expenseEditorPage = new ExpenseEditorPage(page);
+    const expenseDetailPage = new ExpenseDetailPage(page);
+    const title = "Cabin groceries";
+    const seededAmountText = formatAmountText(90);
+
+    const seededParty = await harness.joinSeededParty({
+      fixture: createImbalancedPartyFixture(),
+      participantName: defaultParticipants.blair.name,
+    });
+
+    await partyPage.openExpenseInLog(title);
+    await expenseDetailPage.expectLoaded(seededParty.partyId, title, seededAmountText);
+    await expenseDetailPage.openEdit();
+    await expenseEditorPage.expectEditLoaded(seededParty.partyId, title);
+
+    await page
+      .locator('input[aria-label="Upload photo"]')
+      .setInputFiles(["public/pwa-64x64.png", "public/pwa-192x192.png"]);
+
+    const attachmentButtons = page.getByRole("button", { name: "View photo" });
+    await expect(attachmentButtons).toHaveCount(2);
+    await attachmentButtons.nth(1).click();
+
+    await expect(page).toHaveURL(/\?media=1$/);
+    await expect(page.locator("[data-media-gallery-image]")).toHaveJSProperty("naturalWidth", 192);
+  });
+
   test("keeps expense draft values when validation fails", async ({ harness, page }) => {
     const partyPage = new PartyPage(page);
     const expenseEditorPage = new ExpenseEditorPage(page);

--- a/packages/pwa/e2e/expense-log.spec.ts
+++ b/packages/pwa/e2e/expense-log.spec.ts
@@ -294,9 +294,14 @@ test.describe("Expense log", () => {
     await expect(overlay).toHaveAttribute("data-exiting", "true");
     await expect(overlay).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
 
-    await expect(overlay).toBeHidden();
+    await attachmentButton.evaluate((element) => (element as HTMLElement).click());
+
+    await expect(page).toHaveURL(/\?media=0$/);
+    await expect(overlay).toHaveCSS("background-color", "rgba(0, 0, 0, 0.25)");
     await slowExitAnimation.evaluate((element) => element.parentNode?.removeChild(element));
 
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(overlay).toBeHidden();
     await attachmentButton.click();
 
     await expect(page).toHaveURL(/\?media=0$/);

--- a/packages/pwa/e2e/expense-log.spec.ts
+++ b/packages/pwa/e2e/expense-log.spec.ts
@@ -191,6 +191,56 @@ test.describe("Expense log", () => {
     await expect(page.locator("[data-media-gallery-image]")).toHaveJSProperty("naturalWidth", 192);
   });
 
+  test("keeps gallery controls available while an attachment is loading", async ({
+    harness,
+    page,
+  }) => {
+    const partyPage = new PartyPage(page);
+    const expenseEditorPage = new ExpenseEditorPage(page);
+    const expenseDetailPage = new ExpenseDetailPage(page);
+    const title = "Cabin groceries";
+    const seededAmountText = formatAmountText(90);
+
+    const seededParty = await harness.joinSeededParty({
+      fixture: createImbalancedPartyFixture(),
+      participantName: defaultParticipants.blair.name,
+    });
+
+    await partyPage.openExpenseInLog(title);
+    await expenseDetailPage.expectLoaded(seededParty.partyId, title, seededAmountText);
+    await expenseDetailPage.openEdit();
+    await expenseEditorPage.expectEditLoaded(seededParty.partyId, title);
+
+    await page
+      .locator('input[aria-label="Upload photo"]')
+      .setInputFiles(["public/pwa-64x64.png", "public/pwa-192x192.png"]);
+    await expect(page.getByRole("button", { name: "View photo" })).toHaveCount(2);
+
+    await page.evaluate(() => {
+      window.Image = class PendingImage {
+        onerror: null = null;
+        onload: null = null;
+
+        set src(_src: string) {}
+      } as unknown as typeof Image;
+    });
+
+    await page.getByRole("button", { name: "View photo" }).nth(1).click();
+
+    await expect(page).toHaveURL(/\?media=1$/);
+    await expect(page.getByRole("button", { name: "Close" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Previous" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Next" })).toBeVisible();
+    await expect(page.locator("[data-media-gallery-image]")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Previous" }).click();
+    await expect(page).toHaveURL(/\?media=0$/);
+    await page.getByRole("button", { name: "Next" }).click();
+    await expect(page).toHaveURL(/\?media=1$/);
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(page).not.toHaveURL(/[?&]media=/);
+  });
+
   test("keeps expense draft values when validation fails", async ({ harness, page }) => {
     const partyPage = new PartyPage(page);
     const expenseEditorPage = new ExpenseEditorPage(page);

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -542,7 +542,7 @@ msgstr "Clear expression"
 msgid "Clear search"
 msgstr "Clear search"
 
-#: src/components/MediaGallery.tsx:241
+#: src/components/MediaGallery.tsx:252
 #: src/components/RouteQRScanner.tsx:60
 msgid "Close"
 msgstr "Close"
@@ -1697,7 +1697,7 @@ msgstr "New trizum"
 msgid "New Zealand Dollar"
 msgstr "New Zealand Dollar"
 
-#: src/components/MediaGallery.tsx:258
+#: src/components/MediaGallery.tsx:269
 msgid "Next"
 msgstr "Next"
 
@@ -2118,7 +2118,7 @@ msgstr "Point your camera at a trizum QR code"
 msgid "Polish Zloty"
 msgstr "Polish Zloty"
 
-#: src/components/MediaGallery.tsx:251
+#: src/components/MediaGallery.tsx:262
 msgid "Previous"
 msgstr "Previous"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -905,7 +905,7 @@ msgstr "Edit"
 msgid "Editing {0}"
 msgstr "Editing {0}"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:223
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:227
 msgid "Editing {expenseName}"
 msgstr "Editing {expenseName}"
 
@@ -1038,7 +1038,7 @@ msgstr "Expense amounts don't match total. Please check your split configuration
 msgid "Expense Split Mode"
 msgstr "Expense Split Mode"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:188
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:192
 msgid "Expense updated"
 msgstr "Expense updated"
 
@@ -1088,7 +1088,7 @@ msgstr "Failed to mark expense as paid"
 msgid "Failed to transfer debt"
 msgstr "Failed to transfer debt"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:193
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:197
 msgid "Failed to update expense"
 msgstr "Failed to update expense"
 
@@ -2911,7 +2911,7 @@ msgstr "Update password"
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 msgstr "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:157
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:161
 msgid "Updating expense..."
 msgstr "Updating expense..."
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -542,7 +542,7 @@ msgstr "Clear expression"
 msgid "Clear search"
 msgstr "Clear search"
 
-#: src/components/MediaGallery.tsx:243
+#: src/components/MediaGallery.tsx:244
 #: src/components/RouteQRScanner.tsx:60
 msgid "Close"
 msgstr "Close"
@@ -1697,7 +1697,7 @@ msgstr "New trizum"
 msgid "New Zealand Dollar"
 msgstr "New Zealand Dollar"
 
-#: src/components/MediaGallery.tsx:260
+#: src/components/MediaGallery.tsx:261
 msgid "Next"
 msgstr "Next"
 
@@ -2118,7 +2118,7 @@ msgstr "Point your camera at a trizum QR code"
 msgid "Polish Zloty"
 msgstr "Polish Zloty"
 
-#: src/components/MediaGallery.tsx:253
+#: src/components/MediaGallery.tsx:254
 msgid "Previous"
 msgstr "Previous"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -542,7 +542,7 @@ msgstr "Clear expression"
 msgid "Clear search"
 msgstr "Clear search"
 
-#: src/components/MediaGallery.tsx:244
+#: src/components/MediaGallery.tsx:241
 #: src/components/RouteQRScanner.tsx:60
 msgid "Close"
 msgstr "Close"
@@ -1697,7 +1697,7 @@ msgstr "New trizum"
 msgid "New Zealand Dollar"
 msgstr "New Zealand Dollar"
 
-#: src/components/MediaGallery.tsx:261
+#: src/components/MediaGallery.tsx:258
 msgid "Next"
 msgstr "Next"
 
@@ -2118,7 +2118,7 @@ msgstr "Point your camera at a trizum QR code"
 msgid "Polish Zloty"
 msgstr "Polish Zloty"
 
-#: src/components/MediaGallery.tsx:254
+#: src/components/MediaGallery.tsx:251
 msgid "Previous"
 msgstr "Previous"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -905,7 +905,7 @@ msgstr "Edit"
 msgid "Editing {0}"
 msgstr "Editing {0}"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:224
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:223
 msgid "Editing {expenseName}"
 msgstr "Editing {expenseName}"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -518,7 +518,7 @@ msgstr "Borrar expresión"
 msgid "Clear search"
 msgstr "Borrar búsqueda"
 
-#: src/components/MediaGallery.tsx:244
+#: src/components/MediaGallery.tsx:241
 #: src/components/RouteQRScanner.tsx:60
 msgid "Close"
 msgstr "Cerrar"
@@ -1645,7 +1645,7 @@ msgstr "Nuevo trizum"
 msgid "New Zealand Dollar"
 msgstr "Dólar Neozelandés"
 
-#: src/components/MediaGallery.tsx:261
+#: src/components/MediaGallery.tsx:258
 msgid "Next"
 msgstr "Siguiente"
 
@@ -2050,7 +2050,7 @@ msgstr "Apunta tu cámara a un código QR de trizum"
 msgid "Polish Zloty"
 msgstr "Zloty Polaco"
 
-#: src/components/MediaGallery.tsx:254
+#: src/components/MediaGallery.tsx:251
 msgid "Previous"
 msgstr "Anterior"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -877,7 +877,7 @@ msgstr "Editar"
 msgid "Editing {0}"
 msgstr "Editando {0}"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:224
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:223
 msgid "Editing {expenseName}"
 msgstr "Editando {expenseName}"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -518,7 +518,7 @@ msgstr "Borrar expresión"
 msgid "Clear search"
 msgstr "Borrar búsqueda"
 
-#: src/components/MediaGallery.tsx:241
+#: src/components/MediaGallery.tsx:252
 #: src/components/RouteQRScanner.tsx:60
 msgid "Close"
 msgstr "Cerrar"
@@ -1645,7 +1645,7 @@ msgstr "Nuevo trizum"
 msgid "New Zealand Dollar"
 msgstr "Dólar Neozelandés"
 
-#: src/components/MediaGallery.tsx:258
+#: src/components/MediaGallery.tsx:269
 msgid "Next"
 msgstr "Siguiente"
 
@@ -2050,7 +2050,7 @@ msgstr "Apunta tu cámara a un código QR de trizum"
 msgid "Polish Zloty"
 msgstr "Zloty Polaco"
 
-#: src/components/MediaGallery.tsx:251
+#: src/components/MediaGallery.tsx:262
 msgid "Previous"
 msgstr "Anterior"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -518,7 +518,7 @@ msgstr "Borrar expresión"
 msgid "Clear search"
 msgstr "Borrar búsqueda"
 
-#: src/components/MediaGallery.tsx:243
+#: src/components/MediaGallery.tsx:244
 #: src/components/RouteQRScanner.tsx:60
 msgid "Close"
 msgstr "Cerrar"
@@ -1645,7 +1645,7 @@ msgstr "Nuevo trizum"
 msgid "New Zealand Dollar"
 msgstr "Dólar Neozelandés"
 
-#: src/components/MediaGallery.tsx:260
+#: src/components/MediaGallery.tsx:261
 msgid "Next"
 msgstr "Siguiente"
 
@@ -2050,7 +2050,7 @@ msgstr "Apunta tu cámara a un código QR de trizum"
 msgid "Polish Zloty"
 msgstr "Zloty Polaco"
 
-#: src/components/MediaGallery.tsx:253
+#: src/components/MediaGallery.tsx:254
 msgid "Previous"
 msgstr "Anterior"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -877,7 +877,7 @@ msgstr "Editar"
 msgid "Editing {0}"
 msgstr "Editando {0}"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:223
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:227
 msgid "Editing {expenseName}"
 msgstr "Editando {expenseName}"
 
@@ -998,7 +998,7 @@ msgstr "Gasto añadido"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:188
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:192
 msgid "Expense updated"
 msgstr "Gasto actualizado"
 
@@ -1044,7 +1044,7 @@ msgstr "Error al marcar el gasto como pagado"
 msgid "Failed to transfer debt"
 msgstr "No se pudo transferir la deuda"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:193
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:197
 msgid "Failed to update expense"
 msgstr "Error al actualizar el gasto"
 
@@ -2823,7 +2823,7 @@ msgstr "Actualizar contraseña"
 msgid "Update who you are in this party so that we can show you the expenses and stats that matter to you."
 msgstr "Actualiza quién eres en este grupo para que podamos mostrarte los gastos y estadísticas que te importan."
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:157
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:161
 msgid "Updating expense..."
 msgstr "Actualizando gasto..."
 

--- a/packages/pwa/src/components/MediaGallery.tsx
+++ b/packages/pwa/src/components/MediaGallery.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/core/macro";
 import { cn, type ClassName } from "#src/ui/utils.ts";
-import { use, useEffect, useRef } from "react";
+import { Suspense, use, useEffect, useRef } from "react";
 import { useGesture } from "@use-gesture/react";
 import { LazyMotion, animate, domAnimation, m, useMotionValue } from "motion/react";
 import type { IconProps } from "#src/ui/Icon.tsx";
@@ -13,8 +13,7 @@ import { mediaGalleryItemLoader, type MediaGalleryItem } from "./mediaGalleryIte
 
 export type { MediaGalleryItem } from "./mediaGalleryItemLoader.ts";
 
-export interface MediaGalleryProps {
-  items: MediaGalleryItem[];
+interface MediaGalleryCommonProps {
   index: number;
   onChange: (index: number) => void;
   onClose: () => void;
@@ -22,18 +21,29 @@ export interface MediaGalleryProps {
   showCloseButton?: boolean;
 }
 
+export type MediaGalleryProps = MediaGalleryCommonProps &
+  (
+    | {
+        items: MediaGalleryItem[];
+        itemCount?: never;
+        renderItem?: never;
+      }
+    | {
+        getItemKey: (index: number) => React.Key;
+        items?: never;
+        itemCount: number;
+        renderItem: (index: number) => React.ReactNode;
+      }
+  );
+
 const CLOSE_THRESHOLD = 150;
 
-export default function MediaGallery({
-  items,
-  index,
-  onClose,
-  onChange,
-  onDragProgress,
-  showCloseButton = true,
-}: MediaGalleryProps) {
-  const currentItem = use(mediaGalleryItemLoader.read(items, index));
-  const maxIndex = items.length - 1;
+export default function MediaGallery(props: MediaGalleryProps) {
+  const { index, onClose, onChange, onDragProgress, showCloseButton = true } = props;
+  const itemCount = props.items !== undefined ? props.items.length : props.itemCount;
+  const currentItemKey =
+    props.items !== undefined ? props.items[index]?.src : props.getItemKey(index);
+  const maxIndex = itemCount - 1;
 
   function goToPrevious() {
     let nextIndex = index - 1;
@@ -57,7 +67,7 @@ export default function MediaGallery({
     onChange(nextIndex);
   }
 
-  const showNavigation = items.length > 1;
+  const showNavigation = itemCount > 1;
 
   const x = useMotionValue(0);
   const y = useMotionValue(0);
@@ -226,12 +236,13 @@ export default function MediaGallery({
         <div className="flex h-full w-full items-center justify-center select-none [-webkit-user-drag:_none]">
           <m.div ref={ref} className="relative" style={{ x, y, scale }}>
             <div className="absolute inset-0" />
-            <img
-              data-media-gallery-image=""
-              src={currentItem.src}
-              alt=""
-              className="pointer-events-none select-none [-webkit-user-drag:_none]"
-            />
+            <Suspense key={currentItemKey} fallback={null}>
+              {props.items ? (
+                <MediaGalleryImage items={props.items} index={index} />
+              ) : (
+                props.renderItem(index)
+              )}
+            </Suspense>
           </m.div>
         </div>
 
@@ -263,6 +274,19 @@ export default function MediaGallery({
         )}
       </div>
     </LazyMotion>
+  );
+}
+
+export function MediaGalleryImage({ items, index }: { items: MediaGalleryItem[]; index: number }) {
+  const item = use(mediaGalleryItemLoader.read(items, index));
+
+  return (
+    <img
+      data-media-gallery-image=""
+      src={item.src}
+      alt=""
+      className="pointer-events-none select-none [-webkit-user-drag:_none]"
+    />
   );
 }
 

--- a/packages/pwa/src/components/MediaGallery.tsx
+++ b/packages/pwa/src/components/MediaGallery.tsx
@@ -230,6 +230,7 @@ export default function MediaGallery({
           <m.div ref={ref} className="relative" style={{ x, y, scale }}>
             <div className="absolute inset-0" />
             <img
+              data-media-gallery-image=""
               src={currentItem.src}
               alt=""
               className="pointer-events-none select-none [-webkit-user-drag:_none]"

--- a/packages/pwa/src/components/MediaGallery.tsx
+++ b/packages/pwa/src/components/MediaGallery.tsx
@@ -9,10 +9,9 @@ import {
   calculateMediaGalleryPinchTransform,
   type MediaGalleryPoint,
 } from "./mediaGalleryPinch.ts";
+import { mediaGalleryItemLoader, type MediaGalleryItem } from "./mediaGalleryItemLoader.ts";
 
-export type MediaGalleryItem = {
-  src: string;
-};
+export type { MediaGalleryItem } from "./mediaGalleryItemLoader.ts";
 
 export interface MediaGalleryProps {
   items: MediaGalleryItem[];
@@ -33,8 +32,8 @@ export default function MediaGallery({
   onDragProgress,
   showCloseButton = true,
 }: MediaGalleryProps) {
-  const dataSource = useAsyncMediaGalleryItems(items);
-  const maxIndex = dataSource.length - 1;
+  const currentItem = use(mediaGalleryItemLoader.read(items, index));
+  const maxIndex = items.length - 1;
 
   function goToPrevious() {
     let nextIndex = index - 1;
@@ -59,8 +58,6 @@ export default function MediaGallery({
   }
 
   const showNavigation = items.length > 1;
-
-  const currentItem = dataSource[index];
 
   const x = useMotionValue(0);
   const y = useMotionValue(0);
@@ -285,44 +282,4 @@ function GalleryButton({ className, label, onClick, icon }: GalleryButtonProps) 
       icon={icon}
     />
   );
-}
-
-const itemCacheBySrc = new Map<string, MediaGalleryItem>();
-const itemPromiseCacheBySrc = new Map<string, Promise<MediaGalleryItem>>();
-
-function useAsyncMediaGalleryItems(items: MediaGalleryItem[]) {
-  return items.map((originalItem: MediaGalleryItem) => {
-    const { src } = originalItem;
-
-    const cachedItem = itemCacheBySrc.get(src);
-
-    if (cachedItem) {
-      return cachedItem;
-    }
-
-    if (itemPromiseCacheBySrc.has(src)) {
-      return use(itemPromiseCacheBySrc.get(src) as Promise<MediaGalleryItem>);
-    }
-
-    const promise = new Promise<MediaGalleryItem>((resolve, reject) => {
-      const image = new Image();
-      image.src = src;
-      image.onload = () => {
-        const completeItem = {
-          ...originalItem,
-          width: image.width,
-          height: image.height,
-        };
-
-        itemCacheBySrc.set(src, completeItem);
-        resolve(completeItem);
-      };
-      image.onerror = () => {
-        reject(new Error(`Failed to load image ${src}`));
-      };
-    });
-
-    itemPromiseCacheBySrc.set(src, promise);
-    return use(promise);
-  });
 }

--- a/packages/pwa/src/components/RouteMediaGallery.tsx
+++ b/packages/pwa/src/components/RouteMediaGallery.tsx
@@ -36,12 +36,18 @@ export function RouteMediaGallery({
     setDragProgress(progress);
   }
 
+  function handleClose() {
+    onClose();
+    setDragProgress(0);
+  }
+
   // Calculate background opacity and blur based on drag progress
   const backgroundOpacity = 0.25 * (1 - dragProgress);
   const backdropBlur = `blur(${(1 - dragProgress) * 8}px)`;
 
   return (
     <ModalOverlay
+      data-media-gallery-overlay=""
       isOpen={isOpen}
       className={({ isEntering, isExiting }) =>
         `fixed inset-0 isolate z-50 ${isEntering ? "animate-in fade-in duration-300 ease-out" : ""} ${isExiting ? "animate-out fade-out duration-200 ease-in" : ""} `
@@ -60,7 +66,7 @@ export function RouteMediaGallery({
             index={galleryIndex}
             renderItem={(index) => <RouteMediaGalleryImage photoId={photoIds[index]} />}
             onChange={onIndexChange}
-            onClose={onClose}
+            onClose={handleClose}
             onDragProgress={handleDragProgress}
           />
         )}

--- a/packages/pwa/src/components/RouteMediaGallery.tsx
+++ b/packages/pwa/src/components/RouteMediaGallery.tsx
@@ -1,8 +1,8 @@
 import { Modal, ModalOverlay } from "react-aria-components";
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { useMediaFileObjectUrls } from "#src/hooks/useMediaFile.ts";
-import MediaGallery, { type MediaGalleryItem } from "#src/components/MediaGallery.tsx";
-import { useMultipleSuspenseDocument } from "#src/lib/automerge/suspense-hooks.ts";
+import MediaGallery, { MediaGalleryImage } from "#src/components/MediaGallery.tsx";
+import { useSuspenseDocument } from "#src/lib/automerge/suspense-hooks.ts";
 import type { MediaFile } from "#src/models/media.ts";
 
 export interface RouteMediaGalleryProps {
@@ -54,53 +54,26 @@ export function RouteMediaGallery({
     >
       <Modal className="h-full w-full">
         {isOpen && selectedPhotoId && (
-          <Suspense key={`${galleryIndex}:${selectedPhotoId}`} fallback={null}>
-            <GalleryItemsResolver
-              photoIds={photoIds}
-              index={galleryIndex}
-              onChange={onIndexChange}
-              onClose={onClose}
-              onDragProgress={handleDragProgress}
-            />
-          </Suspense>
+          <MediaGallery
+            getItemKey={(index) => photoIds[index]}
+            itemCount={photoIds.length}
+            index={galleryIndex}
+            renderItem={(index) => <RouteMediaGalleryImage photoId={photoIds[index]} />}
+            onChange={onIndexChange}
+            onClose={onClose}
+            onDragProgress={handleDragProgress}
+          />
         )}
       </Modal>
     </ModalOverlay>
   );
 }
 
-interface GalleryItemsResolverProps {
-  photoIds: string[];
-  index: number;
-  onChange: (index: number) => void;
-  onClose: () => void;
-  onDragProgress: (progress: number) => void;
-}
+function RouteMediaGalleryImage({ photoId }: { photoId: string }) {
+  const [mediaFile] = useSuspenseDocument<MediaFile>(photoId as MediaFile["id"], {
+    required: true,
+  });
+  const [url] = useMediaFileObjectUrls([mediaFile]);
 
-// This component renders children for each photo to resolve URLs
-function GalleryItemsResolver({
-  photoIds,
-  index,
-  onChange,
-  onClose,
-  onDragProgress,
-}: GalleryItemsResolverProps) {
-  const mediaFileIds = photoIds as MediaFile["id"][];
-  const mediaFiles = useMultipleSuspenseDocument<MediaFile>(mediaFileIds, {
-    required: true as const,
-  }).map(({ doc }) => doc);
-  const urls = useMediaFileObjectUrls(mediaFiles);
-  const galleryItems: MediaGalleryItem[] = urls.map((url) => ({
-    src: url,
-  }));
-
-  return (
-    <MediaGallery
-      index={index}
-      items={galleryItems}
-      onChange={onChange}
-      onClose={onClose}
-      onDragProgress={onDragProgress}
-    />
-  );
+  return <MediaGalleryImage items={[{ src: url }]} index={0} />;
 }

--- a/packages/pwa/src/components/RouteMediaGallery.tsx
+++ b/packages/pwa/src/components/RouteMediaGallery.tsx
@@ -27,6 +27,7 @@ export function RouteMediaGallery({
   onClose,
 }: RouteMediaGalleryProps) {
   const isOpen = galleryIndex !== undefined && galleryIndex >= 0;
+  const selectedPhotoId = galleryIndex === undefined ? undefined : photoIds[galleryIndex];
 
   // Track drag progress for background opacity animation
   const [dragProgress, setDragProgress] = useState(0);
@@ -52,8 +53,8 @@ export function RouteMediaGallery({
       }}
     >
       <Modal className="h-full w-full">
-        {isOpen && photoIds.length > 0 && (
-          <Suspense fallback={null}>
+        {isOpen && selectedPhotoId && (
+          <Suspense key={`${galleryIndex}:${selectedPhotoId}`} fallback={null}>
             <GalleryItemsResolver
               photoIds={photoIds}
               index={galleryIndex}

--- a/packages/pwa/src/components/RouteMediaGallery.tsx
+++ b/packages/pwa/src/components/RouteMediaGallery.tsx
@@ -1,5 +1,5 @@
 import { Modal, ModalOverlay } from "react-aria-components";
-import { useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { useMediaFileObjectUrls } from "#src/hooks/useMediaFile.ts";
 import MediaGallery, { MediaGalleryImage } from "#src/components/MediaGallery.tsx";
 import { useSuspenseDocument } from "#src/lib/automerge/suspense-hooks.ts";
@@ -31,6 +31,28 @@ export function RouteMediaGallery({
 
   // Track drag progress for background opacity animation
   const [dragProgress, setDragProgress] = useState(0);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const overlay = overlayRef.current;
+
+    if (!overlay || isOpen) {
+      return;
+    }
+
+    function handleAnimationEnd(event: AnimationEvent) {
+      if (event.target === overlay) {
+        setDragProgress(0);
+      }
+    }
+
+    // Reset before React Aria handles the same event and unmounts the exiting overlay.
+    overlay.addEventListener("animationend", handleAnimationEnd, { capture: true });
+
+    return () => {
+      overlay.removeEventListener("animationend", handleAnimationEnd, { capture: true });
+    };
+  }, [isOpen]);
 
   function handleDragProgress(progress: number) {
     setDragProgress(progress);
@@ -38,7 +60,6 @@ export function RouteMediaGallery({
 
   function handleClose() {
     onClose();
-    setDragProgress(0);
   }
 
   // Calculate background opacity and blur based on drag progress
@@ -47,6 +68,7 @@ export function RouteMediaGallery({
 
   return (
     <ModalOverlay
+      ref={overlayRef}
       data-media-gallery-overlay=""
       isOpen={isOpen}
       className={({ isEntering, isExiting }) =>

--- a/packages/pwa/src/components/RouteMediaGallery.tsx
+++ b/packages/pwa/src/components/RouteMediaGallery.tsx
@@ -1,5 +1,5 @@
 import { Modal, ModalOverlay } from "react-aria-components";
-import { useLayoutEffect, useRef, useState } from "react";
+import { Suspense, useState } from "react";
 import { useMediaFileObjectUrls } from "#src/hooks/useMediaFile.ts";
 import MediaGallery, { MediaGalleryImage } from "#src/components/MediaGallery.tsx";
 import { useSuspenseDocument } from "#src/lib/automerge/suspense-hooks.ts";
@@ -31,35 +31,17 @@ export function RouteMediaGallery({
 
   // Track drag progress for background opacity animation
   const [dragProgress, setDragProgress] = useState(0);
-  const overlayRef = useRef<HTMLDivElement>(null);
+  const [wasOpen, setWasOpen] = useState(isOpen);
 
-  useLayoutEffect(() => {
-    const overlay = overlayRef.current;
-
-    if (!overlay || isOpen) {
-      return;
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen);
+    if (isOpen) {
+      setDragProgress(0);
     }
-
-    function handleAnimationEnd(event: AnimationEvent) {
-      if (event.target === overlay) {
-        setDragProgress(0);
-      }
-    }
-
-    // Reset before React Aria handles the same event and unmounts the exiting overlay.
-    overlay.addEventListener("animationend", handleAnimationEnd, { capture: true });
-
-    return () => {
-      overlay.removeEventListener("animationend", handleAnimationEnd, { capture: true });
-    };
-  }, [isOpen]);
+  }
 
   function handleDragProgress(progress: number) {
     setDragProgress(progress);
-  }
-
-  function handleClose() {
-    onClose();
   }
 
   // Calculate background opacity and blur based on drag progress
@@ -68,7 +50,6 @@ export function RouteMediaGallery({
 
   return (
     <ModalOverlay
-      ref={overlayRef}
       data-media-gallery-overlay=""
       isOpen={isOpen}
       className={({ isEntering, isExiting }) =>
@@ -88,7 +69,7 @@ export function RouteMediaGallery({
             index={galleryIndex}
             renderItem={(index) => <RouteMediaGalleryImage photoId={photoIds[index]} />}
             onChange={onIndexChange}
-            onClose={handleClose}
+            onClose={onClose}
             onDragProgress={handleDragProgress}
           />
         )}
@@ -103,5 +84,9 @@ function RouteMediaGalleryImage({ photoId }: { photoId: string }) {
   });
   const [url] = useMediaFileObjectUrls([mediaFile]);
 
-  return <MediaGalleryImage items={[{ src: url }]} index={0} />;
+  return (
+    <Suspense fallback={null}>
+      <MediaGalleryImage items={[{ src: url }]} index={0} />
+    </Suspense>
+  );
 }

--- a/packages/pwa/src/components/mediaGalleryItemLoader.test.ts
+++ b/packages/pwa/src/components/mediaGalleryItemLoader.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { createMediaGalleryItemLoader, type MediaGalleryItem } from "./mediaGalleryItemLoader.ts";
+
+describe("createMediaGalleryItemLoader", () => {
+  it("loads the selected item first without waiting for earlier items", async () => {
+    const resolveBySrc = new Map<string, (item: MediaGalleryItem) => void>();
+    const loadItem = vi.fn<(item: MediaGalleryItem) => Promise<MediaGalleryItem>>(
+      (item: MediaGalleryItem) =>
+        new Promise<MediaGalleryItem>((resolve) => {
+          resolveBySrc.set(item.src, resolve);
+        }),
+    );
+    const loader = createMediaGalleryItemLoader(loadItem);
+    const items = [{ src: "first" }, { src: "second" }, { src: "third" }];
+
+    const selectedItemPromise = loader.read(items, 1);
+
+    expect(loadItem.mock.calls.map(([item]) => item.src)).toEqual(["second", "first", "third"]);
+
+    resolveBySrc.get("second")?.(items[1]);
+
+    await expect(selectedItemPromise).resolves.toEqual(items[1]);
+  });
+});

--- a/packages/pwa/src/components/mediaGalleryItemLoader.ts
+++ b/packages/pwa/src/components/mediaGalleryItemLoader.ts
@@ -1,0 +1,64 @@
+export interface MediaGalleryItem {
+  src: string;
+}
+
+type LoadMediaGalleryItem = (item: MediaGalleryItem) => Promise<MediaGalleryItem>;
+
+export function createMediaGalleryItemLoader(loadItem: LoadMediaGalleryItem) {
+  const itemPromiseCacheBySrc = new Map<string, Promise<MediaGalleryItem>>();
+
+  function load(item: MediaGalleryItem) {
+    const cachedPromise = itemPromiseCacheBySrc.get(item.src);
+
+    if (cachedPromise) {
+      return cachedPromise;
+    }
+
+    const promise = loadItem(item).then(
+      (loadedItem) => loadedItem,
+      (error: unknown) => {
+        itemPromiseCacheBySrc.delete(item.src);
+        throw error;
+      },
+    );
+
+    itemPromiseCacheBySrc.set(item.src, promise);
+    return promise;
+  }
+
+  return {
+    read(items: MediaGalleryItem[], index: number) {
+      const selectedItem = items[index];
+
+      if (!selectedItem) {
+        throw new Error(`Media gallery item not found at index ${index}`);
+      }
+
+      // Start the selected image first so a cold gallery never waits for index 0.
+      const selectedItemPromise = load(selectedItem);
+
+      for (const [itemIndex, item] of items.entries()) {
+        if (itemIndex !== index) {
+          void load(item).catch(() => undefined);
+        }
+      }
+
+      return selectedItemPromise;
+    },
+  };
+}
+
+export const mediaGalleryItemLoader = createMediaGalleryItemLoader(
+  (originalItem: MediaGalleryItem) =>
+    new Promise<MediaGalleryItem>((resolve, reject) => {
+      const image = new Image();
+
+      image.onload = () => {
+        resolve(originalItem);
+      };
+      image.onerror = () => {
+        reject(new Error(`Failed to load image ${originalItem.src}`));
+      };
+      image.src = originalItem.src;
+    }),
+);

--- a/packages/pwa/src/hooks/useMediaFile.ts
+++ b/packages/pwa/src/hooks/useMediaFile.ts
@@ -56,8 +56,13 @@ function releaseMediaFileObjectUrl(key: string) {
   entry.refCount -= 1;
 
   if (entry.refCount <= 0) {
-    URL.revokeObjectURL(entry.url);
-    mediaFileObjectUrlCache.delete(key);
+    // Let replacement consumers retain a shared URL before revoking it.
+    queueMicrotask(() => {
+      if (mediaFileObjectUrlCache.get(key) === entry && entry.refCount <= 0) {
+        URL.revokeObjectURL(entry.url);
+        mediaFileObjectUrlCache.delete(key);
+      }
+    });
   }
 }
 

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/-expenseEditValues.test.ts
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/-expenseEditValues.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vite-plus/test";
 import type { Expense } from "#src/models/expense.ts";
-import { getExpenseEditValues } from "./-expenseEditValues.ts";
+import { getExpenseEditValues, getOrCreateExpenseEditCopy } from "./-expenseEditValues.ts";
 
 const NOW = new Date("2026-07-15T12:00:00.000Z");
 const UNSAVED_PHOTO = "unsaved-photo" as Expense["photos"][number];
@@ -22,6 +22,29 @@ describe("getExpenseEditValues", () => {
     expense.__editCopyLastUpdatedAt = new Date(NOW.getTime() - 5 * 60 * 1000);
 
     expect(getExpenseEditValues(expense, NOW.getTime()).photos).toEqual([SAVED_PHOTO]);
+  });
+});
+
+describe("getOrCreateExpenseEditCopy", () => {
+  test("keeps an active edit copy", () => {
+    const expense = createExpense({ photos: [SAVED_PHOTO] });
+    expense.__editCopy = createExpense({ photos: [UNSAVED_PHOTO] });
+    expense.__editCopyLastUpdatedAt = NOW;
+
+    expect(getOrCreateExpenseEditCopy(expense, NOW.getTime()).photos).toEqual([UNSAVED_PHOTO]);
+  });
+
+  test("rebuilds an expired edit copy from the saved expense", () => {
+    const expense = createExpense({ photos: [SAVED_PHOTO] });
+    expense.__editCopy = createExpense({ photos: [EXPIRED_PHOTO] });
+    expense.__editCopyLastUpdatedAt = new Date(NOW.getTime() - 5 * 60 * 1000);
+
+    const editCopy = getOrCreateExpenseEditCopy(expense, NOW.getTime());
+    editCopy.name = "Updated lunch";
+
+    expect(editCopy.photos).toEqual([SAVED_PHOTO]);
+    expect(editCopy).not.toHaveProperty("__editCopy");
+    expect(editCopy).not.toHaveProperty("__editCopyLastUpdatedAt");
   });
 });
 

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/-expenseEditValues.test.ts
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/-expenseEditValues.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vite-plus/test";
+import type { Expense } from "#src/models/expense.ts";
+import { getExpenseEditValues } from "./-expenseEditValues.ts";
+
+const NOW = new Date("2026-07-15T12:00:00.000Z");
+const UNSAVED_PHOTO = "unsaved-photo" as Expense["photos"][number];
+const SAVED_PHOTO = "saved-photo" as Expense["photos"][number];
+const EXPIRED_PHOTO = "expired-photo" as Expense["photos"][number];
+
+describe("getExpenseEditValues", () => {
+  test("includes an attachment added to an unsaved edit", () => {
+    const expense = createExpense({ photos: [] });
+    expense.__editCopy = createExpense({ photos: [UNSAVED_PHOTO] });
+    expense.__editCopyLastUpdatedAt = NOW;
+
+    expect(getExpenseEditValues(expense, NOW.getTime()).photos).toEqual([UNSAVED_PHOTO]);
+  });
+
+  test("discards an expired edit copy", () => {
+    const expense = createExpense({ photos: [SAVED_PHOTO] });
+    expense.__editCopy = createExpense({ photos: [EXPIRED_PHOTO] });
+    expense.__editCopyLastUpdatedAt = new Date(NOW.getTime() - 5 * 60 * 1000);
+
+    expect(getExpenseEditValues(expense, NOW.getTime()).photos).toEqual([SAVED_PHOTO]);
+  });
+});
+
+function createExpense({ photos }: { photos: Expense["photos"] }): Expense {
+  return {
+    id: "expense-id:chunk-id",
+    name: "Lunch",
+    paidAt: NOW,
+    paidBy: { participant: 1200 },
+    shares: { participant: { type: "divide", value: 1 } },
+    photos,
+    __hash: photos.join(","),
+  };
+}

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/-expenseEditValues.ts
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/-expenseEditValues.ts
@@ -1,0 +1,31 @@
+import { getExpenseTotalAmount, type Expense } from "#src/models/expense.ts";
+
+const TIME_TO_DISCARD_EDIT_COPY = 1000 * 60 * 5;
+
+export function getExpenseEditValues(expense: Expense, now = Date.now()) {
+  const currentExpense = shouldUseEditCopy(expense, now) ? expense.__editCopy : expense;
+
+  return {
+    name: currentExpense.name,
+    amount: getExpenseTotalAmount(currentExpense) / 100,
+    paidAt: currentExpense.paidAt,
+    paidBy: Object.keys(currentExpense.paidBy)[0],
+    shares: currentExpense.shares,
+    photos: currentExpense.photos,
+  };
+}
+
+export function getExpenseEditHash(expense: Expense) {
+  return shouldUseEditCopy(expense, Date.now()) ? expense.__editCopy.__hash : expense.__hash;
+}
+
+function shouldUseEditCopy(
+  expense: Expense,
+  now: number,
+): expense is Expense & { __editCopy: Omit<Expense, "__editCopy"> } {
+  if (!expense.__editCopy || !expense.__editCopyLastUpdatedAt) {
+    return false;
+  }
+
+  return expense.__editCopyLastUpdatedAt.getTime() + TIME_TO_DISCARD_EDIT_COPY > now;
+}

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/-expenseEditValues.ts
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/-expenseEditValues.ts
@@ -1,4 +1,5 @@
 import { getExpenseTotalAmount, type Expense } from "#src/models/expense.ts";
+import { clone } from "@opentf/std";
 
 const TIME_TO_DISCARD_EDIT_COPY = 1000 * 60 * 5;
 
@@ -15,8 +16,21 @@ export function getExpenseEditValues(expense: Expense, now = Date.now()) {
   };
 }
 
-export function getExpenseEditHash(expense: Expense) {
-  return shouldUseEditCopy(expense, Date.now()) ? expense.__editCopy.__hash : expense.__hash;
+export function getExpenseEditHash(expense: Expense, now = Date.now()) {
+  return shouldUseEditCopy(expense, now) ? expense.__editCopy.__hash : expense.__hash;
+}
+
+export function getOrCreateExpenseEditCopy(expense: Expense, now = Date.now()) {
+  if (shouldUseEditCopy(expense, now)) {
+    return expense.__editCopy;
+  }
+
+  const editCopy = clone(expense);
+  delete editCopy.__editCopy;
+  delete editCopy.__editCopyLastUpdatedAt;
+  expense.__editCopy = editCopy;
+
+  return expense.__editCopy;
 }
 
 function shouldUseEditCopy(

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx
@@ -15,7 +15,6 @@ import {
   decodeExpenseId,
   findExpenseById,
   calculateExpenseHash,
-  getExpenseTotalAmount,
   type Expense,
 } from "#src/models/expense.ts";
 import type { PartyExpenseChunk } from "#src/models/party.ts";
@@ -29,6 +28,7 @@ import { toast } from "sonner";
 import { RouteMediaGallery } from "#src/components/RouteMediaGallery.tsx";
 import { useRouteCalculator } from "#src/components/useRouteCalculator.ts";
 import { useRouteMediaGallery } from "#src/components/useRouteMediaGallery.ts";
+import { getExpenseEditHash, getExpenseEditValues } from "./-expenseEditValues.ts";
 import { hasExpenseEditOpenedFromDetailState } from "./-expenseEditRouteState.ts";
 
 interface EditExpenseSearchParams {
@@ -58,7 +58,6 @@ export const Route = createFileRoute("/party_/$partyId/expense/$expenseId_/edit"
   },
 });
 
-const TIME_TO_DISCARD_EDIT_COPY = 1000 * 60 * 5; // 5 minutes
 const logger = getLogger("routes", "EditExpense");
 
 function EditExpense() {
@@ -74,8 +73,6 @@ function EditExpense() {
   const navigate = useNavigate({ from: Route.fullPath });
   const router = useRouter();
   const currentLocation = useLocation();
-
-  const photos = expense?.photos ?? [];
 
   function mergeSearchOptions<TOptions extends { search: Partial<EditExpenseSearchParams> }>(
     options: TOptions,
@@ -110,10 +107,13 @@ function EditExpense() {
     throw new Error("Expense not found");
   }
 
+  const formValues = getExpenseEditValues(expense);
+  const photos = formValues.photos;
+
   const editorRef = useRef<ExpenseEditorRef>(null);
   const currentHashRef = useRef<string | null>(null);
   if (currentHashRef.current === null) {
-    currentHashRef.current = getExpenseHash(expense);
+    currentHashRef.current = getExpenseEditHash(expense);
   }
 
   const onChange = (
@@ -207,14 +207,13 @@ function EditExpense() {
     return subscribeToExpenseChanges((updatedExpense) => {
       const raw = clone(updatedExpense);
 
-      const currentHash = getExpenseHash(raw);
+      const currentHash = getExpenseEditHash(raw);
       currentHashRef.current = currentHash;
 
-      editorRef.current?.setValues(getFormValues(raw));
+      editorRef.current?.setValues(getExpenseEditValues(raw));
     });
   }, [subscribeToExpenseChanges]);
 
-  const formValues = getFormValues(expense);
   const expenseName = formValues.name;
 
   return (
@@ -279,7 +278,7 @@ function useExpense() {
   }
 
   function subscribeToExpenseChanges(callback: (expense: Expense) => void) {
-    let prevHash = expense ? getExpenseHash(expense) : "";
+    let prevHash = expense ? getExpenseEditHash(expense) : "";
 
     const handler = (payload: DocHandleChangePayload<PartyExpenseChunk>) => {
       const [expense] = findExpenseById(payload.doc.expenses, expenseId);
@@ -288,7 +287,7 @@ function useExpense() {
         return;
       }
 
-      const currentHash = getExpenseHash(expense);
+      const currentHash = getExpenseEditHash(expense);
 
       if (currentHash === prevHash) {
         return;
@@ -315,46 +314,4 @@ function useExpense() {
     onUpdateExpense,
     subscribeToExpenseChanges,
   };
-}
-
-function getFormValues(expense: Expense): ExpenseEditorFormValues {
-  if (shouldUseEditCopy(expense)) {
-    return {
-      name: expense.__editCopy.name,
-      paidAt: expense.__editCopy.paidAt,
-      shares: expense.__editCopy.shares,
-      photos: expense.__editCopy.photos,
-      amount: getExpenseTotalAmount(expense.__editCopy) / 100,
-      paidBy: Object.keys(expense.__editCopy.paidBy)[0],
-    };
-  }
-
-  return {
-    name: expense.name,
-    amount: getExpenseTotalAmount(expense) / 100,
-    paidAt: expense.paidAt,
-    paidBy: Object.keys(expense.paidBy)[0],
-    shares: expense.shares,
-    photos: expense.photos,
-  };
-}
-
-function getExpenseHash(expense: Expense) {
-  if (shouldUseEditCopy(expense)) {
-    return expense.__editCopy.__hash;
-  }
-
-  return expense.__hash;
-}
-
-function shouldUseEditCopy(expense: Expense): expense is Expense & { __editCopy: Expense } {
-  if (!expense.__editCopy) {
-    return false;
-  }
-
-  if (!expense.__editCopyLastUpdatedAt) {
-    return false;
-  }
-
-  return expense.__editCopyLastUpdatedAt.getTime() + TIME_TO_DISCARD_EDIT_COPY > Date.now();
 }

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx
@@ -28,7 +28,11 @@ import { toast } from "sonner";
 import { RouteMediaGallery } from "#src/components/RouteMediaGallery.tsx";
 import { useRouteCalculator } from "#src/components/useRouteCalculator.ts";
 import { useRouteMediaGallery } from "#src/components/useRouteMediaGallery.ts";
-import { getExpenseEditHash, getExpenseEditValues } from "./-expenseEditValues.ts";
+import {
+  getExpenseEditHash,
+  getExpenseEditValues,
+  getOrCreateExpenseEditCopy,
+} from "./-expenseEditValues.ts";
 import { hasExpenseEditOpenedFromDetailState } from "./-expenseEditRouteState.ts";
 
 interface EditExpenseSearchParams {
@@ -267,12 +271,9 @@ function useExpense() {
         return;
       }
 
-      if (!entry.__editCopy) {
-        entry.__editCopy = clone(entry);
-      }
-
-      patchMutate(entry.__editCopy, patches);
-      entry.__editCopy.__hash = calculateExpenseHash(entry.__editCopy);
+      const editCopy = getOrCreateExpenseEditCopy(entry);
+      patchMutate(editCopy, patches);
+      editCopy.__hash = calculateExpenseHash(editCopy);
       entry.__editCopyLastUpdatedAt = new Date();
     });
   }


### PR DESCRIPTION
## Description

Fix expense attachment galleries while an expense edit is still unsaved and
when another client opens the attachments with a cold media cache.

- Read gallery attachments from an active expense edit copy, preserving the
  existing five-minute draft lifetime.
- Discard an expired edit copy before applying a new change, preventing stale
  attachments or other draft values from being restored and refreshed.
- Start the attachment selected by `?media=<index>` before background
  preloading the other gallery images. A cold client opening `?media=1` no
  longer suspends on attachment 0 first.
- Keep the gallery shell outside the media Suspense boundary so Close,
  Previous, and Next remain interactive while the Automerge media document or
  browser image is loading.
- Key the image-only boundary to the attachment ID so a suspended replacement
  cannot retain the previous image.
- Keep shared object URLs alive through the replacement image's preload handoff
  so distinct media documents with identical bytes do not render blank.
- Preserve route-gallery drag progress through the exit animation and reset it
  synchronously whenever the gallery reopens, including when an exit is
  interrupted. This avoids both the close blink and a transparent backdrop on
  the next open.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not included; this restores the intended gallery lifecycle without changing
its design.

## Additional Notes

- Added unit coverage for active and expired expense edit copies, including
  the stale-attachment restoration case.
- Added a loader regression proving attachment 2 resolves while attachment 1
  remains cold.
- Added expense-edit Playwright coverage for opening attachment 2, using
  Close, Previous, and Next while image loading remains suspended, and keeping
  the backdrop transparent throughout drag dismissal before restoring it on
  both an interrupted exit and a completed close/reopen.
- The focused interrupted-exit gallery regression passes in Chromium and
  WebKit.
- React Doctor reports 100/100 for the changed React source.
