### PR TITLE
chore(deps): update manual non-major dependencies

### DIFF
--- a/packages/mobile/android/capacitor.settings.gradle
+++ b/packages/mobile/android/capacitor.settings.gradle
@@ -18,7 +18,7 @@ include ':capawesome-capacitor-app-update'
 project(':capawesome-capacitor-app-update').projectDir = new File('../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.3_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-app-update/android')
 
 include ':capawesome-capacitor-apple-sign-in'
-project(':capawesome-capacitor-apple-sign-in').projectDir = new File('../../../node_modules/.pnpm/@capawesome+capacitor-apple-sign-in@0.1.1_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-apple-sign-in/android')
+project(':capawesome-capacitor-apple-sign-in').projectDir = new File('../../../node_modules/.pnpm/@capawesome+capacitor-apple-sign-in@0.1.2_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-apple-sign-in/android')
 
 include ':capawesome-capacitor-google-sign-in'
 project(':capawesome-capacitor-google-sign-in').projectDir = new File('../../../node_modules/.pnpm/@capawesome+capacitor-google-sign-in@0.1.2_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-google-sign-in/android')

--- a/packages/mobile/ios/App/Podfile
+++ b/packages/mobile/ios/App/Podfile
@@ -16,7 +16,7 @@ def capacitor_pods
   pod 'CapacitorShare', :path => '../../../../node_modules/.pnpm/@capacitor+share@8.0.1_@capacitor+core@8.4.1/node_modules/@capacitor/share'
   pod 'CapacitorSplashScreen', :path => '../../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.4.1/node_modules/@capacitor/splash-screen'
   pod 'CapawesomeCapacitorAppUpdate', :path => '../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.3_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-app-update'
-  pod 'CapawesomeCapacitorAppleSignIn', :path => '../../../../node_modules/.pnpm/@capawesome+capacitor-apple-sign-in@0.1.1_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-apple-sign-in'
+  pod 'CapawesomeCapacitorAppleSignIn', :path => '../../../../node_modules/.pnpm/@capawesome+capacitor-apple-sign-in@0.1.2_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-apple-sign-in'
   pod 'CapawesomeCapacitorGoogleSignIn', :path => '../../../../node_modules/.pnpm/@capawesome+capacitor-google-sign-in@0.1.2_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-google-sign-in'
   pod 'CapacitorPluginSafeArea', :path => '../../../../node_modules/.pnpm/capacitor-plugin-safe-area@5.0.0_@capacitor+core@8.4.1/node_modules/capacitor-plugin-safe-area'
 end

--- a/packages/mobile/ios/App/Podfile.lock
+++ b/packages/mobile/ios/App/Podfile.lock
@@ -25,7 +25,7 @@ PODS:
     - Capacitor
   - CapacitorSplashScreen (8.0.1):
     - Capacitor
-  - CapawesomeCapacitorAppleSignIn (0.1.1):
+  - CapawesomeCapacitorAppleSignIn (0.1.2):
     - Capacitor
   - CapawesomeCapacitorAppUpdate (8.0.3):
     - Capacitor
@@ -64,7 +64,7 @@ DEPENDENCIES:
   - "CapacitorPluginSafeArea (from `../../../../node_modules/.pnpm/capacitor-plugin-safe-area@5.0.0_@capacitor+core@8.4.1/node_modules/capacitor-plugin-safe-area`)"
   - "CapacitorShare (from `../../../../node_modules/.pnpm/@capacitor+share@8.0.1_@capacitor+core@8.4.1/node_modules/@capacitor/share`)"
   - "CapacitorSplashScreen (from `../../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.4.1/node_modules/@capacitor/splash-screen`)"
-  - "CapawesomeCapacitorAppleSignIn (from `../../../../node_modules/.pnpm/@capawesome+capacitor-apple-sign-in@0.1.1_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-apple-sign-in`)"
+  - "CapawesomeCapacitorAppleSignIn (from `../../../../node_modules/.pnpm/@capawesome+capacitor-apple-sign-in@0.1.2_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-apple-sign-in`)"
   - "CapawesomeCapacitorAppUpdate (from `../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.3_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-app-update`)"
   - "CapawesomeCapacitorGoogleSignIn (from `../../../../node_modules/.pnpm/@capawesome+capacitor-google-sign-in@0.1.2_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-google-sign-in`)"
 
@@ -97,7 +97,7 @@ EXTERNAL SOURCES:
   CapacitorSplashScreen:
     :path: "../../../../node_modules/.pnpm/@capacitor+splash-screen@8.0.1_@capacitor+core@8.4.1/node_modules/@capacitor/splash-screen"
   CapawesomeCapacitorAppleSignIn:
-    :path: "../../../../node_modules/.pnpm/@capawesome+capacitor-apple-sign-in@0.1.1_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-apple-sign-in"
+    :path: "../../../../node_modules/.pnpm/@capawesome+capacitor-apple-sign-in@0.1.2_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-apple-sign-in"
   CapawesomeCapacitorAppUpdate:
     :path: "../../../../node_modules/.pnpm/@capawesome+capacitor-app-update@8.0.3_@capacitor+core@8.4.1/node_modules/@capawesome/capacitor-app-update"
   CapawesomeCapacitorGoogleSignIn:
@@ -106,16 +106,16 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: 214137f5c378d1dec88a68425c467fe65aaff637
-  Capacitor: 35242afe195b1e53c58ca1b827d1b444c5e6602b
-  CapacitorApp: 449ffe26375e96f8aaaee625ac6e01e5c57c8650
-  CapacitorCamera: 8f6acf83664118321111e76acef86390211ccb08
+  Capacitor: 9c34c6eb2165694e51758f5b425d470cb00f5bea
+  CapacitorApp: a4d8d936cc4390859a3766f141048abe55d4076f
+  CapacitorCamera: a9b5f1a5d09e61b7a979e3510b87cdda99265d2f
   CapacitorCordova: eebe6bcf807b1b06f3f48237650f96bbcd0eef09
-  CapacitorPluginSafeArea: 9d0682951c011bf0b36e513a89103c5fbff7ac49
-  CapacitorShare: 0c58305114538568059bfc07111f22dcb9cb2a82
-  CapacitorSplashScreen: 4b46c72298db552b3c57ce021ef028b6dc7f1fa7
-  CapawesomeCapacitorAppleSignIn: c793d6d2b2cb22d0a029d758dcf33484f385f382
-  CapawesomeCapacitorAppUpdate: 3a7537c6a6696837b51d06f26b2e909fd7b9226f
-  CapawesomeCapacitorGoogleSignIn: 7d9ecee5c88e500f7fd364b22cfbfd8386724534
+  CapacitorPluginSafeArea: 5c90e7423e8129641686afe8ae6084b65b20527e
+  CapacitorShare: 8a565649d321a05a1ae8b525b2a9b4f2d92c70ce
+  CapacitorSplashScreen: 1281f7df4d9b4a72bccab8d03e6b2bbd17dff122
+  CapawesomeCapacitorAppleSignIn: 7498b234c78f4740d37ddc477812e12a0c89de67
+  CapawesomeCapacitorAppUpdate: 4f528462dfa538ce5ab47136020eda033b3f1f5c
+  CapawesomeCapacitorGoogleSignIn: 094abd5aff6a9fc2ffec5b0a6313735bf9864896
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 4f2618a4a1e762a1ee134a1e2323bba9843e06da
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
@@ -125,6 +125,6 @@ SPEC CHECKSUMS:
   PromisesSwift: 217dea0fd5d2ad65222a109c48698add13cc1c5b
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
 
-PODFILE CHECKSUM: 966ebe3fb259762febd710a21b328171097c1d12
+PODFILE CHECKSUM: 3f8e8d6b1d972213ccbcda87302358c5750cd79d
 
 COCOAPODS: 1.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,14 +62,14 @@ catalogs:
       specifier: 8.0.3
       version: 8.0.3
     '@capawesome/capacitor-apple-sign-in':
-      specifier: 0.1.1
-      version: 0.1.1
+      specifier: 0.1.2
+      version: 0.1.2
     '@capawesome/capacitor-google-sign-in':
       specifier: 0.1.2
       version: 0.1.2
     '@capawesome/capver':
-      specifier: 0.1.4
-      version: 0.1.4
+      specifier: 0.1.5
+      version: 0.1.5
     '@changesets/changelog-github':
       specifier: 0.7.0
       version: 0.7.0
@@ -125,8 +125,8 @@ catalogs:
       specifier: 2.2.4
       version: 2.2.4
     '@openai/codex':
-      specifier: 0.144.3
-      version: 0.144.3
+      specifier: 0.144.4
+      version: 0.144.4
     '@playwright/test':
       specifier: 1.61.1
       version: 1.61.1
@@ -452,7 +452,7 @@ importers:
         version: 0.4.0(zod@4.4.3)
       '@openai/codex':
         specifier: 'catalog:'
-        version: 0.144.3
+        version: 0.144.4
       '@trizum/logging':
         specifier: workspace:*
         version: link:../logging
