### PR TITLE
fix(pwa): prevent negative expense allocations

### DIFF
--- a/.changeset/nonnegative-expense-splits.md
+++ b/.changeset/nonnegative-expense-splits.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Prevent expense amount fields from displaying or saving negative participant allocations.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -170,7 +170,7 @@ msgstr "Align QR code here"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:473
+#: src/components/ExpenseEditor.tsx:442
 msgid "Amount"
 msgstr "Amount"
 
@@ -178,11 +178,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:817
+#: src/components/ExpenseEditor.tsx:787
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:460
+#: src/components/ExpenseEditor.tsx:429
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -283,7 +283,7 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:369
+#: src/components/ExpenseEditor.tsx:338
 #: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -551,7 +551,7 @@ msgstr "Close"
 msgid "Close attachment preview"
 msgstr "Close attachment preview"
 
-#: src/components/CurrencyField.tsx:466
+#: src/components/CurrencyField.tsx:467
 msgid "Close calculator"
 msgstr "Close calculator"
 
@@ -813,7 +813,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:525
+#: src/components/ExpenseEditor.tsx:495
 msgid "Date"
 msgstr "Date"
 
@@ -1030,7 +1030,7 @@ msgstr "Exact"
 msgid "Expense added"
 msgstr "Expense added"
 
-#: src/components/ExpenseEditor.tsx:166
+#: src/components/ExpenseEditor.tsx:135
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
@@ -1051,7 +1051,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:110
-#: src/components/ExpenseEditor.tsx:1042
+#: src/components/ExpenseEditor.tsx:1008
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1096,7 +1096,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:1017
+#: src/components/ExpenseEditor.tsx:983
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -1222,7 +1222,7 @@ msgstr "Haitian Gourde"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "Have an idea to improve trizum? We'd love to hear it."
 
-#: src/components/ExpenseEditor.tsx:919
+#: src/components/ExpenseEditor.tsx:885
 msgid "Heads up!"
 msgstr "Heads up!"
 
@@ -1315,7 +1315,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:577
+#: src/components/ExpenseEditor.tsx:547
 msgid "Include all"
 msgstr "Include all"
 
@@ -1574,7 +1574,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:362
+#: src/components/ExpenseEditor.tsx:331
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1823,11 +1823,11 @@ msgstr "Only your own debt can be transferred"
 msgid "Open archived parties"
 msgstr "Open archived parties"
 
-#: src/components/CurrencyField.tsx:466
+#: src/components/CurrencyField.tsx:467
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:372
+#: src/components/ExpenseEditor.tsx:341
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1876,7 +1876,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:500
+#: src/components/ExpenseEditor.tsx:470
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -2090,7 +2090,7 @@ msgstr "Platinum (troy ounce)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Please allow camera access in your browser settings to scan QR codes."
 
-#: src/components/ExpenseEditor.tsx:937
+#: src/components/ExpenseEditor.tsx:903
 msgid "Please correct it before saving."
 msgstr "Please correct it before saving."
 
@@ -2171,7 +2171,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1134
+#: src/components/ExpenseEditor.tsx:1100
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2240,7 +2240,7 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:282
+#: src/components/ExpenseEditor.tsx:251
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:120
@@ -2351,7 +2351,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:775
+#: src/components/ExpenseEditor.tsx:745
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -2359,7 +2359,7 @@ msgstr "Shares for {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:923
+#: src/components/ExpenseEditor.tsx:889
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 
@@ -2531,7 +2531,7 @@ msgstr "Stop trizum cloud on this device"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:282
+#: src/components/ExpenseEditor.tsx:251
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:120
@@ -2578,11 +2578,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:799
+#: src/components/ExpenseEditor.tsx:769
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:800
+#: src/components/ExpenseEditor.tsx:770
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2621,8 +2621,8 @@ msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:157
 #: src/components/AvatarPicker.tsx:172
-#: src/components/ExpenseEditor.tsx:1062
-#: src/components/ExpenseEditor.tsx:1076
+#: src/components/ExpenseEditor.tsx:1028
+#: src/components/ExpenseEditor.tsx:1042
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2721,7 +2721,7 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:436
+#: src/components/ExpenseEditor.tsx:405
 msgid "Title"
 msgstr "Title"
 
@@ -2919,14 +2919,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:962
+#: src/components/ExpenseEditor.tsx:928
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:166
 #: src/components/AvatarPicker.tsx:184
