### PR TITLE
feat(pwa): improve expense validation feedback

### DIFF
--- a/.changeset/calm-expenses-check.md
+++ b/.changeset/calm-expenses-check.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": minor
+---
+
+Improve expense validation with a persistent form status bar and a detailed dialog for form-wide issues such as mismatched split totals.

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -46,11 +46,11 @@ msgstr "{archivedParticipantCount, plural, one {# archived} other {# archived}}"
 msgid "{archivedParticipantCount} archived"
 msgstr "{archivedParticipantCount} archived"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:119
+#: src/components/ExpenseEditorValidationStatus.tsx:158
 msgid "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
 msgstr "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:116
+#: src/components/ExpenseEditorValidationStatus.tsx:155
 msgid "{issueCount, plural, one {# warning} other {# warnings}}"
 msgstr "{issueCount, plural, one {# warning} other {# warnings}}"
 
@@ -140,7 +140,7 @@ msgstr "Add an expense"
 msgid "Add Apple as a sign-in method"
 msgstr "Add Apple as a sign-in method"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:110
+#: src/components/ExpenseEditorValidationStatus.tsx:149
 msgid "Add expense details to get started"
 msgstr "Add expense details to get started"
 
@@ -198,7 +198,7 @@ msgstr "Algerian Dinar"
 msgid "Align QR code here"
 msgstr "Align QR code here"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:114
+#: src/components/ExpenseEditorValidationStatus.tsx:153
 msgid "All expense checks passed"
 msgstr "All expense checks passed"
 
@@ -206,7 +206,7 @@ msgstr "All expense checks passed"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:462
+#: src/components/ExpenseEditor.tsx:468
 msgid "Amount"
 msgstr "Amount"
 
@@ -214,11 +214,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:805
+#: src/components/ExpenseEditor.tsx:811
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:449
+#: src/components/ExpenseEditor.tsx:455
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -319,7 +319,7 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:358
+#: src/components/ExpenseEditor.tsx:364
 #: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -631,7 +631,7 @@ msgstr "Comorian Franc"
 msgid "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 msgstr "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:112
+#: src/components/ExpenseEditorValidationStatus.tsx:151
 msgid "Complete the required details"
 msgstr "Complete the required details"
 
@@ -853,7 +853,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:515
+#: src/components/ExpenseEditor.tsx:521
 msgid "Date"
 msgstr "Date"
 
@@ -945,7 +945,7 @@ msgstr "Edit"
 msgid "Editing {0}"
 msgstr "Editing {0}"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:227
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:228
 msgid "Editing {expenseName}"
 msgstr "Editing {expenseName}"
 
@@ -1074,8 +1074,8 @@ msgstr "Expense added"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:150
-#: src/components/ExpenseEditorValidationStatus.tsx:160
+#: src/components/ExpenseEditorValidationStatus.tsx:189
+#: src/components/ExpenseEditorValidationStatus.tsx:199
 msgid "Expense checks"
 msgstr "Expense checks"
 
@@ -1096,7 +1096,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:110
-#: src/components/ExpenseEditor.tsx:973
+#: src/components/ExpenseEditor.tsx:979
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1141,7 +1141,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:948
+#: src/components/ExpenseEditor.tsx:954
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -1360,7 +1360,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:567
+#: src/components/ExpenseEditor.tsx:573
 msgid "Include all"
 msgstr "Include all"
 
@@ -1619,7 +1619,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:351
+#: src/components/ExpenseEditor.tsx:357
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1721,7 +1721,7 @@ msgstr "Nepalese Rupee"
 msgid "Netherlands Antillean Guilder"
 msgstr "Netherlands Antillean Guilder"
 
-#: src/routes/party_.$partyId.add.tsx:138
+#: src/routes/party_.$partyId.add.tsx:139
 msgid "New expense"
 msgstr "New expense"
 
@@ -1876,7 +1876,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:361
+#: src/components/ExpenseEditor.tsx:367
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1925,7 +1925,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:490
+#: src/components/ExpenseEditor.tsx:496
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -2245,7 +2245,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1065
+#: src/components/ExpenseEditor.tsx:1071
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2261,7 +2261,7 @@ msgstr "Report Issues"
 msgid "Reset password"
 msgstr "Reset password"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:163
+#: src/components/ExpenseEditorValidationStatus.tsx:202
 msgid "Resolve these issues before saving the expense."
 msgstr "Resolve these issues before saving the expense."
 
@@ -2286,7 +2286,7 @@ msgstr "Restore to home"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:175
+#: src/components/ExpenseEditorValidationStatus.tsx:214
 msgid "Review expense"
 msgstr "Review expense"
 
@@ -2322,7 +2322,7 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:265
+#: src/components/ExpenseEditor.tsx:271
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2434,11 +2434,11 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:763
+#: src/components/ExpenseEditor.tsx:769
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:195
+#: src/components/ExpenseEditorValidationStatus.tsx:234
 msgid "Shares sum up to <0/>, while the expense amount is <1/>."
 msgstr "Shares sum up to <0/>, while the expense amount is <1/>."
 
@@ -2593,7 +2593,7 @@ msgstr "Split expenses fairly among multiple participants"
 msgid "Split expenses, stay even."
 msgstr "Split expenses, stay even."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:192
+#: src/components/ExpenseEditorValidationStatus.tsx:231
 msgid "Split total does not match"
 msgstr "Split total does not match"
 
@@ -2622,7 +2622,7 @@ msgstr "Stop trizum cloud on this device"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:265
+#: src/components/ExpenseEditor.tsx:271
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2670,11 +2670,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:787
+#: src/components/ExpenseEditor.tsx:793
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:788
+#: src/components/ExpenseEditor.tsx:794
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2713,8 +2713,8 @@ msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:157
 #: src/components/AvatarPicker.tsx:172
-#: src/components/ExpenseEditor.tsx:993
-#: src/components/ExpenseEditor.tsx:1007
+#: src/components/ExpenseEditor.tsx:999
+#: src/components/ExpenseEditor.tsx:1013
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2813,7 +2813,7 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:425
+#: src/components/ExpenseEditor.tsx:431
 msgid "Title"
 msgstr "Title"
 
@@ -3011,14 +3011,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:893
+#: src/components/ExpenseEditor.tsx:899
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:166
 #: src/components/AvatarPicker.tsx:184
-#: src/components/ExpenseEditor.tsx:1002
-#: src/components/ExpenseEditor.tsx:1019
+#: src/components/ExpenseEditor.tsx:1008
+#: src/components/ExpenseEditor.tsx:1025
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -3031,7 +3031,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:933
+#: src/components/ExpenseEditor.tsx:939
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -3124,7 +3124,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1054
+#: src/components/ExpenseEditor.tsx:1060
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -1080,7 +1080,7 @@ msgid "Expense amounts don't match total. Please check your split configuration.
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
 #: src/components/ExpenseEditorValidationStatus.tsx:193
-#: src/components/ExpenseEditorValidationStatus.tsx:203
+#: src/components/ExpenseEditorValidationStatus.tsx:202
 msgid "Expense checks"
 msgstr "Expense checks"
 
@@ -2291,7 +2291,7 @@ msgstr "Restore to home"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:222
+#: src/components/ExpenseEditorValidationStatus.tsx:213
 msgid "Review expense"
 msgstr "Review expense"
 
@@ -2443,7 +2443,7 @@ msgstr "Shares for {0}"
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:247
+#: src/components/ExpenseEditorValidationStatus.tsx:233
 msgid "Shares sum up to <0/>, while the expense amount is <1/>."
 msgstr "Shares sum up to <0/>, while the expense amount is <1/>."
 
@@ -2598,7 +2598,7 @@ msgstr "Split expenses fairly among multiple participants"
 msgid "Split expenses, stay even."
 msgstr "Split expenses, stay even."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:244
+#: src/components/ExpenseEditorValidationStatus.tsx:230
 msgid "Split total does not match"
 msgstr "Split total does not match"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -46,6 +46,14 @@ msgstr "{archivedParticipantCount, plural, one {# archived} other {# archived}}"
 msgid "{archivedParticipantCount} archived"
 msgstr "{archivedParticipantCount} archived"
 
+#: src/components/ExpenseEditorValidationStatus.tsx:119
+msgid "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
+msgstr "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
+
+#: src/components/ExpenseEditorValidationStatus.tsx:116
+msgid "{issueCount, plural, one {# warning} other {# warnings}}"
+msgstr "{issueCount, plural, one {# warning} other {# warnings}}"
+
 #: src/routes/migrate_.tricount.tsx:377
 msgid "{message}"
 msgstr "{message}"
@@ -132,6 +140,10 @@ msgstr "Add an expense"
 msgid "Add Apple as a sign-in method"
 msgstr "Add Apple as a sign-in method"
 
+#: src/components/ExpenseEditorValidationStatus.tsx:110
+msgid "Add expense details to get started"
+msgstr "Add expense details to get started"
+
 #: src/components/PartyStatsView.tsx:850
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Add expenses to this party to unlock totals, rankings, and individual spend."
@@ -186,11 +198,15 @@ msgstr "Algerian Dinar"
 msgid "Align QR code here"
 msgstr "Align QR code here"
 
+#: src/components/ExpenseEditorValidationStatus.tsx:114
+msgid "All expense checks passed"
+msgstr "All expense checks passed"
+
 #: src/components/PartyStatsView.tsx:183
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:442
+#: src/components/ExpenseEditor.tsx:462
 msgid "Amount"
 msgstr "Amount"
 
@@ -198,11 +214,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:787
+#: src/components/ExpenseEditor.tsx:805
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:429
+#: src/components/ExpenseEditor.tsx:449
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -303,7 +319,7 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:338
+#: src/components/ExpenseEditor.tsx:358
 #: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -615,6 +631,10 @@ msgstr "Comorian Franc"
 msgid "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 msgstr "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 
+#: src/components/ExpenseEditorValidationStatus.tsx:112
+msgid "Complete the required details"
+msgstr "Complete the required details"
+
 #: src/routes/index/-components/ProfileSetupCard.tsx:26
 msgid "Complete your profile"
 msgstr "Complete your profile"
@@ -833,7 +853,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:495
+#: src/components/ExpenseEditor.tsx:515
 msgid "Date"
 msgstr "Date"
 
@@ -1054,6 +1074,11 @@ msgstr "Expense added"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
+#: src/components/ExpenseEditorValidationStatus.tsx:150
+#: src/components/ExpenseEditorValidationStatus.tsx:160
+msgid "Expense checks"
+msgstr "Expense checks"
+
 #: src/components/ExpenseEditor.tsx:257
 msgid "Expense Split Mode"
 msgstr "Expense Split Mode"
@@ -1071,7 +1096,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:110
-#: src/components/ExpenseEditor.tsx:1008
+#: src/components/ExpenseEditor.tsx:973
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1116,7 +1141,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:983
+#: src/components/ExpenseEditor.tsx:948
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -1335,7 +1360,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:547
+#: src/components/ExpenseEditor.tsx:567
 msgid "Include all"
 msgstr "Include all"
 
@@ -1594,7 +1619,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:331
+#: src/components/ExpenseEditor.tsx:351
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1851,7 +1876,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:341
+#: src/components/ExpenseEditor.tsx:361
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1900,7 +1925,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:470
+#: src/components/ExpenseEditor.tsx:490
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -2220,7 +2245,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1100
+#: src/components/ExpenseEditor.tsx:1065
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2235,6 +2260,10 @@ msgstr "Report Issues"
 #: src/routes/reset-password.tsx:70
 msgid "Reset password"
 msgstr "Reset password"
+
+#: src/components/ExpenseEditorValidationStatus.tsx:163
+msgid "Resolve these issues before saving the expense."
+msgstr "Resolve these issues before saving the expense."
 
 #: src/components/AppRecoveryDialog.tsx:76
 msgid "Restart app"
@@ -2256,6 +2285,10 @@ msgstr "Restore to home"
 #: src/components/PartyPendingComponent.tsx:141
 msgid "Retry"
 msgstr "Retry"
+
+#: src/components/ExpenseEditorValidationStatus.tsx:175
+msgid "Review expense"
+msgstr "Review expense"
 
 #: src/routes/new/route.tsx:180
 msgid "Romanian Leu"