@@ -545,7 +545,7 @@ importers:
         version: 8.0.3(@capacitor/core@8.4.1)
       '@capawesome/capacitor-apple-sign-in':
         specifier: 'catalog:'
-        version: 0.1.1(@capacitor/core@8.4.1)
+        version: 0.1.2(@capacitor/core@8.4.1)
       '@capawesome/capacitor-google-sign-in':
         specifier: 'catalog:'
         version: 0.1.2(@capacitor/core@8.4.1)
@@ -567,7 +567,7 @@ importers:
         version: 8.4.1
       '@capawesome/capver':
         specifier: 'catalog:'
-        version: 0.1.4(@swc/core@1.13.3(@swc/helpers@0.5.23))(@swc/wasm@1.13.3)(@types/node@24.13.3)(@typescript/typescript6@6.0.2)
+        version: 0.1.5(@swc/core@1.13.3(@swc/helpers@0.5.23))(@swc/wasm@1.13.3)(@types/node@24.13.3)(@typescript/typescript6@6.0.2)
       '@trizum/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -624,7 +624,7 @@ importers:
         version: 8.0.3(@capacitor/core@8.4.1)
       '@capawesome/capacitor-apple-sign-in':
         specifier: 'catalog:'
-        version: 0.1.1(@capacitor/core@8.4.1)
+        version: 0.1.2(@capacitor/core@8.4.1)
       '@capawesome/capacitor-google-sign-in':
         specifier: 'catalog:'
         version: 0.1.2(@capacitor/core@8.4.1)