-#: src/components/ExpenseEditor.tsx:1071
-#: src/components/ExpenseEditor.tsx:1088
+#: src/components/ExpenseEditor.tsx:1037
+#: src/components/ExpenseEditor.tsx:1054
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2939,7 +2939,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:1002
+#: src/components/ExpenseEditor.tsx:968
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -3032,7 +3032,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1123
+#: src/components/ExpenseEditor.tsx:1089
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -162,7 +162,7 @@ msgstr "Alinea el código QR aquí"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:473
+#: src/components/ExpenseEditor.tsx:442
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -170,11 +170,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:817
+#: src/components/ExpenseEditor.tsx:787
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:460
+#: src/components/ExpenseEditor.tsx:429
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -271,7 +271,7 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:369
+#: src/components/ExpenseEditor.tsx:338
 #: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -527,7 +527,7 @@ msgstr "Cerrar"
 msgid "Close attachment preview"
 msgstr "Cerrar vista previa del adjunto"
 
-#: src/components/CurrencyField.tsx:466
+#: src/components/CurrencyField.tsx:467
 msgid "Close calculator"
 msgstr "Cerrar calculadora"
 
@@ -785,7 +785,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:525
+#: src/components/ExpenseEditor.tsx:495
 msgid "Date"
 msgstr "Fecha"
 
@@ -994,7 +994,7 @@ msgstr "Por ahora todo está archivado. Puedes reabrir cualquier grupo desde la 
 msgid "Expense added"
 msgstr "Gasto añadido"
 
-#: src/components/ExpenseEditor.tsx:166
+#: src/components/ExpenseEditor.tsx:135
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
@@ -1011,7 +1011,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:110
-#: src/components/ExpenseEditor.tsx:1042
+#: src/components/ExpenseEditor.tsx:1008
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1052,7 +1052,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:1017
+#: src/components/ExpenseEditor.tsx:983
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -1174,7 +1174,7 @@ msgstr "Gourde Haitiano"
 msgid "Have an idea to improve trizum? We'd love to hear it."
 msgstr "¿Tienes una idea para mejorar trizum? Nos encantaría escucharla."
 
-#: src/components/ExpenseEditor.tsx:919
+#: src/components/ExpenseEditor.tsx:885
 msgid "Heads up!"
 msgstr "¡Atención!"
 
@@ -1267,7 +1267,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:577
+#: src/components/ExpenseEditor.tsx:547
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1522,7 +1522,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:362
+#: src/components/ExpenseEditor.tsx:331
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1767,11 +1767,11 @@ msgstr "Solo puedes transferir tus propias deudas"
 msgid "Open archived parties"
 msgstr "Abrir grupos archivados"
 
-#: src/components/CurrencyField.tsx:466
+#: src/components/CurrencyField.tsx:467
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:372
+#: src/components/ExpenseEditor.tsx:341
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1816,7 +1816,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:500
+#: src/components/ExpenseEditor.tsx:470
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -2022,7 +2022,7 @@ msgstr "Platino (onza troy)"
 msgid "Please allow camera access in your browser settings to scan QR codes."
 msgstr "Por favor, permite el acceso a la cámara en la configuración de tu navegador para escanear códigos QR."
 
-#: src/components/ExpenseEditor.tsx:937
+#: src/components/ExpenseEditor.tsx:903
 msgid "Please correct it before saving."
 msgstr "Por favor, corrígelo antes de guardar."
 
@@ -2099,7 +2099,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1134
+#: src/components/ExpenseEditor.tsx:1100
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2168,7 +2168,7 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:282
+#: src/components/ExpenseEditor.tsx:251
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:120
@@ -2279,7 +2279,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:775
+#: src/components/ExpenseEditor.tsx:745
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -2287,7 +2287,7 @@ msgstr "Partes para {participantName}"
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
 msgstr "Las partes suman <0>{0} {1}</0> mientras que la cantidad del gasto es <1>{amount} {2}</1>."
 
-#: src/components/ExpenseEditor.tsx:923
+#: src/components/ExpenseEditor.tsx:889
 msgid "Shares sum up to <0>{totalAmount} {currency}</0> while the expense amount is <1>{expenseAmount} {currency}</1>."
 msgstr "Las partes suman <0>{totalAmount} {currency}</0> mientras que la cantidad del gasto es <1>{expenseAmount} {currency}</1>."
 
@@ -2455,7 +2455,7 @@ msgstr "Detener trizum cloud en este dispositivo"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:282
+#: src/components/ExpenseEditor.tsx:251
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/route.tsx:120
@@ -2502,11 +2502,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:799
+#: src/components/ExpenseEditor.tsx:769
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:800
+#: src/components/ExpenseEditor.tsx:770
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2545,8 +2545,8 @@ msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:157
 #: src/components/AvatarPicker.tsx:172