@@ -2289,7 +2322,7 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:251
+#: src/components/ExpenseEditor.tsx:265
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2401,9 +2434,13 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:745
+#: src/components/ExpenseEditor.tsx:763
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
+
+#: src/components/ExpenseEditorValidationStatus.tsx:195
+msgid "Shares sum up to <0/>, while the expense amount is <1/>."
+msgstr "Shares sum up to <0/>, while the expense amount is <1/>."
 
 #: src/components/ExpenseEditor.tsx:797
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
@@ -2556,6 +2593,10 @@ msgstr "Split expenses fairly among multiple participants"
 msgid "Split expenses, stay even."
 msgstr "Split expenses, stay even."
 
+#: src/components/ExpenseEditorValidationStatus.tsx:192
+msgid "Split total does not match"
+msgstr "Split total does not match"
+
 #: src/routes/new/route.tsx:260
 msgid "Sri Lankan Rupee"
 msgstr "Sri Lankan Rupee"
@@ -2581,7 +2622,7 @@ msgstr "Stop trizum cloud on this device"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:251
+#: src/components/ExpenseEditor.tsx:265
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2629,11 +2670,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:769
+#: src/components/ExpenseEditor.tsx:787
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:770
+#: src/components/ExpenseEditor.tsx:788
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2672,8 +2713,8 @@ msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:157
 #: src/components/AvatarPicker.tsx:172
-#: src/components/ExpenseEditor.tsx:1028
-#: src/components/ExpenseEditor.tsx:1042
+#: src/components/ExpenseEditor.tsx:993
+#: src/components/ExpenseEditor.tsx:1007
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2772,7 +2813,7 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:405
+#: src/components/ExpenseEditor.tsx:425
 msgid "Title"
 msgstr "Title"
 
@@ -2970,14 +3011,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:928
+#: src/components/ExpenseEditor.tsx:893
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:166
 #: src/components/AvatarPicker.tsx:184
-#: src/components/ExpenseEditor.tsx:1037
-#: src/components/ExpenseEditor.tsx:1054
+#: src/components/ExpenseEditor.tsx:1002
+#: src/components/ExpenseEditor.tsx:1019
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -2990,7 +3031,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:968
+#: src/components/ExpenseEditor.tsx:933
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -3083,7 +3124,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1089
+#: src/components/ExpenseEditor.tsx:1054
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -46,11 +46,11 @@ msgstr "{archivedParticipantCount, plural, one {# archived} other {# archived}}"
 msgid "{archivedParticipantCount} archived"
 msgstr "{archivedParticipantCount} archived"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:158
+#: src/components/ExpenseEditorValidationStatus.tsx:162
 msgid "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
 msgstr "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:155
+#: src/components/ExpenseEditorValidationStatus.tsx:159
 msgid "{issueCount, plural, one {# warning} other {# warnings}}"
 msgstr "{issueCount, plural, one {# warning} other {# warnings}}"
 
@@ -140,7 +140,7 @@ msgstr "Add an expense"
 msgid "Add Apple as a sign-in method"
 msgstr "Add Apple as a sign-in method"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:149
+#: src/components/ExpenseEditorValidationStatus.tsx:153
 msgid "Add expense details to get started"
 msgstr "Add expense details to get started"
 
@@ -198,7 +198,7 @@ msgstr "Algerian Dinar"
 msgid "Align QR code here"
 msgstr "Align QR code here"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:153
+#: src/components/ExpenseEditorValidationStatus.tsx:157
 msgid "All expense checks passed"
 msgstr "All expense checks passed"
 
@@ -631,7 +631,7 @@ msgstr "Comorian Franc"
 msgid "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 msgstr "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:151
+#: src/components/ExpenseEditorValidationStatus.tsx:155
 msgid "Complete the required details"
 msgstr "Complete the required details"
 
@@ -1074,8 +1074,8 @@ msgstr "Expense added"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Expense amounts don't match total. Please check your split configuration."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:189
-#: src/components/ExpenseEditorValidationStatus.tsx:199
+#: src/components/ExpenseEditorValidationStatus.tsx:193
+#: src/components/ExpenseEditorValidationStatus.tsx:203
 msgid "Expense checks"
 msgstr "Expense checks"
 
@@ -2261,7 +2261,7 @@ msgstr "Report Issues"
 msgid "Reset password"
 msgstr "Reset password"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:202
+#: src/components/ExpenseEditorValidationStatus.tsx:206
 msgid "Resolve these issues before saving the expense."
 msgstr "Resolve these issues before saving the expense."
 
@@ -2286,7 +2286,7 @@ msgstr "Restore to home"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:214
+#: src/components/ExpenseEditorValidationStatus.tsx:218
 msgid "Review expense"
 msgstr "Review expense"
 
@@ -2438,7 +2438,7 @@ msgstr "Shares for {0}"
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:234
+#: src/components/ExpenseEditorValidationStatus.tsx:238
 msgid "Shares sum up to <0/>, while the expense amount is <1/>."
 msgstr "Shares sum up to <0/>, while the expense amount is <1/>."
 
@@ -2593,7 +2593,7 @@ msgstr "Split expenses fairly among multiple participants"
 msgid "Split expenses, stay even."
 msgstr "Split expenses, stay even."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:231
+#: src/components/ExpenseEditorValidationStatus.tsx:235
 msgid "Split total does not match"
 msgstr "Split total does not match"
 

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -211,7 +211,7 @@ msgstr "All expense checks passed"
 msgid "All time"
 msgstr "All time"
 
-#: src/components/ExpenseEditor.tsx:468
+#: src/components/ExpenseEditor.tsx:472
 msgid "Amount"
 msgstr "Amount"
 
@@ -219,11 +219,11 @@ msgstr "Amount"
 msgid "Amount for {0}"
 msgstr "Amount for {0}"
 
-#: src/components/ExpenseEditor.tsx:811
+#: src/components/ExpenseEditor.tsx:815
 msgid "Amount for {participantName}"
 msgstr "Amount for {participantName}"
 
-#: src/components/ExpenseEditor.tsx:455
+#: src/components/ExpenseEditor.tsx:459
 msgid "Amount must be greater than 0"
 msgstr "Amount must be greater than 0"
 
@@ -324,7 +324,7 @@ msgstr "Authentication error"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/components/ExpenseEditor.tsx:364
+#: src/components/ExpenseEditor.tsx:368
 #: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Auto-open calculator"
@@ -858,7 +858,7 @@ msgstr "Czech Koruna"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/ExpenseEditor.tsx:521
+#: src/components/ExpenseEditor.tsx:525
 msgid "Date"
 msgstr "Date"
 
@@ -1101,7 +1101,7 @@ msgid "Expenses counted"
 msgstr "Expenses counted"
 
 #: src/components/AvatarPicker.tsx:110
-#: src/components/ExpenseEditor.tsx:979
+#: src/components/ExpenseEditor.tsx:983
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Failed to access camera"
@@ -1146,7 +1146,7 @@ msgstr "Failed to update expense"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Failed to upload avatar. Please try again."
 
-#: src/components/ExpenseEditor.tsx:954
+#: src/components/ExpenseEditor.tsx:958
 msgid "Failed to upload, please try again"
 msgstr "Failed to upload, please try again"
 
@@ -1365,7 +1365,7 @@ msgstr "Importing attachments ({0} of {1})"
 msgid "Importing Tricount data..."
 msgstr "Importing Tricount data..."
 
-#: src/components/ExpenseEditor.tsx:573
+#: src/components/ExpenseEditor.tsx:577
 msgid "Include all"
 msgstr "Include all"
 
@@ -1624,7 +1624,7 @@ msgstr "Mauritian Rupee"
 msgid "Me"
 msgstr "Me"
 
-#: src/components/ExpenseEditor.tsx:357
+#: src/components/ExpenseEditor.tsx:361
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1881,7 +1881,7 @@ msgstr "Open archived parties"
 msgid "Open calculator"
 msgstr "Open calculator"
 
-#: src/components/ExpenseEditor.tsx:367
+#: src/components/ExpenseEditor.tsx:371
 msgid "Open calculator when focusing amount fields"
 msgstr "Open calculator when focusing amount fields"
 
@@ -1930,7 +1930,7 @@ msgstr "Paid as {currentParticipantName}"
 msgid "Paid at"
 msgstr "Paid at"
 
-#: src/components/ExpenseEditor.tsx:496
+#: src/components/ExpenseEditor.tsx:500
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Paid by"
@@ -2250,7 +2250,7 @@ msgstr "Remove"
 msgid "Remove avatar"
 msgstr "Remove avatar"
 
-#: src/components/ExpenseEditor.tsx:1071
+#: src/components/ExpenseEditor.tsx:1075
 msgid "Remove photo"
 msgstr "Remove photo"
 
@@ -2327,7 +2327,7 @@ msgstr "São Tomé and Príncipe Dobra"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/ExpenseEditor.tsx:271
+#: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2439,7 +2439,7 @@ msgstr "Shares"
 msgid "Shares for {0}"
 msgstr "Shares for {0}"
 
-#: src/components/ExpenseEditor.tsx:769
+#: src/components/ExpenseEditor.tsx:773
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
@@ -2627,7 +2627,7 @@ msgstr "Stop trizum cloud on this device"
 msgid "Submit a Request"
 msgstr "Submit a Request"
 
-#: src/components/ExpenseEditor.tsx:271
+#: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2675,11 +2675,11 @@ msgstr "Swipe between expenses and balances tabs."
 msgid "Swiss Franc"
 msgstr "Swiss Franc"
 
-#: src/components/ExpenseEditor.tsx:793
+#: src/components/ExpenseEditor.tsx:797
 msgid "Switch to a set amount"
 msgstr "Switch to a set amount"
 
-#: src/components/ExpenseEditor.tsx:794
+#: src/components/ExpenseEditor.tsx:798
 msgid "Switch to fractional split"
 msgstr "Switch to fractional split"
 
@@ -2718,8 +2718,8 @@ msgstr "Tajikistani Somoni"
 
 #: src/components/AvatarPicker.tsx:157
 #: src/components/AvatarPicker.tsx:172
-#: src/components/ExpenseEditor.tsx:999
-#: src/components/ExpenseEditor.tsx:1013
+#: src/components/ExpenseEditor.tsx:1003
+#: src/components/ExpenseEditor.tsx:1017
 msgid "Take photo"
 msgstr "Take photo"
 
@@ -2818,7 +2818,7 @@ msgstr "This stops trizum cloud on this device. Your local data stays on this de
 msgid "Timeframe"
 msgstr "Timeframe"
 
-#: src/components/ExpenseEditor.tsx:431
+#: src/components/ExpenseEditor.tsx:435
 msgid "Title"
 msgstr "Title"
 
@@ -3016,14 +3016,14 @@ msgstr "Updating expense..."
 msgid "Updating trizum..."
 msgstr "Updating trizum..."
 
-#: src/components/ExpenseEditor.tsx:899
+#: src/components/ExpenseEditor.tsx:903
 msgid "Upload or capture an image of your receipt"
 msgstr "Upload or capture an image of your receipt"
 
 #: src/components/AvatarPicker.tsx:166
 #: src/components/AvatarPicker.tsx:184
-#: src/components/ExpenseEditor.tsx:1008
-#: src/components/ExpenseEditor.tsx:1025
+#: src/components/ExpenseEditor.tsx:1012
+#: src/components/ExpenseEditor.tsx:1029
 msgid "Upload photo"
 msgstr "Upload photo"
 
@@ -3036,7 +3036,7 @@ msgstr "Uploading avatar..."
 msgid "Uploading pictures..."
 msgstr "Uploading pictures..."
 
-#: src/components/ExpenseEditor.tsx:939
+#: src/components/ExpenseEditor.tsx:943
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -3129,7 +3129,7 @@ msgstr "View on GitHub"
 msgid "View party"
 msgstr "View party"
 
-#: src/components/ExpenseEditor.tsx:1060
+#: src/components/ExpenseEditor.tsx:1064
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "View photo"

--- a/packages/pwa/locale/en/messages.po
+++ b/packages/pwa/locale/en/messages.po
@@ -24,6 +24,11 @@ msgstr "(me)"
 msgid "[DEV] Create expenses"
 msgstr "[DEV] Create expenses"
 