@@ -1822,8 +1822,8 @@ packages:
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
-  '@capawesome/capacitor-apple-sign-in@0.1.1':
-    resolution: {integrity: sha512-4CkO5YYn/CkJXOPFjKMZbGgHQyyGWVj5BafwffG4w3Ye5uRJ5VkijbR18WrjtLM8mQLjdGZAt6bquA03MontUQ==}
+  '@capawesome/capacitor-apple-sign-in@0.1.2':
+    resolution: {integrity: sha512-qux8WBnoDYe8axpVkXYSsPPfl0Wy+bXddmhJ5GLx4V7AR2LVP7YZnl/AN0xbQI1pGJv234hAgrFGdZnUwhVyxw==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
@@ -1832,8 +1832,8 @@ packages:
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
-  '@capawesome/capver@0.1.4':
-    resolution: {integrity: sha512-FY3zre+9A3yeBHf1fXCvjUyAcH0RsEmJL4pvHwB4uAlOZDrIbWmQWQQTrseKk4+tVFjM+uhFY2Pqqe0hLm5UdA==}
+  '@capawesome/capver@0.1.5':
+    resolution: {integrity: sha512-XSqWpEN7HRAg67GyM2yc9eTxERRIqauRmJxI+DE0ZqCMqzDhcqu/w4IaHt7jMEtEUQHav5+zbxsHqH7XEzLAjQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3022,43 +3022,43 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@openai/codex@0.144.3':
-    resolution: {integrity: sha512-8Re3wp5CdYiM7nsF4StFa5js6IT11N7srhxfvwtol7ENHDht05C+HS4e1CTmYjqkhgsUzl2R1gB27iN2pdbVnA==}
+  '@openai/codex@0.144.4':
+    resolution: {integrity: sha512-DTHzYatlKq9dw55E0/HsbK4tRCEKabuJ10ybbqpsG8gVv/kvwEdg3Z4OI3cvLXKa21xkIa4lkGlZoO/HmqmFFw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.144.3-darwin-arm64':
-    resolution: {integrity: sha512-v/yT1wqslBcwquUvUPZvAdYyiZcCBIUL+pE4ymHpbUMVduwDJBw1EjLroOhe9FkYFDHzWGyv7YEw7iIV4k+0dA==}
+  '@openai/codex@0.144.4-darwin-arm64':
+    resolution: {integrity: sha512-6J3g498cM2oA7vYIJhpuGJlnIi/M5JdYmjB5BZ1Of5HQ0ziIlplFSvH801oVy9J5TQFp642ODzOu/ZEokDUXsg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.144.3-darwin-x64':
-    resolution: {integrity: sha512-308U0s7AeRg3AlnxJtmJk03yRRriEplC6ceFoB3OpWh+przqt8/u6MKDVU3KHdjb+vasa0IpmDWv5VrFw3oJAw==}
+  '@openai/codex@0.144.4-darwin-x64':
+    resolution: {integrity: sha512-k1HC8gdbAy+VmMbekYkhM+r+QE2Xfgd67n1VSp94tjz7aXVKoalHcDkdKNM/uUQ8o2tvbiwhHSUftJF8Sm9/Lw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.144.3-linux-arm64':
-    resolution: {integrity: sha512-mJgDUmoPMry9a7g6ywsMQ4uQko2K0uHLqzEITUJMXiNNbCRBQKS+PxDWBlSK0bF0v72uAhWRRRGvPXslwhIdyg==}
+  '@openai/codex@0.144.4-linux-arm64':
+    resolution: {integrity: sha512-OlKx65579OwIzech9Tt3OUH9+hFZfFrCBP1hL2MudnMIoNr1+cFZjB5YIj5MWMRoBD+K5W3wdBIpQSH855b5Sg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.144.3-linux-x64':
-    resolution: {integrity: sha512-xtDY5sWQPbYBj2lLWZJvc0jBre0XQ7ZmN4VbSEvazbQ2X7uHhm1D/0oZ7AI+SgC/VfZrUhvxRHd43/AmXSaAzA==}
+  '@openai/codex@0.144.4-linux-x64':
+    resolution: {integrity: sha512-2jxrmV6+/7eBNdg5uhhmOEPFu2o28eYY/ClLzWhSBHH8uo3f2KA1z9JQcVtwlbToW03nEPlEzYNYfCF1UBqsVQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.144.3-win32-arm64':
-    resolution: {integrity: sha512-uvgBLuBX58GIq58CquhvhEmwLlH9Lc46rLmE5/CkEf1vQiCvWqVHxL28t7P9cmWGoeMuxsrIwqJgyzmRu6wZMQ==}
+  '@openai/codex@0.144.4-win32-arm64':
+    resolution: {integrity: sha512-CCgfI1smFhHZTIpTuBwDJwBr/AR40RTqaFxbBWVabu0RMeYDteRuPiDfdTlktf3C43Y1q10VZXhVGYtCokDg2w==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.144.3-win32-x64':
-    resolution: {integrity: sha512-0o8LpbZuBvqcAdIqMh96pECFTtfkgMT2sP/Q2IKYUOOlSudq3ulvdDW6zARq04HhbOxSsU9TBYDkdqtDs2YcYQ==}
+  '@openai/codex@0.144.4-win32-x64':
+    resolution: {integrity: sha512-iL1ky0ERgdQJOKzom/Ms1fhpwkSmpsA9eVrzAqURFlYGS8z7JqwEgm33+nLGCsY7y25d8Xs/LJ91Oiqz3yXcUg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -10579,7 +10579,7 @@ snapshots:
     dependencies:
       '@capacitor/core': 8.4.1
 
-  '@capawesome/capacitor-apple-sign-in@0.1.1(@capacitor/core@8.4.1)':
+  '@capawesome/capacitor-apple-sign-in@0.1.2(@capacitor/core@8.4.1)':
     dependencies:
       '@capacitor/core': 8.4.1
 
@@ -10587,7 +10587,7 @@ snapshots:
     dependencies:
       '@capacitor/core': 8.4.1
 
-  '@capawesome/capver@0.1.4(@swc/core@1.13.3(@swc/helpers@0.5.23))(@swc/wasm@1.13.3)(@types/node@24.13.3)(@typescript/typescript6@6.0.2)':
+  '@capawesome/capver@0.1.5(@swc/core@1.13.3(@swc/helpers@0.5.23))(@swc/wasm@1.13.3)(@types/node@24.13.3)(@typescript/typescript6@6.0.2)':
     dependencies:
       '@robingenz/zli': 0.2.0(zod@4.0.17)
       '@trapezedev/project': 7.1.4(@swc/core@1.13.3(@swc/helpers@0.5.23))(@swc/wasm@1.13.3)(@types/node@24.13.3)(@typescript/typescript6@6.0.2)
@@ -11748,31 +11748,31 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@openai/codex@0.144.3':
+  '@openai/codex@0.144.4':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.144.3-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.144.3-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.144.3-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.144.3-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.144.3-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.144.3-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.144.4-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.144.4-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.144.4-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.144.4-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.144.4-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.144.4-win32-x64'
 
-  '@openai/codex@0.144.3-darwin-arm64':
+  '@openai/codex@0.144.4-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.144.3-darwin-x64':
+  '@openai/codex@0.144.4-darwin-x64':
     optional: true
 
-  '@openai/codex@0.144.3-linux-arm64':
+  '@openai/codex@0.144.4-linux-arm64':
     optional: true
 
-  '@openai/codex@0.144.3-linux-x64':
+  '@openai/codex@0.144.4-linux-x64':
     optional: true
 
-  '@openai/codex@0.144.3-win32-arm64':
+  '@openai/codex@0.144.4-win32-arm64':
     optional: true
 
-  '@openai/codex@0.144.3-win32-x64':
+  '@openai/codex@0.144.4-win32-x64':
     optional: true
 
   '@opentelemetry/api-logs@0.220.0':
@@ -12963,7 +12963,7 @@ snapshots:
       '@capacitor/share': 8.0.1(@capacitor/core@8.4.1)
       '@capacitor/splash-screen': 8.0.1(@capacitor/core@8.4.1)
       '@capawesome/capacitor-app-update': 8.0.3(@capacitor/core@8.4.1)
-      '@capawesome/capacitor-apple-sign-in': 0.1.1(@capacitor/core@8.4.1)
+      '@capawesome/capacitor-apple-sign-in': 0.1.2(@capacitor/core@8.4.1)
       '@capawesome/capacitor-google-sign-in': 0.1.2(@capacitor/core@8.4.1)
       '@fontsource-variable/fira-code': 5.2.7
       '@fontsource-variable/inter': 5.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,9 +50,9 @@ catalog:
   "@capacitor/share": 8.0.1
   "@capacitor/splash-screen": 8.0.1
   "@capawesome/capacitor-app-update": 8.0.3
-  "@capawesome/capacitor-apple-sign-in": 0.1.1
+  "@capawesome/capacitor-apple-sign-in": 0.1.2
   "@capawesome/capacitor-google-sign-in": 0.1.2
-  "@capawesome/capver": 0.1.4
+  "@capawesome/capver": 0.1.5
   "@changesets/changelog-github": 0.7.0
   "@changesets/cli": 2.31.0
   "@cloudflare/vite-plugin": 1.45.0
@@ -71,7 +71,7 @@ catalog:
   "@lingui/vite-plugin": 6.5.0
   "@logtape/logtape": 2.2.4
   "@logtape/sentry": 2.2.4
-  "@openai/codex": 0.144.3
+  "@openai/codex": 0.144.4
   "@playwright/test": 1.61.1
   "@rolldown/plugin-babel": 0.2.3
   "@sentry/cli": 3.6.0


### PR DESCRIPTION
Supersedes #407.
## Why
Reviewed chore(deps): update manual non-major dependencies (#407); affected areas: mobile, workspace; updates: @capawesome/capacitor-apple-sign-in 0.1.1 -> 0.1.2, @capawesome/capver 0.1.4 -> 0.1.5, @openai/codex 0.144.3 -> 0.144.5, agent-browser 0.31.2 -> 0.32.1.
Sandcastle Codex review did not complete.
- [blocker] PR checks are failing: Check Android, Mobile Sync (ios), Mobile Sync (android)
- [blocker] Required Codex review failed: codex exited with code 1:
## What
- Updates: @capawesome/capacitor-apple-sign-in 0.1.1 -> 0.1.2, @capawesome/capver 0.1.4 -> 0.1.5, @openai/codex 0.144.3 -> 0.144.5, agent-browser 0.31.2 -> 0.32.1.
- Fix: Reused the existing superseding PR and refreshed local validation.
- Files: `.changeset/android-optional-camera.md`, `.changeset/android-party-back.md`, `.changeset/app-worker-balance-recalculation.md`, `.changeset/async-action-components.md`, `.changeset/bright-avatars-look.md`, and 64 more
## How
- Local validation: failed.
- [pass] `vp install --frozen-lockfile`
- [pass] `vp run --no-cache check`
- [fail] `vp run --no-cache test` (exit 1)
- Failed command: `vp run --no-cache test` (exit 1).
- Failure output:
```text
Error: Vitest failed to find the current suite. One of the following is possible:
Error: Vitest failed to find the current suite. One of the following is possible:
 Test Files  2 failed (2)
::error file=/tmp/trizum-renovate-existing-Tg17ca/packages/logging/src/github-actions.test.ts,title=[logging] src/github-actions.test.ts,line=45,column=1::Error: Vitest failed to find the current suite. One of the following is possible:%0A- "vitest" is imported directly without running "vitest" command%0A- "vitest" is imported inside "globalSetup" (to fix this, use "setupFiles" instead, because "globalSetup" runs in a different context)%0A- "vitest" is imported inside Vite / Vitest config file%0
[truncated 1051 bytes]
::error file=/tmp/trizum-renovate-existing-Tg17ca/packages/logging/src/index.test.ts,title=[logging] src/index.test.ts,line=25,column=1::Error: Vitest failed to find the current suite. O
[truncated 422 bytes]
```
- CI on this PR is the source of truth for merge readiness.