-#: src/components/ExpenseEditor.tsx:1062
-#: src/components/ExpenseEditor.tsx:1076
+#: src/components/ExpenseEditor.tsx:1028
+#: src/components/ExpenseEditor.tsx:1042
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2645,7 +2645,7 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:436
+#: src/components/ExpenseEditor.tsx:405
 msgid "Title"
 msgstr "Título"
 
@@ -2831,14 +2831,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:962
+#: src/components/ExpenseEditor.tsx:928
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:166
 #: src/components/AvatarPicker.tsx:184
-#: src/components/ExpenseEditor.tsx:1071
-#: src/components/ExpenseEditor.tsx:1088
+#: src/components/ExpenseEditor.tsx:1037
+#: src/components/ExpenseEditor.tsx:1054
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2846,7 +2846,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:1002
+#: src/components/ExpenseEditor.tsx:968
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2935,7 +2935,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1123
+#: src/components/ExpenseEditor.tsx:1089
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/src/components/CurrencyField.tsx
+++ b/packages/pwa/src/components/CurrencyField.tsx
@@ -13,6 +13,7 @@ import { IconButton } from "#src/ui/IconButton.js";
 import { cn } from "#src/ui/utils.js";
 import { getPresenceElementIdFromTarget } from "./presencePosition.ts";
 import type { MediaFile } from "#src/models/media.ts";