+#. placeholder {0}: issues.length
+#: src/components/ExpenseEditorValidationStatus.tsx:206
+msgid "{0, plural, one {# issue must be resolved before saving.} other {# issues must be resolved before saving.}}"
+msgstr "{0, plural, one {# issue must be resolved before saving.} other {# issues must be resolved before saving.}}"
+
 #. placeholder {0}: preview.remainingCount
 #: src/components/PartyListCard.tsx:324
 #: src/routes/party_.$partyId.transfer-debt/-components/DestinationPartyCard.tsx:80
@@ -2286,7 +2291,7 @@ msgstr "Restore to home"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:218
+#: src/components/ExpenseEditorValidationStatus.tsx:222
 msgid "Review expense"
 msgstr "Review expense"
 
@@ -2438,7 +2443,7 @@ msgstr "Shares for {0}"
 msgid "Shares for {participantName}"
 msgstr "Shares for {participantName}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:238
+#: src/components/ExpenseEditorValidationStatus.tsx:247
 msgid "Shares sum up to <0/>, while the expense amount is <1/>."
 msgstr "Shares sum up to <0/>, while the expense amount is <1/>."
 
@@ -2593,7 +2598,7 @@ msgstr "Split expenses fairly among multiple participants"
 msgid "Split expenses, stay even."
 msgstr "Split expenses, stay even."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:235
+#: src/components/ExpenseEditorValidationStatus.tsx:244
 msgid "Split total does not match"
 msgstr "Split total does not match"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -24,6 +24,11 @@ msgstr "(yo)"
 msgid "[DEV] Create expenses"
 msgstr "[DEV] Crear gastos"
 
+#. placeholder {0}: issues.length
+#: src/components/ExpenseEditorValidationStatus.tsx:206
+msgid "{0, plural, one {# issue must be resolved before saving.} other {# issues must be resolved before saving.}}"
+msgstr "{0, plural, one {Se debe resolver # problema antes de guardar.} other {Se deben resolver # problemas antes de guardar.}}"
+
 #. placeholder {0}: preview.remainingCount
 #: src/components/PartyListCard.tsx:324
 #: src/routes/party_.$partyId.transfer-debt/-components/DestinationPartyCard.tsx:80
@@ -2214,7 +2219,7 @@ msgstr "Restaurar al inicio"
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:218
+#: src/components/ExpenseEditorValidationStatus.tsx:222
 msgid "Review expense"
 msgstr "Revisar gasto"
 
@@ -2366,7 +2371,7 @@ msgstr "Partes para {0}"
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:238
+#: src/components/ExpenseEditorValidationStatus.tsx:247
 msgid "Shares sum up to <0/>, while the expense amount is <1/>."
 msgstr "Las partes suman <0/>, mientras que el importe del gasto es <1/>."
 
@@ -2517,7 +2522,7 @@ msgstr "Divide los gastos de forma justa entre múltiples participantes"
 msgid "Split expenses, stay even."
 msgstr "Reparte gastos, mantén las cuentas claras."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:235
+#: src/components/ExpenseEditorValidationStatus.tsx:244
 msgid "Split total does not match"
 msgstr "El total de las partes no coincide"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -1044,7 +1044,7 @@ msgid "Expense amounts don't match total. Please check your split configuration.
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
 #: src/components/ExpenseEditorValidationStatus.tsx:193
-#: src/components/ExpenseEditorValidationStatus.tsx:203
+#: src/components/ExpenseEditorValidationStatus.tsx:202
 msgid "Expense checks"
 msgstr "Comprobaciones del gasto"
 
@@ -2219,7 +2219,7 @@ msgstr "Restaurar al inicio"
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:222
+#: src/components/ExpenseEditorValidationStatus.tsx:213
 msgid "Review expense"
 msgstr "Revisar gasto"
 
@@ -2371,7 +2371,7 @@ msgstr "Partes para {0}"
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:247
+#: src/components/ExpenseEditorValidationStatus.tsx:233
 msgid "Shares sum up to <0/>, while the expense amount is <1/>."
 msgstr "Las partes suman <0/>, mientras que el importe del gasto es <1/>."
 
@@ -2522,7 +2522,7 @@ msgstr "Divide los gastos de forma justa entre múltiples participantes"
 msgid "Split expenses, stay even."
 msgstr "Reparte gastos, mantén las cuentas claras."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:244
+#: src/components/ExpenseEditorValidationStatus.tsx:230
 msgid "Split total does not match"
 msgstr "El total de las partes no coincide"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -203,7 +203,7 @@ msgstr "Todas las comprobaciones del gasto se han superado"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:468
+#: src/components/ExpenseEditor.tsx:472
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -211,11 +211,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:811
+#: src/components/ExpenseEditor.tsx:815
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:455
+#: src/components/ExpenseEditor.tsx:459
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -312,7 +312,7 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:364
+#: src/components/ExpenseEditor.tsx:368
 #: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -830,7 +830,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:521
+#: src/components/ExpenseEditor.tsx:525
 msgid "Date"
 msgstr "Fecha"
 
@@ -1061,7 +1061,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:110
-#: src/components/ExpenseEditor.tsx:979
+#: src/components/ExpenseEditor.tsx:983
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1102,7 +1102,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:954
+#: src/components/ExpenseEditor.tsx:958
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -1317,7 +1317,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:573
+#: src/components/ExpenseEditor.tsx:577
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1572,7 +1572,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:357
+#: src/components/ExpenseEditor.tsx:361
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1825,7 +1825,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:367
+#: src/components/ExpenseEditor.tsx:371
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1870,7 +1870,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:496
+#: src/components/ExpenseEditor.tsx:500
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -2178,7 +2178,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1071
+#: src/components/ExpenseEditor.tsx:1075
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2255,7 +2255,7 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:271
+#: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2367,7 +2367,7 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:769
+#: src/components/ExpenseEditor.tsx:773
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
@@ -2551,7 +2551,7 @@ msgstr "Detener trizum cloud en este dispositivo"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:271
+#: src/components/ExpenseEditor.tsx:275
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2599,11 +2599,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:793
+#: src/components/ExpenseEditor.tsx:797
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:794
+#: src/components/ExpenseEditor.tsx:798
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2642,8 +2642,8 @@ msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:157
 #: src/components/AvatarPicker.tsx:172
-#: src/components/ExpenseEditor.tsx:999
-#: src/components/ExpenseEditor.tsx:1013
+#: src/components/ExpenseEditor.tsx:1003
+#: src/components/ExpenseEditor.tsx:1017
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2742,7 +2742,7 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:431
+#: src/components/ExpenseEditor.tsx:435
 msgid "Title"
 msgstr "Título"
 
@@ -2928,14 +2928,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:899
+#: src/components/ExpenseEditor.tsx:903
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:166
 #: src/components/AvatarPicker.tsx:184
-#: src/components/ExpenseEditor.tsx:1008
-#: src/components/ExpenseEditor.tsx:1025
+#: src/components/ExpenseEditor.tsx:1012
+#: src/components/ExpenseEditor.tsx:1029
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2943,7 +2943,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:939
+#: src/components/ExpenseEditor.tsx:943
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -3032,7 +3032,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1060
+#: src/components/ExpenseEditor.tsx:1064
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -46,11 +46,11 @@ msgstr "{archivedParticipantCount, plural, one {# archivado} other {# archivados
 msgid "{archivedParticipantCount} archived"
 msgstr "{archivedParticipantCount} archivados"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:158
+#: src/components/ExpenseEditorValidationStatus.tsx:162
 msgid "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
 msgstr "{issueCount, plural, one {Se debe resolver # problema} other {Se deben resolver # problemas}}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:155
+#: src/components/ExpenseEditorValidationStatus.tsx:159
 msgid "{issueCount, plural, one {# warning} other {# warnings}}"
 msgstr "{issueCount, plural, one {# advertencia} other {# advertencias}}"
 
@@ -136,7 +136,7 @@ msgstr "Añadir un gasto"
 msgid "Add Apple as a sign-in method"
 msgstr "Añadir Apple como método de inicio de sesión"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:149
+#: src/components/ExpenseEditorValidationStatus.tsx:153
 msgid "Add expense details to get started"
 msgstr "Añade los detalles del gasto para empezar"
 
@@ -190,7 +190,7 @@ msgstr "Dinar Argelino"
 msgid "Align QR code here"
 msgstr "Alinea el código QR aquí"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:153
+#: src/components/ExpenseEditorValidationStatus.tsx:157
 msgid "All expense checks passed"
 msgstr "Todas las comprobaciones del gasto se han superado"
 
@@ -607,7 +607,7 @@ msgstr "Franco Comorense"
 msgid "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 msgstr "Compara cuánto ha pagado cada persona en distintos períodos. Las transferencias de saldos no se incluyen en estos totales."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:151
+#: src/components/ExpenseEditorValidationStatus.tsx:155
 msgid "Complete the required details"
 msgstr "Completa los datos obligatorios"
 
@@ -1038,8 +1038,8 @@ msgstr "Gasto añadido"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:189
-#: src/components/ExpenseEditorValidationStatus.tsx:199
+#: src/components/ExpenseEditorValidationStatus.tsx:193
+#: src/components/ExpenseEditorValidationStatus.tsx:203
 msgid "Expense checks"
 msgstr "Comprobaciones del gasto"
 
@@ -2189,7 +2189,7 @@ msgstr "Reportar problemas"
 msgid "Reset password"
 msgstr "Restablecer contraseña"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:202
+#: src/components/ExpenseEditorValidationStatus.tsx:206
 msgid "Resolve these issues before saving the expense."
 msgstr "Resuelve estos problemas antes de guardar el gasto."
 
@@ -2214,7 +2214,7 @@ msgstr "Restaurar al inicio"
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:214
+#: src/components/ExpenseEditorValidationStatus.tsx:218
 msgid "Review expense"
 msgstr "Revisar gasto"
 
@@ -2366,7 +2366,7 @@ msgstr "Partes para {0}"
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:234
+#: src/components/ExpenseEditorValidationStatus.tsx:238
 msgid "Shares sum up to <0/>, while the expense amount is <1/>."
 msgstr "Las partes suman <0/>, mientras que el importe del gasto es <1/>."
 
@@ -2517,7 +2517,7 @@ msgstr "Divide los gastos de forma justa entre múltiples participantes"
 msgid "Split expenses, stay even."
 msgstr "Reparte gastos, mantén las cuentas claras."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:231
+#: src/components/ExpenseEditorValidationStatus.tsx:235
 msgid "Split total does not match"
 msgstr "El total de las partes no coincide"
 

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -46,6 +46,14 @@ msgstr "{archivedParticipantCount, plural, one {# archivado} other {# archivados
 msgid "{archivedParticipantCount} archived"
 msgstr "{archivedParticipantCount} archivados"
 
+#: src/components/ExpenseEditorValidationStatus.tsx:119
+msgid "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
+msgstr "{issueCount, plural, one {Se debe resolver # problema} other {Se deben resolver # problemas}}"
+
+#: src/components/ExpenseEditorValidationStatus.tsx:116
+msgid "{issueCount, plural, one {# warning} other {# warnings}}"
+msgstr "{issueCount, plural, one {# advertencia} other {# advertencias}}"
+
 #: src/routes/migrate_.tricount.tsx:377
 msgid "{message}"
 msgstr "{message}"
@@ -128,6 +136,10 @@ msgstr "Añadir un gasto"
 msgid "Add Apple as a sign-in method"
 msgstr "Añadir Apple como método de inicio de sesión"
 
+#: src/components/ExpenseEditorValidationStatus.tsx:110
+msgid "Add expense details to get started"
+msgstr "Añade los detalles del gasto para empezar"
+
 #: src/components/PartyStatsView.tsx:850
 msgid "Add expenses to this party to unlock totals, rankings, and individual spend."
 msgstr "Añade gastos a este grupo para desbloquear totales, rankings y gasto individual."
@@ -178,11 +190,15 @@ msgstr "Dinar Argelino"
 msgid "Align QR code here"
 msgstr "Alinea el código QR aquí"
 
