### PR TITLE
fix(mobile): automatically release iOS after approval

### DIFF
--- a/.changeset/bright-dodos-release.md
+++ b/.changeset/bright-dodos-release.md
@@ -1,0 +1,5 @@
+---
+"@trizum/mobile": patch
+---
+
+Configure iOS production submissions to release automatically after App Store approval while keeping phased rollout disabled.

--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -285,7 +285,7 @@ platform :ios do
       skip_metadata: false,
       force: true,
       submit_for_review: false,
-      automatic_release: false,
+      automatic_release: automatic_release,
       phased_release: false,
       run_precheck_before_submit: !submit_for_review,
       precheck_include_in_app_purchases: false,


### PR DESCRIPTION
## Description

Pass the requested `automatic_release` value to the metadata-enabled Fastlane `deliver` call so App Store Connect records the release type as automatic after approval.

The release workflow already supplied `automatic_release: true`, but `deploy_appstore_full` hardcoded it to `false` while uploading metadata. That set the App Store version to manual release. The later review-submission call skips metadata, so it could not overwrite the release type.

Phased release remains explicitly disabled, preserving an immediate rollout to all users after approval.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (not applicable; this changes Fastlane configuration)
- [x] I've run `vp run lingui:extract` (no user-facing strings changed)
- [x] I've added a changeset

## Screenshots

Not applicable; this PR has no UI changes.

## Additional Notes

Targeted validation: `mise exec -- vp run --filter @trizum/mobile ruby:check:ios`.

The workspace check passes with two pre-existing React locale-format warnings unrelated to this PR.