+import { clampCurrencyValue } from "#src/ui/fields/currencyValue.ts";
 
 export type CurrencyFieldProps = React.ComponentProps<typeof AppCurrencyField> & {
   calculator?: boolean;
@@ -134,8 +135,8 @@ function useCurrencyFieldCalculator({
   });
   const { requestId, isClosedFromCalculator, isClosingFromRouteChange } = calculatorCloseState;
   const [state, actions] = useCalculatorMode({
-    value: fieldProps.value ?? 0,
-    onChange: (value) => fieldProps.onChange?.(value),
+    value: clampCurrencyValue(fieldProps.value ?? 0, fieldProps.minValue),
+    onChange: (value) => fieldProps.onChange?.(clampCurrencyValue(value, fieldProps.minValue)),
     currency: fieldProps.currency,
   });
   const calculatorFieldId =

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -11,7 +11,6 @@ import { AppNumberField, AppTextField } from "#src/ui/fields/TextField.js";
 import { CurrencyField } from "./CurrencyField";
 import { convertToUnits } from "#src/lib/expenses.js";
 import { toast } from "sonner";
-import { add, equal, subtract } from "dinero.js";
 import { useExpenseParticipants } from "#src/hooks/useExpenseParticipants.ts";
 import { useCurrentParty } from "#src/hooks/useParty.ts";
 import { Checkbox } from "#src/ui/Checkbox.tsx";
@@ -27,12 +26,10 @@ import { MenuTrigger, Popover } from "react-aria-components";
 import { Menu, MenuItem } from "#src/ui/Menu.js";
 import { Switch } from "#src/ui/Switch.tsx";
 import { usePartyList } from "#src/hooks/usePartyList.ts";
-import { getExpenseUnitShares } from "#src/models/expense.ts";
 import { useMediaFile } from "#src/hooks/useMediaFile.ts";
 import { Skeleton } from "#src/ui/Skeleton.tsx";
 import type { MediaFile } from "#src/models/media.ts";
 import { getImageUploadErrorMessage, useMediaFileActions } from "#src/hooks/useMediaFileActions.ts";
-import { createMoney } from "#src/lib/money.ts";
 import {
   compressionPresets,
   imageCaptureAccept,
@@ -46,6 +43,10 @@ import {
 import { getLogger } from "#src/lib/log.ts";
 import { MediaGalleryContext } from "./MediaGalleryContext";
 import type { AppFormApi } from "#src/lib/reactFormTypes.ts";
+import {
+  expenseEditorSharesMatchAmount,
+  getExpenseEditorUnitShares,
+} from "#src/lib/expenseEditor.ts";
 
 export interface ExpenseEditorFormValues {
   name: string;
@@ -130,39 +131,7 @@ export function ExpenseEditor({
         return;
       }
 
-      // Validate that amounts add up correctly using Dinero.js for precise calculations
-      const activeParticipants = Object.keys(value.shares);
-      const totalAmount = createMoney(convertToUnits(value.amount));
-
-      // Calculate total shares for divide participants
-      const totalShares = activeParticipants.reduce((total, participantId) => {
-        const share = value.shares[participantId];
-        if (share?.type === "divide") {
-          return total + share.value;
-        }
-        return total;
-      }, 0);
-
-      // Calculate total amount taken by exact shares using Dinero.js
-      const exactTotal = activeParticipants.reduce((total, participantId) => {
-        const share = value.shares[participantId];
-        if (share?.type === "exact") {
-          // Use Math.round to handle any floating point precision issues
-          return add(total, createMoney(Math.round(share.value)));
-        }
-        return total;
-      }, createMoney(0));
-
-      // Calculate total split amount using Dinero.js
-      let totalSplit = exactTotal;
-      if (totalShares > 0) {
-        // Calculate remaining amount for divide participants
-        const remainingAmount = subtract(totalAmount, exactTotal);
-        totalSplit = add(exactTotal, remainingAmount);
-      }
-
-      // Compare using Dinero.js equality
-      if (!equal(totalSplit, totalAmount)) {
+      if (!expenseEditorSharesMatchAmount(value.amount, value.shares)) {
         toast.error(t`Expense amounts don't match total. Please check your split configuration.`);
         return;
       }
@@ -474,6 +443,7 @@ function ExpenseDetailsFields({
             onCloseCalculator={onCloseCalculator}
             onOpenCalculator={onOpenCalculator}
             value={field.state.value}
+            minValue={0}
             onChange={(value) => {
               field.handleChange(value || 0);
             }}
@@ -861,6 +831,7 @@ function ParticipantSplitAmountField({
       onCloseCalculator={onCloseCalculator}
       onOpenCalculator={onOpenCalculator}
       value={participantAmount / 100}
+      minValue={0}
       onChange={onChange}
       className="w-20"
       inputClassName="h-7 px-0 text-right border-t-0 border-x-0 rounded-none border-b"
@@ -880,12 +851,7 @@ function calculateParticipantUnitAmounts(
   amount: number,
   shares: Record<ExpenseUser, { type: "divide" | "exact"; value: number }>,
 ) {
-  const amountInUnits = convertToUnits(amount);
-
-  return getExpenseUnitShares({
-    shares,
-    paidBy: { noop: amountInUnits },
-  });
+  return getExpenseEditorUnitShares(amount, shares);
 }
 
 interface SharesWarningProps {

--- a/packages/pwa/src/lib/expenseEditor.test.ts
+++ b/packages/pwa/src/lib/expenseEditor.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vite-plus/test";
+import { expenseEditorSharesMatchAmount, getExpenseEditorUnitShares } from "./expenseEditor.ts";
+
+describe("expense editor shares", () => {
+  test("clamps a negative adjusted participant amount to zero", () => {
+    const shares = {
+      exact: { type: "exact" as const, value: 15_000 },
+      adjusted: { type: "divide" as const, value: 1 },
+    };
+
+    expect(getExpenseEditorUnitShares(100, shares)).toStrictEqual({
+      exact: 15_000,
+      adjusted: 0,
+    });
+  });
+
+  test("rejects a split that only balances with a negative participant amount", () => {
+    const shares = {
+      exact: { type: "exact" as const, value: 15_000 },
+      adjusted: { type: "divide" as const, value: 1 },
+    };
+
+    expect(expenseEditorSharesMatchAmount(100, shares)).toBe(false);
+  });
+
+  test("accepts a valid non-negative split", () => {
+    const shares = {
+      exact: { type: "exact" as const, value: 5_000 },
+      adjusted: { type: "divide" as const, value: 1 },
+    };
+
+    expect(expenseEditorSharesMatchAmount(100, shares)).toBe(true);
+  });
+});

--- a/packages/pwa/src/lib/expenseEditor.ts
+++ b/packages/pwa/src/lib/expenseEditor.ts
@@ -1,0 +1,31 @@
+import type { ExpenseUser } from "#src/lib/expenses.ts";
+import { convertToUnits } from "#src/lib/expenses.ts";
+import { createMoney } from "#src/lib/money.ts";
+import { getExpenseUnitShares } from "#src/models/expense.ts";
+import { add, equal } from "dinero.js";
+
+export type ExpenseEditorShares = Record<ExpenseUser, { type: "divide" | "exact"; value: number }>;
+
+export function getExpenseEditorUnitShares(amount: number, shares: ExpenseEditorShares) {
+  const unitShares = getExpenseUnitShares({
+    shares,
+    paidBy: { noop: convertToUnits(amount) },
+  });
+
+  return Object.fromEntries(
+    Object.entries(unitShares).map(([participantId, participantAmount]) => [
+      participantId,
+      Math.max(participantAmount, 0),
+    ]),
+  );
+}
+
+export function expenseEditorSharesMatchAmount(amount: number, shares: ExpenseEditorShares) {
+  const totalAmount = createMoney(convertToUnits(amount));
+  const totalSplit = Object.values(getExpenseEditorUnitShares(amount, shares)).reduce(
+    (total, participantAmount) => add(total, createMoney(participantAmount)),
+    createMoney(0),
+  );
+
+  return equal(totalSplit, totalAmount);
+}

--- a/packages/pwa/src/ui/fields/AppCurrencyField.tsx
+++ b/packages/pwa/src/ui/fields/AppCurrencyField.tsx
@@ -8,6 +8,7 @@ import {
 import { cn, type ClassName } from "../utils";
 import { FieldError, Label } from "./Field";
 import { getCurrencyDecimalPrecision } from "./currencyPrecision.js";
+import { clampCurrencyValue } from "./currencyValue.js";
 import { Input, TextField } from "./TextFieldPrimitives.js";
 
 interface AppCurrencyFieldProps extends Omit<AriaTextFieldProps, "value" | "onChange"> {
@@ -19,6 +20,7 @@ interface AppCurrencyFieldProps extends Omit<AriaTextFieldProps, "value" | "onCh
   inputClassName?: ClassName;
   inputEndAdornment?: React.ReactNode;
   currency?: string;
+  minValue?: number;
 }
 
 export function AppCurrencyField({
@@ -32,12 +34,16 @@ export function AppCurrencyField({
   inputEndAdornment,
   inputMode,
   currency,
+  minValue,
   ...props
 }: AppCurrencyFieldProps) {
-  const [internalValue, setInternalValue] = React.useState(() => value?.toString() || "");
+  const constrainedValue = value === undefined ? undefined : clampCurrencyValue(value, minValue);
+  const [internalValue, setInternalValue] = React.useState(
+    () => constrainedValue?.toString() || "",
+  );
 
   const parsedInternalValue = parseFloat(internalValue || "0");
-  const parsedValue = parseFloat(value?.toString() || "0");
+  const parsedValue = parseFloat(constrainedValue?.toString() || "0");
 
   if (parsedInternalValue !== parsedValue) {
     setInternalValue(parsedValue.toString());
@@ -95,11 +101,11 @@ export function AppCurrencyField({
 
         const trimmedValue = value.trim();
         if (trimmedValue === "" || trimmedValue === ".") {
-          onChange?.(0);
+          onChange?.(clampCurrencyValue(0, minValue));
         } else {
           const parsed = parseFloat(trimmedValue);
           if (!isNaN(parsed)) {
-            onChange?.(parsed);
+            onChange?.(clampCurrencyValue(parsed, minValue));
           }
         }
       }}

--- a/packages/pwa/src/ui/fields/currencyValue.test.ts
+++ b/packages/pwa/src/ui/fields/currencyValue.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vite-plus/test";
+import { clampCurrencyValue } from "./currencyValue.ts";
+
+describe("clampCurrencyValue", () => {
+  test("clamps values below the configured minimum", () => {
+    expect(clampCurrencyValue(-10, 0)).toBe(0);
+    expect(clampCurrencyValue(10, 0)).toBe(10);
+  });
+
+  test("preserves negative values when no minimum is configured", () => {
+    expect(clampCurrencyValue(-10)).toBe(-10);
+  });
+});

--- a/packages/pwa/src/ui/fields/currencyValue.ts
+++ b/packages/pwa/src/ui/fields/currencyValue.ts
@@ -1,0 +1,3 @@
+export function clampCurrencyValue(value: number, minValue?: number) {
+  return minValue === undefined ? value : Math.max(value, minValue);
+}


### PR DESCRIPTION
## Description

Prevent the expense editor from displaying or saving negative currency allocations.

- Add a reusable minimum value constraint to currency fields and calculator commits.
- Apply a minimum of zero to the total and participant amount fields.
- Clamp automatically adjusted participant allocations at zero and validate the form against those non-negative values.
- Add regression coverage for clamping and rejecting splits that only balance through a negative allocation.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not included: this changes currency field constraints and validation behavior without altering the editor layout.

## Additional Notes

- React Doctor reports 100/100 for the changed React files.
- Lingui extraction only updated generated source locations; no copy or translations changed.