+#: src/components/ExpenseEditorValidationStatus.tsx:114
+msgid "All expense checks passed"
+msgstr "Todas las comprobaciones del gasto se han superado"
+
 #: src/components/PartyStatsView.tsx:183
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:442
+#: src/components/ExpenseEditor.tsx:462
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -190,11 +206,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:787
+#: src/components/ExpenseEditor.tsx:805
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:429
+#: src/components/ExpenseEditor.tsx:449
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -291,7 +307,7 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:338
+#: src/components/ExpenseEditor.tsx:358
 #: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -591,6 +607,10 @@ msgstr "Franco Comorense"
 msgid "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 msgstr "Compara cuánto ha pagado cada persona en distintos períodos. Las transferencias de saldos no se incluyen en estos totales."
 
+#: src/components/ExpenseEditorValidationStatus.tsx:112
+msgid "Complete the required details"
+msgstr "Completa los datos obligatorios"
+
 #: src/routes/index/-components/ProfileSetupCard.tsx:26
 msgid "Complete your profile"
 msgstr "Completa tu perfil"
@@ -805,7 +825,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:495
+#: src/components/ExpenseEditor.tsx:515
 msgid "Date"
 msgstr "Fecha"
 
@@ -1018,6 +1038,11 @@ msgstr "Gasto añadido"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
+#: src/components/ExpenseEditorValidationStatus.tsx:150
+#: src/components/ExpenseEditorValidationStatus.tsx:160
+msgid "Expense checks"
+msgstr "Comprobaciones del gasto"
+
 #: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:192
 msgid "Expense updated"
 msgstr "Gasto actualizado"
@@ -1031,7 +1056,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:110
-#: src/components/ExpenseEditor.tsx:1008
+#: src/components/ExpenseEditor.tsx:973
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1072,7 +1097,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:983
+#: src/components/ExpenseEditor.tsx:948
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -1287,7 +1312,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:547
+#: src/components/ExpenseEditor.tsx:567
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1542,7 +1567,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:331
+#: src/components/ExpenseEditor.tsx:351
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1795,7 +1820,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:341
+#: src/components/ExpenseEditor.tsx:361
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1840,7 +1865,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:470
+#: src/components/ExpenseEditor.tsx:490
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -2148,7 +2173,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1100
+#: src/components/ExpenseEditor.tsx:1065
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2163,6 +2188,10 @@ msgstr "Reportar problemas"
 #: src/routes/reset-password.tsx:70
 msgid "Reset password"
 msgstr "Restablecer contraseña"
+
+#: src/components/ExpenseEditorValidationStatus.tsx:163
+msgid "Resolve these issues before saving the expense."
+msgstr "Resuelve estos problemas antes de guardar el gasto."
 
 #: src/components/AppRecoveryDialog.tsx:76
 msgid "Restart app"
@@ -2184,6 +2213,10 @@ msgstr "Restaurar al inicio"
 #: src/components/PartyPendingComponent.tsx:141
 msgid "Retry"
 msgstr "Reintentar"
+
+#: src/components/ExpenseEditorValidationStatus.tsx:175
+msgid "Review expense"
+msgstr "Revisar gasto"
 
 #: src/routes/new/route.tsx:180
 msgid "Romanian Leu"
@@ -2217,7 +2250,7 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:251
+#: src/components/ExpenseEditor.tsx:265
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2329,9 +2362,13 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:745
+#: src/components/ExpenseEditor.tsx:763
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
+
+#: src/components/ExpenseEditorValidationStatus.tsx:195
+msgid "Shares sum up to <0/>, while the expense amount is <1/>."
+msgstr "Las partes suman <0/>, mientras que el importe del gasto es <1/>."
 
 #: src/components/ExpenseEditor.tsx:797
 msgid "Shares sum up to <0>{0} {1}</0> while the expense amount is <1>{amount} {2}</1>."
@@ -2480,6 +2517,10 @@ msgstr "Divide los gastos de forma justa entre múltiples participantes"
 msgid "Split expenses, stay even."
 msgstr "Reparte gastos, mantén las cuentas claras."
 
+#: src/components/ExpenseEditorValidationStatus.tsx:192
+msgid "Split total does not match"
+msgstr "El total de las partes no coincide"
+
 #: src/routes/new/route.tsx:260
 msgid "Sri Lankan Rupee"
 msgstr "Rupia de Sri Lanka"
@@ -2505,7 +2546,7 @@ msgstr "Detener trizum cloud en este dispositivo"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:251
+#: src/components/ExpenseEditor.tsx:265
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2553,11 +2594,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:769
+#: src/components/ExpenseEditor.tsx:787
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:770
+#: src/components/ExpenseEditor.tsx:788
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2596,8 +2637,8 @@ msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:157
 #: src/components/AvatarPicker.tsx:172
-#: src/components/ExpenseEditor.tsx:1028
-#: src/components/ExpenseEditor.tsx:1042
+#: src/components/ExpenseEditor.tsx:993
+#: src/components/ExpenseEditor.tsx:1007
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2696,7 +2737,7 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:405
+#: src/components/ExpenseEditor.tsx:425
 msgid "Title"
 msgstr "Título"
 
@@ -2882,14 +2923,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:928
+#: src/components/ExpenseEditor.tsx:893
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:166
 #: src/components/AvatarPicker.tsx:184
-#: src/components/ExpenseEditor.tsx:1037
-#: src/components/ExpenseEditor.tsx:1054
+#: src/components/ExpenseEditor.tsx:1002
+#: src/components/ExpenseEditor.tsx:1019
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2897,7 +2938,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:968
+#: src/components/ExpenseEditor.tsx:933
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -2986,7 +3027,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1089
+#: src/components/ExpenseEditor.tsx:1054
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/locale/es/messages.po
+++ b/packages/pwa/locale/es/messages.po
@@ -46,11 +46,11 @@ msgstr "{archivedParticipantCount, plural, one {# archivado} other {# archivados
 msgid "{archivedParticipantCount} archived"
 msgstr "{archivedParticipantCount} archivados"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:119
+#: src/components/ExpenseEditorValidationStatus.tsx:158
 msgid "{issueCount, plural, one {# issue must be resolved} other {# issues must be resolved}}"
 msgstr "{issueCount, plural, one {Se debe resolver # problema} other {Se deben resolver # problemas}}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:116
+#: src/components/ExpenseEditorValidationStatus.tsx:155
 msgid "{issueCount, plural, one {# warning} other {# warnings}}"
 msgstr "{issueCount, plural, one {# advertencia} other {# advertencias}}"
 
@@ -136,7 +136,7 @@ msgstr "Añadir un gasto"
 msgid "Add Apple as a sign-in method"
 msgstr "Añadir Apple como método de inicio de sesión"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:110
+#: src/components/ExpenseEditorValidationStatus.tsx:149
 msgid "Add expense details to get started"
 msgstr "Añade los detalles del gasto para empezar"
 
@@ -190,7 +190,7 @@ msgstr "Dinar Argelino"
 msgid "Align QR code here"
 msgstr "Alinea el código QR aquí"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:114
+#: src/components/ExpenseEditorValidationStatus.tsx:153
 msgid "All expense checks passed"
 msgstr "Todas las comprobaciones del gasto se han superado"
 
@@ -198,7 +198,7 @@ msgstr "Todas las comprobaciones del gasto se han superado"
 msgid "All time"
 msgstr "Todo el tiempo"
 
-#: src/components/ExpenseEditor.tsx:462
+#: src/components/ExpenseEditor.tsx:468
 msgid "Amount"
 msgstr "Cantidad"
 
@@ -206,11 +206,11 @@ msgstr "Cantidad"
 msgid "Amount for {0}"
 msgstr "Cantidad para {0}"
 
-#: src/components/ExpenseEditor.tsx:805
+#: src/components/ExpenseEditor.tsx:811
 msgid "Amount for {participantName}"
 msgstr "Cantidad para {participantName}"
 
-#: src/components/ExpenseEditor.tsx:449
+#: src/components/ExpenseEditor.tsx:455
 msgid "Amount must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
@@ -307,7 +307,7 @@ msgstr "Error de autenticación"
 msgid "Authentication failed"
 msgstr "No se pudo autenticar"
 
-#: src/components/ExpenseEditor.tsx:358
+#: src/components/ExpenseEditor.tsx:364
 #: src/routes/settings.tsx:242
 msgid "Auto-open calculator"
 msgstr "Abrir calculadora automáticamente"
@@ -607,7 +607,7 @@ msgstr "Franco Comorense"
 msgid "Compare how much everyone has paid across different timeframes. Settlement transfers are excluded from these totals."
 msgstr "Compara cuánto ha pagado cada persona en distintos períodos. Las transferencias de saldos no se incluyen en estos totales."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:112
+#: src/components/ExpenseEditorValidationStatus.tsx:151
 msgid "Complete the required details"
 msgstr "Completa los datos obligatorios"
 
@@ -825,7 +825,7 @@ msgstr "Corona Checa"
 msgid "Danish Krone"
 msgstr "Corona Danesa"
 
-#: src/components/ExpenseEditor.tsx:515
+#: src/components/ExpenseEditor.tsx:521
 msgid "Date"
 msgstr "Fecha"
 
@@ -917,7 +917,7 @@ msgstr "Editar"
 msgid "Editing {0}"
 msgstr "Editando {0}"
 
-#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:227
+#: src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx:228
 msgid "Editing {expenseName}"
 msgstr "Editando {expenseName}"
 
@@ -1038,8 +1038,8 @@ msgstr "Gasto añadido"
 msgid "Expense amounts don't match total. Please check your split configuration."
 msgstr "Las cantidades de los gastos no coinciden con el total. Por favor, revisa tu configuración de división."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:150
-#: src/components/ExpenseEditorValidationStatus.tsx:160
+#: src/components/ExpenseEditorValidationStatus.tsx:189
+#: src/components/ExpenseEditorValidationStatus.tsx:199
 msgid "Expense checks"
 msgstr "Comprobaciones del gasto"
 
@@ -1056,7 +1056,7 @@ msgid "Expenses counted"
 msgstr "Gastos contabilizados"
 
 #: src/components/AvatarPicker.tsx:110
-#: src/components/ExpenseEditor.tsx:973
+#: src/components/ExpenseEditor.tsx:979
 #: src/components/QRCodeScanner.tsx:111
 msgid "Failed to access camera"
 msgstr "Error al acceder a la cámara"
@@ -1097,7 +1097,7 @@ msgstr "Error al actualizar el gasto"
 msgid "Failed to upload avatar. Please try again."
 msgstr "Error al subir el avatar. Por favor, inténtalo de nuevo."
 
-#: src/components/ExpenseEditor.tsx:948
+#: src/components/ExpenseEditor.tsx:954
 msgid "Failed to upload, please try again"
 msgstr "Error al subir, por favor inténtalo de nuevo"
 
@@ -1312,7 +1312,7 @@ msgstr "Importando adjuntos ({0} de {1})"
 msgid "Importing Tricount data..."
 msgstr "Importando datos de Tricount..."
 
-#: src/components/ExpenseEditor.tsx:567
+#: src/components/ExpenseEditor.tsx:573
 msgid "Include all"
 msgstr "Incluir todos"
 
@@ -1567,7 +1567,7 @@ msgstr "Rupia de Mauricio"
 msgid "Me"
 msgstr "Yo"
 
-#: src/components/ExpenseEditor.tsx:351
+#: src/components/ExpenseEditor.tsx:357
 #: src/routes/party_.$partyId.expense.$expenseId/route.tsx:87
 #: src/routes/party.$partyId/route.tsx:172
 msgid "Menu"
@@ -1669,7 +1669,7 @@ msgstr "Rupia Nepalí"
 msgid "Netherlands Antillean Guilder"
 msgstr "Florín de las Antillas Neerlandesas"
 
-#: src/routes/party_.$partyId.add.tsx:138
+#: src/routes/party_.$partyId.add.tsx:139
 msgid "New expense"
 msgstr "Nuevo gasto"
 
@@ -1820,7 +1820,7 @@ msgstr "Abrir grupos archivados"
 msgid "Open calculator"
 msgstr "Abrir calculadora"
 
-#: src/components/ExpenseEditor.tsx:361
+#: src/components/ExpenseEditor.tsx:367
 msgid "Open calculator when focusing amount fields"
 msgstr "Abrir calculadora al enfocar campos de importe"
 
@@ -1865,7 +1865,7 @@ msgstr "Pagado por {currentParticipantName}"
 msgid "Paid at"
 msgstr "Pagado el"
 
-#: src/components/ExpenseEditor.tsx:490
+#: src/components/ExpenseEditor.tsx:496
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PaidBy.tsx:48
 msgid "Paid by"
 msgstr "Pagado por"
@@ -2173,7 +2173,7 @@ msgstr "Eliminar"
 msgid "Remove avatar"
 msgstr "Eliminar avatar"
 
-#: src/components/ExpenseEditor.tsx:1065
+#: src/components/ExpenseEditor.tsx:1071
 msgid "Remove photo"
 msgstr "Eliminar foto"
 
@@ -2189,7 +2189,7 @@ msgstr "Reportar problemas"
 msgid "Reset password"
 msgstr "Restablecer contraseña"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:163
+#: src/components/ExpenseEditorValidationStatus.tsx:202
 msgid "Resolve these issues before saving the expense."
 msgstr "Resuelve estos problemas antes de guardar el gasto."
 
@@ -2214,7 +2214,7 @@ msgstr "Restaurar al inicio"
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:175
+#: src/components/ExpenseEditorValidationStatus.tsx:214
 msgid "Review expense"
 msgstr "Revisar gasto"
 
@@ -2250,7 +2250,7 @@ msgstr "Dobra de Santo Tomé y Príncipe"
 msgid "Saudi Riyal"
 msgstr "Riyal Saudí"
 
-#: src/components/ExpenseEditor.tsx:265
+#: src/components/ExpenseEditor.tsx:271
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2362,11 +2362,11 @@ msgstr "Partes"
 msgid "Shares for {0}"
 msgstr "Partes para {0}"
 
-#: src/components/ExpenseEditor.tsx:763
+#: src/components/ExpenseEditor.tsx:769
 msgid "Shares for {participantName}"
 msgstr "Partes para {participantName}"
 
-#: src/components/ExpenseEditorValidationStatus.tsx:195
+#: src/components/ExpenseEditorValidationStatus.tsx:234
 msgid "Shares sum up to <0/>, while the expense amount is <1/>."
 msgstr "Las partes suman <0/>, mientras que el importe del gasto es <1/>."
 
@@ -2517,7 +2517,7 @@ msgstr "Divide los gastos de forma justa entre múltiples participantes"
 msgid "Split expenses, stay even."
 msgstr "Reparte gastos, mantén las cuentas claras."
 
-#: src/components/ExpenseEditorValidationStatus.tsx:192
+#: src/components/ExpenseEditorValidationStatus.tsx:231
 msgid "Split total does not match"
 msgstr "El total de las partes no coincide"
 
@@ -2546,7 +2546,7 @@ msgstr "Detener trizum cloud en este dispositivo"
 msgid "Submit a Request"
 msgstr "Enviar sugerencia"
 
-#: src/components/ExpenseEditor.tsx:265
+#: src/components/ExpenseEditor.tsx:271
 #: src/routes/migrate_.tricount/-components/IdleState.tsx:50
 #: src/routes/new/route.tsx:124
 #: src/routes/party_.$partyId.settings/details.tsx:59
@@ -2594,11 +2594,11 @@ msgstr "Desliza entre las pestañas de gastos y balance."
 msgid "Swiss Franc"
 msgstr "Franco Suizo"
 
-#: src/components/ExpenseEditor.tsx:787
+#: src/components/ExpenseEditor.tsx:793
 msgid "Switch to a set amount"
 msgstr "Cambiar a una cantidad fija"
 
-#: src/components/ExpenseEditor.tsx:788
+#: src/components/ExpenseEditor.tsx:794
 msgid "Switch to fractional split"
 msgstr "Cambiar a división fraccional"
 
@@ -2637,8 +2637,8 @@ msgstr "Somoni Tayiko"
 
 #: src/components/AvatarPicker.tsx:157
 #: src/components/AvatarPicker.tsx:172
-#: src/components/ExpenseEditor.tsx:993
-#: src/components/ExpenseEditor.tsx:1007
+#: src/components/ExpenseEditor.tsx:999
+#: src/components/ExpenseEditor.tsx:1013
 msgid "Take photo"
 msgstr "Hacer foto"
 
@@ -2737,7 +2737,7 @@ msgstr "Esto detiene trizum cloud en este dispositivo. Tus datos locales se qued
 msgid "Timeframe"
 msgstr "Período"
 
-#: src/components/ExpenseEditor.tsx:425
+#: src/components/ExpenseEditor.tsx:431
 msgid "Title"
 msgstr "Título"
 
@@ -2923,14 +2923,14 @@ msgstr "Actualizando gasto..."
 msgid "Updating trizum..."
 msgstr "Actualizando trizum..."
 
-#: src/components/ExpenseEditor.tsx:893
+#: src/components/ExpenseEditor.tsx:899
 msgid "Upload or capture an image of your receipt"
 msgstr "Sube o captura una imagen de tu recibo"
 
 #: src/components/AvatarPicker.tsx:166
 #: src/components/AvatarPicker.tsx:184
-#: src/components/ExpenseEditor.tsx:1002
-#: src/components/ExpenseEditor.tsx:1019
+#: src/components/ExpenseEditor.tsx:1008
+#: src/components/ExpenseEditor.tsx:1025
 msgid "Upload photo"
 msgstr "Subir foto"
 
@@ -2938,7 +2938,7 @@ msgstr "Subir foto"
 msgid "Uploading avatar..."
 msgstr "Subiendo avatar..."
 
-#: src/components/ExpenseEditor.tsx:933
+#: src/components/ExpenseEditor.tsx:939
 msgid "Uploading..."
 msgstr "Subiendo..."
 
@@ -3027,7 +3027,7 @@ msgstr "Ver en GitHub"
 msgid "View party"
 msgstr "Ver grupo"
 
-#: src/components/ExpenseEditor.tsx:1054
+#: src/components/ExpenseEditor.tsx:1060
 #: src/routes/party_.$partyId.expense.$expenseId/-components/PhotoItemById.tsx:11
 msgid "View photo"
 msgstr "Ver foto"

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -43,7 +43,6 @@ import { MediaGalleryContext } from "./MediaGalleryContext";
 import type { AppFormApi } from "#src/lib/reactFormTypes.ts";
 import {
   type ExpenseEditorMode,
-  getExpenseEditorValidationIssues,
   getExpenseEditorValidationResult,
   getExpenseEditorUnitShares,
 } from "#src/lib/expenseEditor.ts";
@@ -135,12 +134,17 @@ export function ExpenseEditor({
         return;
       }
 
-      const blockingIssues = getExpenseEditorValidationIssues(value).filter(
-        (issue) => issue.severity === "error",
-      );
+      const submissionValidation = getExpenseEditorValidationResult(value, {
+        isDirty: true,
+        mode,
+      });
 
-      if (blockingIssues.length > 0) {
+      if (submissionValidation.status === "error") {
         setIsValidationDialogOpen(true);
+        return;
+      }
+
+      if (submissionValidation.status !== "valid" && submissionValidation.status !== "warning") {
         return;
       }
 

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -42,6 +42,7 @@ import { getLogger } from "#src/lib/log.ts";
 import { MediaGalleryContext } from "./MediaGalleryContext";
 import type { AppFormApi } from "#src/lib/reactFormTypes.ts";
 import {
+  type ExpenseEditorMode,
   getExpenseEditorValidationIssues,
   getExpenseEditorValidationResult,
   getExpenseEditorUnitShares,
@@ -64,6 +65,7 @@ export interface ExpenseEditorRef {
 const logger = getLogger("components", "ExpenseEditor");
 
 interface ExpenseEditorProps {
+  mode: ExpenseEditorMode;
   title: string;
   onSubmit: (values: ExpenseEditorFormValues) => void | Promise<void>;
   onChange?: (
@@ -88,6 +90,7 @@ type FieldFocusHandlersFactory = (field: { name: string; handleBlur: () => void 
 };
 
 export function ExpenseEditor({
+  mode,
   title,
   onSubmit,
   defaultValues,
@@ -176,7 +179,10 @@ export function ExpenseEditor({
   const paidBy = useStore(form.store, (state) => state.values.paidBy);
   const photos = useStore(form.store, (state) => state.values.photos);
   const isDirty = useStore(form.store, (state) => state.isDirty);
-  const validation = getExpenseEditorValidationResult({ amount, name, paidBy, shares }, isDirty);
+  const validation = getExpenseEditorValidationResult(
+    { amount, name, paidBy, shares },
+    { isDirty, mode },
+  );
 
   const isReceivingUpdatesRef = useRef(false);
   const focusedFieldRef = useRef<keyof ExpenseEditorFormValues | null>(null);

--- a/packages/pwa/src/components/ExpenseEditor.tsx
+++ b/packages/pwa/src/components/ExpenseEditor.tsx
@@ -3,7 +3,7 @@ import { t } from "@lingui/core/macro";
 import type { ExpenseUser } from "#src/lib/expenses.js";
 import { useForm, useStore, type Updater } from "@tanstack/react-form";
 import { BackButton } from "./BackButton";
-import { Suspense, use, useEffect, useId, useImperativeHandle, useRef } from "react";
+import { Suspense, use, useEffect, useId, useImperativeHandle, useRef, useState } from "react";
 import { IconButton } from "#src/ui/IconButton.js";
 import { useLingui } from "@lingui/react";
 import { validateExpenseTitle } from "#src/lib/validation.js";
@@ -12,14 +12,12 @@ import { CurrencyField } from "./CurrencyField";
 import { convertToUnits } from "#src/lib/expenses.js";
 import { toast } from "sonner";
 import { useExpenseParticipants } from "#src/hooks/useExpenseParticipants.ts";
-import { useCurrentParty } from "#src/hooks/useParty.ts";
 import { Checkbox } from "#src/ui/Checkbox.tsx";
 import type { PartyParticipant } from "#src/models/party.ts";
 import { AppSelect, SelectItem } from "#src/ui/Select.tsx";
 import { Tooltip, TooltipTrigger } from "#src/ui/Tooltip.tsx";
 import { AppDatePicker } from "#src/ui/DatePicker.tsx";
 import { fromDate, getLocalTimeZone, type ZonedDateTime } from "@internationalized/date";
-import { Alert, AlertDescription, AlertTitle } from "#src/ui/Alert.tsx";
 import { Icon } from "#src/ui/Icon.tsx";
 import { Button } from "#src/ui/Button.tsx";
 import { MenuTrigger, Popover } from "react-aria-components";
@@ -44,9 +42,11 @@ import { getLogger } from "#src/lib/log.ts";
 import { MediaGalleryContext } from "./MediaGalleryContext";
 import type { AppFormApi } from "#src/lib/reactFormTypes.ts";
 import {
-  expenseEditorSharesMatchAmount,
+  getExpenseEditorValidationIssues,
+  getExpenseEditorValidationResult,
   getExpenseEditorUnitShares,
 } from "#src/lib/expenseEditor.ts";
+import { ExpenseEditorValidationStatus } from "./ExpenseEditorValidationStatus.tsx";
 
 export interface ExpenseEditorFormValues {
   name: string;
@@ -104,6 +104,7 @@ export function ExpenseEditor({
   const { partyList, setAutoOpenCalculator } = usePartyList();
   const autoOpenCalculator = partyList.autoOpenCalculator ?? false;
   const saveInFlightRef = useRef(false);
+  const [isValidationDialogOpen, setIsValidationDialogOpen] = useState(false);
   const unsortedParticipants = useExpenseParticipants({
     paidBy: {
       [defaultValues.paidBy]: 1,
@@ -131,8 +132,12 @@ export function ExpenseEditor({
         return;
       }
 
-      if (!expenseEditorSharesMatchAmount(value.amount, value.shares)) {
-        toast.error(t`Expense amounts don't match total. Please check your split configuration.`);
+      const blockingIssues = getExpenseEditorValidationIssues(value).filter(
+        (issue) => issue.severity === "error",
+      );
+
+      if (blockingIssues.length > 0) {
+        setIsValidationDialogOpen(true);
         return;
       }
 
@@ -167,7 +172,11 @@ export function ExpenseEditor({
 
   const shares = useStore(form.store, (state) => state.values.shares);
   const amount = useStore(form.store, (state) => state.values.amount);
+  const name = useStore(form.store, (state) => state.values.name);
+  const paidBy = useStore(form.store, (state) => state.values.paidBy);
   const photos = useStore(form.store, (state) => state.values.photos);
+  const isDirty = useStore(form.store, (state) => state.isDirty);
+  const validation = getExpenseEditorValidationResult({ amount, name, paidBy, shares }, isDirty);
 
   const isReceivingUpdatesRef = useRef(false);
   const focusedFieldRef = useRef<keyof ExpenseEditorFormValues | null>(null);
@@ -214,17 +223,22 @@ export function ExpenseEditor({
   );
 
   useEffect(() => {
-    if (!onChange) {
-      return;
-    }
-
     previousValuesRef.current = form.store.state.values;
 
     const subscription = form.store.subscribe((currentState) => {
       const previousValues = previousValuesRef.current;
       previousValuesRef.current = currentState.values;
 
-      if (isReceivingUpdatesRef.current) {
+      if (
+        previousValues.amount !== currentState.values.amount ||
+        previousValues.name !== currentState.values.name ||
+        previousValues.paidBy !== currentState.values.paidBy ||
+        previousValues.shares !== currentState.values.shares
+      ) {
+        setIsValidationDialogOpen(false);
+      }
+
+      if (isReceivingUpdatesRef.current || !onChange) {
         return;
       }
 
@@ -260,6 +274,12 @@ export function ExpenseEditor({
           </form.Subscribe>
         }
         title={title}
+      />
+
+      <ExpenseEditorValidationStatus
+        isOpen={isValidationDialogOpen}
+        onOpenChange={setIsValidationDialogOpen}
+        validation={validation}
       />
 
       <form
@@ -564,8 +584,6 @@ function ExpenseParticipantsSection({
           />
         ))}
       </div>
-
-      <SharesWarning amount={amount} shares={shares} />
     </div>
   );
 }
@@ -852,59 +870,6 @@ function calculateParticipantUnitAmounts(
   shares: Record<ExpenseUser, { type: "divide" | "exact"; value: number }>,
 ) {
   return getExpenseEditorUnitShares(amount, shares);
-}
-
-interface SharesWarningProps {
-  amount: number;
-  shares: Record<ExpenseUser, { type: "divide" | "exact"; value: number }>;
-}
-
-function SharesWarning({ amount, shares }: SharesWarningProps) {
-  const { party } = useCurrentParty();
-  const activeParticipants = Object.keys(shares);
-
-  if (activeParticipants.length === 0) {
-    return null;
-  }
-
-  const unitAmounts = calculateParticipantUnitAmounts(amount, shares);
-  const totalUnitAmount = Object.values(unitAmounts).reduce((sum, amount) => sum + amount, 0);
-  const showWarning = totalUnitAmount - convertToUnits(amount) !== 0;
-  const currency = party.currency;
-  const totalAmount = totalUnitAmount / 100;
-  const expenseAmount = amount;
-
-  if (!showWarning) {
-    return null;
-  }
-
-  return (
-    <Alert variant="default">
-      <Icon icon="lucide.badge-info" />
-
-      <AlertTitle>{t`Heads up!`}</AlertTitle>
-
-      <AlertDescription>
-        <p>
-          <Trans>
-            Shares sum up to{" "}
-            <strong>
-              {totalAmount} {currency}
-            </strong>{" "}
-            while the expense amount is{" "}
-            <strong>
-              {expenseAmount} {currency}
-            </strong>
-            .
-          </Trans>
-        </p>
-
-        <p>
-          <Trans>Please correct it before saving.</Trans>
-        </p>
-      </AlertDescription>
-    </Alert>
-  );
 }
 
 interface PhotosFieldProps {

--- a/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
+++ b/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
@@ -116,10 +116,14 @@ export function ExpenseEditorValidationStatus({
                         statusBarClassName,
                         appearance.className,
                         "justify-start rounded-lg",
-                        (isHovered || isFocusVisible) && "brightness-95 dark:brightness-110",
-                        isFocusVisible &&
+                        !isOpen &&
+                          (isHovered || isFocusVisible) &&
+                          "brightness-95 dark:brightness-110",
+                        !isOpen &&
+                          isFocusVisible &&
                           "ring-2 ring-current ring-offset-2 ring-offset-white dark:ring-offset-accent-950",
-                        isPressed && "brightness-90 dark:brightness-125",
+                        !isOpen && isPressed && "brightness-90 dark:brightness-125",
+                        isOpen && "scale-100 brightness-100 dark:brightness-100",
                       )
                     }
                     type="button"

--- a/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
+++ b/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
@@ -194,25 +194,16 @@ function ExpenseEditorValidationDialog({ issues }: { issues: ExpenseEditorValida
           className="border-accent-200 dark:border-accent-800 dark:bg-accent-950 max-h-[inherit] overflow-y-auto rounded-lg border bg-white shadow-2xl outline-hidden"
         >
           <div className="flex flex-col gap-5 p-5 sm:p-6">
-            <div className="flex items-start gap-3">
-              <span className="text-danger-600 dark:text-danger-300 flex size-9 shrink-0 items-center justify-center">
-                <Icon icon="lucide.circle-alert" className="size-6" />
+            <div className="flex flex-col gap-3">
+              <span className="bg-danger-50 text-danger-600 dark:bg-danger-950/50 dark:text-danger-300 flex size-10 items-center justify-center rounded-full">
+                <Icon icon="lucide.circle-alert" className="size-5" />
               </span>
-              <div className="min-w-0 flex-1">
-                <h2 className="text-lg font-medium">
-                  <Trans>Expense checks</Trans>
-                </h2>
-                <p className="text-accent-700 dark:text-accent-200 mt-1 text-sm">
-                  <Plural
-                    value={issues.length}
-                    one="# issue must be resolved before saving."
-                    other="# issues must be resolved before saving."
-                  />
-                </p>
-              </div>
+              <h2 className="text-lg font-medium">
+                <Trans>Expense checks</Trans>
+              </h2>
             </div>
 
-            <ul className="divide-accent-200 dark:divide-accent-800 flex flex-col divide-y">
+            <ul className="border-accent-200 divide-accent-200 dark:border-accent-800 dark:divide-accent-800 flex flex-col divide-y border-y">
               {issues.map((issue) => (
                 <ExpenseEditorValidationIssueItem issue={issue} key={issue.code} />
               ))}
@@ -234,35 +225,29 @@ function ExpenseEditorValidationIssueItem({ issue }: { issue: ExpenseEditorValid
   switch (issue.code) {
     case "shares-total-mismatch":
       return (
-        <li className="flex gap-3 py-4 first:pt-0 last:pb-0">
-          <Icon
-            icon="lucide.circle-alert"
-            className="text-danger-600 dark:text-danger-300 mt-0.5 size-5 shrink-0"
-          />
-          <div className="min-w-0 flex-1">
-            <h3 className="font-medium">
-              <Trans>Split total does not match</Trans>
-            </h3>
-            <p className="text-accent-700 dark:text-accent-200 mt-1 text-sm">
-              <Trans>
-                Shares sum up to{" "}
-                <CurrencyText
-                  amount={issue.sharesTotal}
-                  currency={party.currency}
-                  className="font-semibold"
-                  variant="inherit"
-                />
-                , while the expense amount is{" "}
-                <CurrencyText
-                  amount={issue.expenseAmount}
-                  currency={party.currency}
-                  className="font-semibold"
-                  variant="inherit"
-                />
-                .
-              </Trans>
-            </p>
-          </div>
+        <li className="py-4">
+          <h3 className="font-medium">
+            <Trans>Split total does not match</Trans>
+          </h3>
+          <p className="text-accent-700 dark:text-accent-200 mt-1 text-sm">
+            <Trans>
+              Shares sum up to{" "}
+              <CurrencyText
+                amount={issue.sharesTotal}
+                currency={party.currency}
+                className="font-semibold"
+                variant="inherit"
+              />
+              , while the expense amount is{" "}
+              <CurrencyText
+                amount={issue.expenseAmount}
+                currency={party.currency}
+                className="font-semibold"
+                variant="inherit"
+              />
+              .
+            </Trans>
+          </p>
         </li>
       );
   }

--- a/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
+++ b/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
@@ -1,5 +1,12 @@
 import { t } from "@lingui/core/macro";
 import { Plural, Trans } from "@lingui/react/macro";
+import {
+  AnimatePresence,
+  LazyMotion,
+  domAnimation,
+  m as motion,
+  useReducedMotion,
+} from "motion/react";
 import { Dialog, DialogTrigger, Modal, ModalOverlay } from "react-aria-components";
 import { CurrencyText } from "#src/components/CurrencyText.tsx";
 import { useCurrentParty } from "#src/hooks/useParty.ts";
@@ -60,6 +67,7 @@ export function ExpenseEditorValidationStatus({
   validation,
 }: ExpenseEditorValidationStatusProps) {
   const appearance = statusAppearances[validation.status];
+  const shouldReduceMotion = useReducedMotion();
   const content = (
     <>
       <Icon icon={appearance.icon} className="size-5 shrink-0" />
@@ -77,23 +85,54 @@ export function ExpenseEditorValidationStatus({
 
   return (
     <div aria-live="polite" className="container px-4">
-      {validation.issues.length === 0 ? (
-        <output className={cn(statusBarClassName, appearance.className)}>{content}</output>
-      ) : (
-        <DialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
-          <Button
-            className={cn(
-              statusBarClassName,
-              appearance.className,
-              "justify-start rounded-lg transition-colors",
-            )}
-            type="button"
-          >
-            {content}
-          </Button>
-          <ExpenseEditorValidationDialog issues={validation.issues} />
-        </DialogTrigger>
-      )}
+      <LazyMotion features={domAnimation}>
+        <div className="relative h-12">
+          <AnimatePresence initial={false}>
+            <motion.div
+              key={validation.status}
+              animate={{ opacity: 1, transform: "translateY(0)" }}
+              className="absolute inset-0"
+              exit={{
+                opacity: 0,
+                transform: shouldReduceMotion ? "translateY(0)" : "translateY(-3px)",
+              }}
+              initial={{
+                opacity: 0,
+                transform: shouldReduceMotion ? "translateY(0)" : "translateY(3px)",
+              }}
+              transition={
+                shouldReduceMotion
+                  ? { duration: 0.1 }
+                  : { duration: 0.18, ease: [0.23, 1, 0.32, 1] }
+              }
+            >
+              {validation.issues.length === 0 ? (
+                <output className={cn(statusBarClassName, appearance.className)}>{content}</output>
+              ) : (
+                <DialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
+                  <Button
+                    className={({ isFocusVisible, isHovered, isPressed }) =>
+                      cn(
+                        statusBarClassName,
+                        appearance.className,
+                        "justify-start rounded-lg",
+                        (isHovered || isFocusVisible) && "brightness-95 dark:brightness-110",
+                        isFocusVisible &&
+                          "ring-2 ring-current ring-offset-2 ring-offset-white dark:ring-offset-accent-950",
+                        isPressed && "brightness-90 dark:brightness-125",
+                      )
+                    }
+                    type="button"
+                  >
+                    {content}
+                  </Button>
+                  <ExpenseEditorValidationDialog issues={validation.issues} />
+                </DialogTrigger>
+              )}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </LazyMotion>
     </div>
   );
 }

--- a/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
+++ b/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
@@ -1,0 +1,216 @@
+import { t } from "@lingui/core/macro";
+import { Plural, Trans } from "@lingui/react/macro";
+import { Dialog, DialogTrigger, Modal, ModalOverlay } from "react-aria-components";
+import { CurrencyText } from "#src/components/CurrencyText.tsx";
+import { useCurrentParty } from "#src/hooks/useParty.ts";
+import type {
+  ExpenseEditorValidationIssue,
+  ExpenseEditorValidationResult,
+  ExpenseEditorValidationStatus,
+} from "#src/lib/expenseEditor.ts";
+import { Button } from "#src/ui/Button.tsx";
+import { Icon, type IconProps } from "#src/ui/Icon.tsx";
+import { cn } from "#src/ui/utils.ts";
+
+interface ExpenseEditorValidationStatusProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  validation: ExpenseEditorValidationResult;
+}
+
+interface StatusAppearance {
+  className: string;
+  icon: IconProps["icon"];
+}
+
+const statusAppearances: Record<ExpenseEditorValidationStatus, StatusAppearance> = {
+  pristine: {
+    className:
+      "border-accent-400 bg-accent-50 text-accent-700 dark:border-accent-700 dark:bg-accent-900 dark:text-accent-200",
+    icon: "lucide.badge-info",
+  },
+  incomplete: {
+    className:
+      "border-accent-400 bg-accent-50 text-accent-700 dark:border-accent-700 dark:bg-accent-900 dark:text-accent-200",
+    icon: "lucide.badge-info",
+  },
+  valid: {
+    className:
+      "border-success-400 bg-success-50 text-success-700 dark:border-success-700 dark:bg-success-950/40 dark:text-success-200",
+    icon: "lucide.circle-check",
+  },
+  warning: {
+    className:
+      "border-warning-500 bg-warning-50 text-warning-800 dark:border-warning-700 dark:bg-warning-950/40 dark:text-warning-200",
+    icon: "lucide.triangle-alert",
+  },
+  error: {
+    className:
+      "border-danger-500 bg-danger-50 text-danger-700 dark:border-danger-700 dark:bg-danger-950/40 dark:text-danger-200",
+    icon: "lucide.circle-alert",
+  },
+};
+
+const statusBarClassName =
+  "flex h-12 w-full items-center gap-3 rounded-lg border px-4 text-left text-sm font-medium";
+
+export function ExpenseEditorValidationStatus({
+  isOpen,
+  onOpenChange,
+  validation,
+}: ExpenseEditorValidationStatusProps) {
+  const appearance = statusAppearances[validation.status];
+  const content = (
+    <>
+      <Icon icon={appearance.icon} className="size-5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">
+        <ExpenseEditorStatusMessage
+          issueCount={validation.issues.length}
+          status={validation.status}
+        />
+      </span>
+      {validation.issues.length > 0 ? (
+        <Icon icon="lucide.chevron-right" className="size-5 shrink-0" />
+      ) : null}
+    </>
+  );
+
+  return (
+    <div aria-live="polite" className="container px-4">
+      {validation.issues.length === 0 ? (
+        <output className={cn(statusBarClassName, appearance.className)}>{content}</output>
+      ) : (
+        <DialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
+          <Button
+            className={cn(
+              statusBarClassName,
+              appearance.className,
+              "justify-start rounded-lg transition-colors",
+            )}
+            type="button"
+          >
+            {content}
+          </Button>
+          <ExpenseEditorValidationDialog issues={validation.issues} />
+        </DialogTrigger>
+      )}
+    </div>
+  );
+}
+
+function ExpenseEditorStatusMessage({
+  issueCount,
+  status,
+}: {
+  issueCount: number;
+  status: ExpenseEditorValidationStatus;
+}) {
+  switch (status) {
+    case "pristine":
+      return <Trans>Add expense details to get started</Trans>;
+    case "incomplete":
+      return <Trans>Complete the required details</Trans>;
+    case "valid":
+      return <Trans>All expense checks passed</Trans>;
+    case "warning":
+      return <Plural value={issueCount} one="# warning" other="# warnings" />;
+    case "error":
+      return (
+        <Plural
+          value={issueCount}
+          one="# issue must be resolved"
+          other="# issues must be resolved"
+        />
+      );
+  }
+}
+
+function ExpenseEditorValidationDialog({ issues }: { issues: ExpenseEditorValidationIssue[] }) {
+  return (
+    <ModalOverlay
+      isDismissable
+      className={({ isEntering, isExiting }) =>
+        cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-accent-950/45 px-safe-or-4 py-safe-offset-6 backdrop-blur-md",
+          isEntering && "duration-200 ease-out animate-in fade-in",
+          isExiting && "duration-150 ease-in animate-out fade-out",
+        )
+      }
+    >
+      <Modal
+        className={({ isEntering, isExiting }) =>
+          cn(
+            "max-h-[calc(var(--visual-viewport-height)*0.9)] w-full max-w-[420px] outline-hidden",
+            isEntering && "duration-200 ease-out animate-in fade-in zoom-in-95",
+            isExiting && "duration-150 ease-in animate-out fade-out zoom-out-95",
+          )
+        }
+      >
+        <Dialog
+          aria-label={t`Expense checks`}
+          className="border-accent-200 dark:border-accent-800 dark:bg-accent-950 max-h-[inherit] overflow-y-auto rounded-lg border bg-white shadow-2xl outline-hidden"
+        >
+          <div className="flex flex-col gap-5 p-5 sm:p-6">
+            <div className="flex flex-col gap-3">
+              <span className="bg-danger-50 text-danger-600 dark:bg-danger-950/50 dark:text-danger-300 flex size-10 items-center justify-center rounded-full">
+                <Icon icon="lucide.circle-alert" className="size-5" />
+              </span>
+              <div className="flex flex-col gap-2">
+                <h2 className="text-lg font-medium">
+                  <Trans>Expense checks</Trans>
+                </h2>
+                <p className="text-accent-700 dark:text-accent-200 text-sm">
+                  <Trans>Resolve these issues before saving the expense.</Trans>
+                </p>
+              </div>
+            </div>
+
+            <ul className="flex flex-col gap-3">
+              {issues.map((issue) => (
+                <ExpenseEditorValidationIssueItem issue={issue} key={issue.code} />
+              ))}
+            </ul>
+
+            <Button className="font-semibold" color="accent" slot="close" type="button">
+              <Trans>Review expense</Trans>
+            </Button>
+          </div>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}
+
+function ExpenseEditorValidationIssueItem({ issue }: { issue: ExpenseEditorValidationIssue }) {
+  const { party } = useCurrentParty();
+
+  switch (issue.code) {
+    case "shares-total-mismatch":
+      return (
+        <li className="border-danger-200 bg-danger-50/60 dark:border-danger-900 dark:bg-danger-950/30 rounded-lg border p-4">
+          <h3 className="text-danger-800 dark:text-danger-200 font-medium">
+            <Trans>Split total does not match</Trans>
+          </h3>
+          <p className="text-danger-700 dark:text-danger-300 mt-1 text-sm">
+            <Trans>
+              Shares sum up to{" "}
+              <CurrencyText
+                amount={issue.sharesTotal}
+                currency={party.currency}
+                className="font-semibold"
+                variant="inherit"
+              />
+              , while the expense amount is{" "}
+              <CurrencyText
+                amount={issue.expenseAmount}
+                currency={party.currency}
+                className="font-semibold"
+                variant="inherit"
+              />
+              .
+            </Trans>
+          </p>
+        </li>
+      );
+  }
+}

--- a/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
+++ b/packages/pwa/src/components/ExpenseEditorValidationStatus.tsx
@@ -194,21 +194,25 @@ function ExpenseEditorValidationDialog({ issues }: { issues: ExpenseEditorValida
           className="border-accent-200 dark:border-accent-800 dark:bg-accent-950 max-h-[inherit] overflow-y-auto rounded-lg border bg-white shadow-2xl outline-hidden"
         >
           <div className="flex flex-col gap-5 p-5 sm:p-6">
-            <div className="flex flex-col gap-3">
-              <span className="bg-danger-50 text-danger-600 dark:bg-danger-950/50 dark:text-danger-300 flex size-10 items-center justify-center rounded-full">
-                <Icon icon="lucide.circle-alert" className="size-5" />
+            <div className="flex items-start gap-3">
+              <span className="text-danger-600 dark:text-danger-300 flex size-9 shrink-0 items-center justify-center">
+                <Icon icon="lucide.circle-alert" className="size-6" />
               </span>
-              <div className="flex flex-col gap-2">
+              <div className="min-w-0 flex-1">
                 <h2 className="text-lg font-medium">
                   <Trans>Expense checks</Trans>
                 </h2>
-                <p className="text-accent-700 dark:text-accent-200 text-sm">
-                  <Trans>Resolve these issues before saving the expense.</Trans>
+                <p className="text-accent-700 dark:text-accent-200 mt-1 text-sm">
+                  <Plural
+                    value={issues.length}
+                    one="# issue must be resolved before saving."
+                    other="# issues must be resolved before saving."
+                  />
                 </p>
               </div>
             </div>
 
-            <ul className="flex flex-col gap-3">
+            <ul className="divide-accent-200 dark:divide-accent-800 flex flex-col divide-y">
               {issues.map((issue) => (
                 <ExpenseEditorValidationIssueItem issue={issue} key={issue.code} />
               ))}
@@ -230,29 +234,35 @@ function ExpenseEditorValidationIssueItem({ issue }: { issue: ExpenseEditorValid
   switch (issue.code) {
     case "shares-total-mismatch":
       return (
-        <li className="border-danger-200 bg-danger-50/60 dark:border-danger-900 dark:bg-danger-950/30 rounded-lg border p-4">
-          <h3 className="text-danger-800 dark:text-danger-200 font-medium">
-            <Trans>Split total does not match</Trans>
-          </h3>
-          <p className="text-danger-700 dark:text-danger-300 mt-1 text-sm">
-            <Trans>
-              Shares sum up to{" "}
-              <CurrencyText
-                amount={issue.sharesTotal}
-                currency={party.currency}
-                className="font-semibold"
-                variant="inherit"
-              />
-              , while the expense amount is{" "}
-              <CurrencyText
-                amount={issue.expenseAmount}
-                currency={party.currency}
-                className="font-semibold"
-                variant="inherit"
-              />
-              .
-            </Trans>
-          </p>
+        <li className="flex gap-3 py-4 first:pt-0 last:pb-0">
+          <Icon
+            icon="lucide.circle-alert"
+            className="text-danger-600 dark:text-danger-300 mt-0.5 size-5 shrink-0"
+          />
+          <div className="min-w-0 flex-1">
+            <h3 className="font-medium">
+              <Trans>Split total does not match</Trans>
+            </h3>
+            <p className="text-accent-700 dark:text-accent-200 mt-1 text-sm">
+              <Trans>
+                Shares sum up to{" "}
+                <CurrencyText
+                  amount={issue.sharesTotal}
+                  currency={party.currency}
+                  className="font-semibold"
+                  variant="inherit"
+                />
+                , while the expense amount is{" "}
+                <CurrencyText
+                  amount={issue.expenseAmount}
+                  currency={party.currency}
+                  className="font-semibold"
+                  variant="inherit"
+                />
+                .
+              </Trans>
+            </p>
+          </div>
         </li>
       );
   }

--- a/packages/pwa/src/lib/expenseEditor.test.ts
+++ b/packages/pwa/src/lib/expenseEditor.test.ts
@@ -121,6 +121,21 @@ describe("expense editor validation status", () => {
     ).toMatchObject({ issues: [], status: "incomplete" });
   });
 
+  test.each(["create", "edit"] as const)(
+    "blocks %s submission when no participants are selected",
+    (mode) => {
+      expect(
+        getExpenseEditorValidationResult(
+          {
+            ...completeExpense,
+            shares: {},
+          },
+          { isDirty: true, mode },
+        ),
+      ).toMatchObject({ issues: [], status: "incomplete" });
+    },
+  );
+
   test("is valid when required values and form-wide checks pass", () => {
     expect(
       getExpenseEditorValidationResult(completeExpense, { isDirty: true, mode: "create" }),

--- a/packages/pwa/src/lib/expenseEditor.test.ts
+++ b/packages/pwa/src/lib/expenseEditor.test.ts
@@ -77,11 +77,34 @@ describe("expense editor shares", () => {
 });
 
 describe("expense editor validation status", () => {
-  test("starts pristine when a valid form has not changed", () => {
-    expect(getExpenseEditorValidationResult(completeExpense, false)).toMatchObject({
+  test("starts pristine when a valid create form has not changed", () => {
+    expect(
+      getExpenseEditorValidationResult(completeExpense, { isDirty: false, mode: "create" }),
+    ).toMatchObject({
       issues: [],
       status: "pristine",
     });
+  });
+
+  test("validates an existing expense before it changes", () => {
+    expect(
+      getExpenseEditorValidationResult(completeExpense, { isDirty: false, mode: "edit" }),
+    ).toMatchObject({
+      issues: [],
+      status: "valid",
+    });
+  });
+
+  test("reports an incomplete existing expense before it changes", () => {
+    expect(
+      getExpenseEditorValidationResult(
+        {
+          ...completeExpense,
+          name: "",
+        },
+        { isDirty: false, mode: "edit" },
+      ),
+    ).toMatchObject({ issues: [], status: "incomplete" });
   });
 
   test("is incomplete when required values are missing", () => {
@@ -93,16 +116,15 @@ describe("expense editor validation status", () => {
           amount: 0,
           shares: {},
         },
-        true,
+        { isDirty: true, mode: "create" },
       ),
     ).toMatchObject({ issues: [], status: "incomplete" });
   });
 
   test("is valid when required values and form-wide checks pass", () => {
-    expect(getExpenseEditorValidationResult(completeExpense, true)).toMatchObject({
-      issues: [],
-      status: "valid",
-    });
+    expect(
+      getExpenseEditorValidationResult(completeExpense, { isDirty: true, mode: "create" }),
+    ).toMatchObject({ issues: [], status: "valid" });
   });
 
   test("surfaces form-wide errors even before the form becomes dirty", () => {
@@ -115,7 +137,7 @@ describe("expense editor validation status", () => {
             adjusted: { type: "divide", value: 1 },
           },
         },
-        false,
+        { isDirty: false, mode: "create" },
       ),
     ).toMatchObject({
       issues: [{ code: "shares-total-mismatch", severity: "error" }],

--- a/packages/pwa/src/lib/expenseEditor.test.ts
+++ b/packages/pwa/src/lib/expenseEditor.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, test } from "vite-plus/test";
-import { expenseEditorSharesMatchAmount, getExpenseEditorUnitShares } from "./expenseEditor.ts";
+import {
+  expenseEditorSharesMatchAmount,
+  getExpenseEditorUnitShares,
+  getExpenseEditorValidationIssues,
+  getExpenseEditorValidationResult,
+  type ExpenseEditorValidationValues,
+} from "./expenseEditor.ts";
+
+const completeExpense: ExpenseEditorValidationValues = {
+  name: "Dinner",
+  amount: 100,
+  paidBy: "payer",
+  shares: {
+    participant: { type: "divide", value: 1 },
+  },
+};
 
 describe("expense editor shares", () => {
   test("clamps a negative adjusted participant amount to zero", () => {
@@ -30,5 +45,81 @@ describe("expense editor shares", () => {
     };
 
     expect(expenseEditorSharesMatchAmount(100, shares)).toBe(true);
+  });
+
+  test("returns a form-wide error with minor-unit totals for an invalid split", () => {
+    const values: ExpenseEditorValidationValues = {
+      ...completeExpense,
+      shares: {
+        exact: { type: "exact", value: 15_000 },
+        adjusted: { type: "divide", value: 1 },
+      },
+    };
+
+    expect(getExpenseEditorValidationIssues(values)).toStrictEqual([
+      {
+        code: "shares-total-mismatch",
+        severity: "error",
+        expenseAmount: 10_000,
+        sharesTotal: 15_000,
+      },
+    ]);
+  });
+
+  test("does not report a split mismatch before participants are selected", () => {
+    expect(
+      getExpenseEditorValidationIssues({
+        ...completeExpense,
+        shares: {},
+      }),
+    ).toStrictEqual([]);
+  });
+});
+
+describe("expense editor validation status", () => {
+  test("starts pristine when a valid form has not changed", () => {
+    expect(getExpenseEditorValidationResult(completeExpense, false)).toMatchObject({
+      issues: [],
+      status: "pristine",
+    });
+  });
+
+  test("is incomplete when required values are missing", () => {
+    expect(
+      getExpenseEditorValidationResult(
+        {
+          ...completeExpense,
+          name: "",
+          amount: 0,
+          shares: {},
+        },
+        true,
+      ),
+    ).toMatchObject({ issues: [], status: "incomplete" });
+  });
+
+  test("is valid when required values and form-wide checks pass", () => {
+    expect(getExpenseEditorValidationResult(completeExpense, true)).toMatchObject({
+      issues: [],
+      status: "valid",
+    });
+  });
+
+  test("surfaces form-wide errors even before the form becomes dirty", () => {
+    expect(
+      getExpenseEditorValidationResult(
+        {
+          ...completeExpense,
+          shares: {
+            exact: { type: "exact", value: 15_000 },
+            adjusted: { type: "divide", value: 1 },
+          },
+        },
+        false,
+      ),
+    ).toMatchObject({
+      issues: [{ code: "shares-total-mismatch", severity: "error" }],
+      status: "error",
+    });
   });
 });

--- a/packages/pwa/src/lib/expenseEditor.ts
+++ b/packages/pwa/src/lib/expenseEditor.ts
@@ -1,10 +1,40 @@
 import type { ExpenseUser } from "#src/lib/expenses.ts";
 import { convertToUnits } from "#src/lib/expenses.ts";
-import { createMoney } from "#src/lib/money.ts";
+import { createMoney, getMoneyAmount } from "#src/lib/money.ts";
 import { getExpenseUnitShares } from "#src/models/expense.ts";
 import { add, equal } from "dinero.js";
 
 export type ExpenseEditorShares = Record<ExpenseUser, { type: "divide" | "exact"; value: number }>;
+
+export interface ExpenseEditorValidationValues {
+  amount: number;
+  name: string;
+  paidBy: ExpenseUser;
+  shares: ExpenseEditorShares;
+}
+
+export interface ExpenseEditorValidationIssue {
+  code: "shares-total-mismatch";
+  severity: "error" | "warning";
+  expenseAmount: number;
+  sharesTotal: number;
+}
+
+export type ExpenseEditorValidationStatus =
+  | "pristine"
+  | "incomplete"
+  | "valid"
+  | "warning"
+  | "error";
+
+export interface ExpenseEditorValidationResult {
+  issues: ExpenseEditorValidationIssue[];
+  status: ExpenseEditorValidationStatus;
+}
+
+type ExpenseEditorValidationRule = (
+  values: ExpenseEditorValidationValues,
+) => ExpenseEditorValidationIssue | null;
 
 export function getExpenseEditorUnitShares(amount: number, shares: ExpenseEditorShares) {
   const unitShares = getExpenseUnitShares({
@@ -22,10 +52,78 @@ export function getExpenseEditorUnitShares(amount: number, shares: ExpenseEditor
 
 export function expenseEditorSharesMatchAmount(amount: number, shares: ExpenseEditorShares) {
   const totalAmount = createMoney(convertToUnits(amount));
+  const totalSplit = createMoney(getExpenseEditorSharesTotal(amount, shares));
+
+  return equal(totalSplit, totalAmount);
+}
+
+export function getExpenseEditorValidationIssues(values: ExpenseEditorValidationValues) {
+  return expenseEditorValidationRules.flatMap((validate) => {
+    const issue = validate(values);
+
+    return issue ? [issue] : [];
+  });
+}
+
+export function getExpenseEditorValidationResult(
+  values: ExpenseEditorValidationValues,
+  isDirty: boolean,
+): ExpenseEditorValidationResult {
+  const issues = getExpenseEditorValidationIssues(values);
+  const hasErrors = issues.some((issue) => issue.severity === "error");
+  const hasWarnings = issues.some((issue) => issue.severity === "warning");
+
+  if (hasErrors) {
+    return { issues, status: "error" };
+  }
+
+  if (hasWarnings) {
+    return { issues, status: "warning" };
+  }
+
+  if (!isDirty) {
+    return { issues, status: "pristine" };
+  }
+
+  if (!isExpenseEditorComplete(values)) {
+    return { issues, status: "incomplete" };
+  }
+
+  return { issues, status: "valid" };
+}
+
+function getExpenseEditorSharesTotal(amount: number, shares: ExpenseEditorShares) {
   const totalSplit = Object.values(getExpenseEditorUnitShares(amount, shares)).reduce(
     (total, participantAmount) => add(total, createMoney(participantAmount)),
     createMoney(0),
   );
 
-  return equal(totalSplit, totalAmount);
+  return getMoneyAmount(totalSplit);
 }
+
+function isExpenseEditorComplete(values: ExpenseEditorValidationValues) {
+  const title = values.name.trim();
+
+  return (
+    title.length > 0 &&
+    title.length <= 50 &&
+    values.amount > 0 &&
+    Boolean(values.paidBy) &&
+    Object.keys(values.shares).length > 0
+  );
+}
+
+const validateSharesTotal: ExpenseEditorValidationRule = ({ amount, shares }) => {
+  if (Object.keys(shares).length === 0 || expenseEditorSharesMatchAmount(amount, shares)) {
+    return null;
+  }
+
+  return {
+    code: "shares-total-mismatch",
+    severity: "error",
+    expenseAmount: convertToUnits(amount),
+    sharesTotal: getExpenseEditorSharesTotal(amount, shares),
+  };
+};
+
+const expenseEditorValidationRules = [validateSharesTotal] as const;

--- a/packages/pwa/src/lib/expenseEditor.ts
+++ b/packages/pwa/src/lib/expenseEditor.ts
@@ -32,6 +32,13 @@ export interface ExpenseEditorValidationResult {
   status: ExpenseEditorValidationStatus;
 }
 
+export type ExpenseEditorMode = "create" | "edit";
+
+export interface ExpenseEditorValidationOptions {
+  isDirty: boolean;
+  mode: ExpenseEditorMode;
+}
+
 type ExpenseEditorValidationRule = (
   values: ExpenseEditorValidationValues,
 ) => ExpenseEditorValidationIssue | null;
@@ -67,7 +74,7 @@ export function getExpenseEditorValidationIssues(values: ExpenseEditorValidation
 
 export function getExpenseEditorValidationResult(
   values: ExpenseEditorValidationValues,
-  isDirty: boolean,
+  { isDirty, mode }: ExpenseEditorValidationOptions,
 ): ExpenseEditorValidationResult {
   const issues = getExpenseEditorValidationIssues(values);
   const hasErrors = issues.some((issue) => issue.severity === "error");
@@ -81,7 +88,7 @@ export function getExpenseEditorValidationResult(
     return { issues, status: "warning" };
   }
 
-  if (!isDirty) {
+  if (!isDirty && mode === "create") {
     return { issues, status: "pristine" };
   }
 

--- a/packages/pwa/src/routes/party_.$partyId.add.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.add.tsx
@@ -135,6 +135,7 @@ function AddExpense() {
   return (
     <>
       <ExpenseEditor
+        mode="create"
         title={t`New expense`}
         onSubmit={onCreateExpense}
         onChange={(_prev, current) => setPhotos(current.photos)}

--- a/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx
+++ b/packages/pwa/src/routes/party_.$partyId.expense.$expenseId_.edit/route.tsx
@@ -224,6 +224,7 @@ function EditExpense() {
     <>
       <RealtimeExpenseEditorPresence expenseId={expenseId} />
       <ExpenseEditor
+        mode="edit"
         title={t({ message: `Editing ${expenseName}` })}
         onSubmit={onSubmit}
         defaultValues={formValues}


### PR DESCRIPTION
## Description

Adds a persistent validation status bar directly below the ExpenseEditor header. The bar covers pristine, incomplete, valid, warning, and error states, and form-wide issues such as mismatched split totals use the error variant.

New expenses begin in the pristine state, while existing expenses run validation immediately when the edit flow opens. Status changes crossfade and slide with reduced-motion support. Actionable bars use the shared button press, hover, and focus feedback, and return to their resting visual state when the details dialog opens.

Removes the old allocation alert from the bottom of the editor. Pressing an actionable status bar—or attempting to save while a blocking issue remains—opens an accessible dialog with validation details and formatted amounts. The dialog uses one alert header followed by a flat, divided issue list on the same surface, keeping both single and multiple errors compact without nested cards or repeated alert icons.

Introduces structured, severity-aware expense validation results and a rule list so future customizable validation rules can plug into the same status and dialog UI. Submission evaluates the complete result rather than only form-wide issues, preventing incomplete expenses—including empty participant allocations—from reaching either the create or update handler.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [x] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Verified against the supplied reference at a 390×844 mobile viewport in dark mode, including pristine, incomplete, valid, error, dialog, status-transition, and dialog-trigger interaction states. The final dialog hierarchy was reviewed with both one- and three-error layouts to confirm the divided list scales cleanly. No repository screenshot assets were added.

## Additional Notes

- React Doctor reports 100/100 for the changed source files.
- Spanish translations are included; Lingui reports zero missing messages.
- Empty-allocation submission coverage runs for both create and edit modes.
- `vp run check` retains two pre-existing locale-format warnings in unrelated expense display components.
- The full workspace build passed through PWA production output and Android/iOS Capacitor sync using the repository-pinned Ruby/CocoaPods bundle.
