### PR TITLE
fix(mobile): make screenshot uploads idempotent

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -297,6 +297,11 @@ Add screenshots to `ios/App/fastlane/screenshots/en-US/` with naming convention:
 
 Run `bundle exec fastlane upload_screenshots` to upload.
 
+The iOS lanes synchronize screenshots by locale, filename, and checksum. This
+makes reruns safe: screenshots missing locally are removed from App Store
+Connect, unchanged screenshots are not uploaded again, and each device set is
+reordered from the numeric filename prefix.
+
 ### Environment Variables
 
 #### Android

--- a/packages/mobile/ios/App/fastlane/Fastfile
+++ b/packages/mobile/ios/App/fastlane/Fastfile
@@ -21,6 +21,10 @@ IOS_SCREENSHOT_PROCESSING_TIMEOUT_SECONDS = 5 * 60
 IOS_VERSION_CHECK_WAIT_RETRY_LIMIT = 5
 IOS_ENTITLEMENTS_PATH = File.expand_path("../App/App.entitlements", __dir__)
 
+# Fastlane's screenshot sync makes reruns idempotent by comparing the local and
+# remote screenshot sets before uploading, then applying the filename order.
+ENV["FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS"] = "true"
+
 default_platform(:ios)
 
 platform :ios do
@@ -262,7 +266,7 @@ platform :ios do
       skip_metadata: true,
       skip_screenshots: false,
       force: true,
-      overwrite_screenshots: true,
+      sync_screenshots: true,
       screenshot_processing_timeout: IOS_SCREENSHOT_PROCESSING_TIMEOUT_SECONDS
     )
   end
@@ -276,12 +280,13 @@ platform :ios do
   lane :deploy_appstore_full do |options|
     submit_for_review = options[:submit_for_review] || false
     automatic_release = options[:automatic_release] || false
+    skip_screenshots = options[:skip_screenshots].nil? ? true : options[:skip_screenshots]
 
     build_release(build_number: options[:build_number])
 
     deliver(
       app_identifier: IOS_APP_IDENTIFIER,
-      skip_screenshots: options[:skip_screenshots].nil? ? true : options[:skip_screenshots],
+      skip_screenshots: skip_screenshots,
       skip_metadata: false,
       force: true,
       submit_for_review: false,
@@ -289,7 +294,7 @@ platform :ios do
       phased_release: false,
       run_precheck_before_submit: !submit_for_review,
       precheck_include_in_app_purchases: false,
-      overwrite_screenshots: true,
+      sync_screenshots: !skip_screenshots,
       screenshot_processing_timeout: IOS_SCREENSHOT_PROCESSING_TIMEOUT_SECONDS,
       version_check_wait_retry_limit: IOS_VERSION_CHECK_WAIT_RETRY_LIMIT,
       submission_information: app_store_submission_information

--- a/packages/mobile/src/fastlane-config.test.ts
+++ b/packages/mobile/src/fastlane-config.test.ts
@@ -1,0 +1,15 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, test } from "vite-plus/test";
+
+const fastfileUrl = new URL("../ios/App/fastlane/Fastfile", import.meta.url);
+
+describe("iOS Fastlane screenshot uploads", () => {
+  test("synchronizes the local screenshot set on every uploading lane", async () => {
+    const fastfile = await readFile(fastfileUrl, "utf8");
+
+    expect(fastfile.match(/sync_screenshots: true/g)).toHaveLength(1);
+    expect(fastfile).toContain("sync_screenshots: !skip_screenshots");
+    expect(fastfile).toContain('ENV["FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS"] = "true"');
+    expect(fastfile).not.toContain("overwrite_screenshots:");
+  });
+});

--- a/packages/screenshots/src/organize-for-fastlane.test.ts
+++ b/packages/screenshots/src/organize-for-fastlane.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, mkdtemp, readdir, rm, unlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vite-plus/test";
+import { organizeScreenshots } from "./organize-for-fastlane.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("organizeScreenshots", () => {
+  test("produces the same clean and ordered iOS set when rerun", async () => {
+    const rootDirectory = await mkdtemp(path.join(os.tmpdir(), "trizum-screenshots-"));
+    temporaryDirectories.push(rootDirectory);
+
+    const screenshotsDirectory = path.join(rootDirectory, "input");
+    const deviceDirectory = path.join(screenshotsDirectory, "en", "iphone-6.5");
+    const outputDirectory = path.join(rootDirectory, "output");
+    await mkdir(deviceDirectory, { recursive: true });
+    await mkdir(path.join(outputDirectory, "en-US"), { recursive: true });
+
+    const inputFilenames = [
+      "expense-editor.portrait.png",
+      "legacy.portrait.png",
+      "expense-details.portrait.png",
+      "balances.portrait.png",
+      "expense-log.portrait.png",
+    ];
+
+    await Promise.all(
+      inputFilenames.map((filename) => writeFile(path.join(deviceDirectory, filename), filename)),
+    );
+    await writeFile(path.join(outputDirectory, "en-US", "stale.png"), "stale");
+
+    const options = {
+      clean: true,
+      output: outputDirectory,
+      platform: "ios" as const,
+      screenshotsDirectory,
+    };
+
+    await organizeScreenshots(options);
+    await unlink(path.join(deviceDirectory, "legacy.portrait.png"));
+    await organizeScreenshots(options);
+
+    const outputFilenames = await readdir(path.join(outputDirectory, "en-US"));
+
+    expect(outputFilenames.sort()).toEqual([
+      'iPhone 6.5" Display-1_balances.png',
+      'iPhone 6.5" Display-2_expense-log.png',
+      'iPhone 6.5" Display-3_expense-details.png',
+      'iPhone 6.5" Display-4_expense-editor.png',
+    ]);
+  });
+});

--- a/packages/screenshots/src/organize-for-fastlane.ts
+++ b/packages/screenshots/src/organize-for-fastlane.ts
@@ -17,6 +17,7 @@
 
 import { copyFile, mkdir, readdir, rm } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import { configureScreenshotsLogging, getLogger } from "./log.ts";
 
@@ -72,13 +73,14 @@ const ANDROID_DEVICE_MAPPING: Record<string, string[] | null> = {
 // Order of screenshots (determines the index in filename)
 const SCREENSHOT_ORDER = ["balances", "expense-log", "expense-details", "expense-editor"];
 
-interface Options {
+export interface OrganizeScreenshotsOptions {
   platform: Platform;
   output: string;
   clean: boolean;
+  screenshotsDirectory?: string;
 }
 
-function parseOptions(): Options {
+function parseOptions(): OrganizeScreenshotsOptions {
   const { values } = parseArgs({
     options: {
       platform: {
@@ -116,8 +118,12 @@ function parseOptions(): Options {
   };
 }
 
-async function getScreenshotFiles(locale: string, device: string): Promise<string[]> {
-  const deviceDir = path.join(SCREENSHOTS_DIR, locale, device);
+async function getScreenshotFiles(
+  screenshotsDir: string,
+  locale: string,
+  device: string,
+): Promise<string[]> {
+  const deviceDir = path.join(screenshotsDir, locale, device);
 
   try {
     const files = await readdir(deviceDir);
@@ -134,7 +140,20 @@ function getScreenshotIndex(filename: string): number {
   return index === -1 ? 999 : index;
 }
 
-async function organizeForIOS(outputDir: string, locales: string[]): Promise<void> {
+export function compareScreenshotFilenames(a: string, b: string): number {
+  const orderDifference = getScreenshotIndex(a) - getScreenshotIndex(b);
+  if (orderDifference !== 0) {
+    return orderDifference;
+  }
+
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+async function organizeForIOS(
+  screenshotsDir: string,
+  outputDir: string,
+  locales: string[],
+): Promise<void> {
   for (const locale of locales) {
     const appStoreLocales = IOS_LOCALE_MAPPING[locale];
     if (!appStoreLocales) {
@@ -143,7 +162,7 @@ async function organizeForIOS(outputDir: string, locales: string[]): Promise<voi
     }
 
     // Get all devices for this locale
-    const localeDir = path.join(SCREENSHOTS_DIR, locale);
+    const localeDir = path.join(screenshotsDir, locale);
     const devices = await readdir(localeDir);
 
     for (const device of devices) {
@@ -160,7 +179,7 @@ async function organizeForIOS(outputDir: string, locales: string[]): Promise<voi
         continue;
       }
 
-      const files = await getScreenshotFiles(locale, device);
+      const files = await getScreenshotFiles(screenshotsDir, locale, device);
       if (files.length === 0) {
         logger.warning("No screenshots found for {locale}/{device}", {
           locale,
@@ -170,7 +189,7 @@ async function organizeForIOS(outputDir: string, locales: string[]): Promise<voi
       }
 
       // Sort files by screenshot order
-      files.sort((a, b) => getScreenshotIndex(a) - getScreenshotIndex(b));
+      files.sort(compareScreenshotFilenames);
 
       // Copy files to each App Store locale
       for (const appStoreLocale of appStoreLocales) {
@@ -182,9 +201,9 @@ async function organizeForIOS(outputDir: string, locales: string[]): Promise<voi
           const name = file.split(".")[0]; // "expense-log.portrait.png" -> "expense-log"
           const index = i + 1; // 1-based index
 
-          // Format: "iPhone 6.7" Display-1_expense-log.png"
+          // Format: "iPhone 6.5" Display-1_expense-log.png"
           const outputFilename = `${deviceFrame}-${index}_${name}.png`;
-          const inputPath = path.join(SCREENSHOTS_DIR, locale, device, file);
+          const inputPath = path.join(screenshotsDir, locale, device, file);
           const outputPath = path.join(localeOutputDir, outputFilename);
 
           await copyFile(inputPath, outputPath);
@@ -201,7 +220,11 @@ async function organizeForIOS(outputDir: string, locales: string[]): Promise<voi
   }
 }
 
-async function organizeForAndroid(outputDir: string, locales: string[]): Promise<void> {
+async function organizeForAndroid(
+  screenshotsDir: string,
+  outputDir: string,
+  locales: string[],
+): Promise<void> {
   for (const locale of locales) {
     const playStoreLocales = ANDROID_LOCALE_MAPPING[locale];
     if (!playStoreLocales) {
@@ -210,7 +233,7 @@ async function organizeForAndroid(outputDir: string, locales: string[]): Promise
     }
 
     // Get all devices for this locale
-    const localeDir = path.join(SCREENSHOTS_DIR, locale);
+    const localeDir = path.join(screenshotsDir, locale);
     const devices = await readdir(localeDir);
 
     for (const device of devices) {
@@ -227,7 +250,7 @@ async function organizeForAndroid(outputDir: string, locales: string[]): Promise
         continue;
       }
 
-      const files = await getScreenshotFiles(locale, device);
+      const files = await getScreenshotFiles(screenshotsDir, locale, device);
       if (files.length === 0) {
         logger.warning("No screenshots found for {locale}/{device}", {
           locale,
@@ -237,7 +260,7 @@ async function organizeForAndroid(outputDir: string, locales: string[]): Promise
       }
 
       // Sort files by screenshot order
-      files.sort((a, b) => getScreenshotIndex(a) - getScreenshotIndex(b));
+      files.sort(compareScreenshotFilenames);
 
       // Copy files to each Play Store locale and screenshot type
       for (const playStoreLocale of playStoreLocales) {
@@ -258,7 +281,7 @@ async function organizeForAndroid(outputDir: string, locales: string[]): Promise
 
             // Android format: "1_expense-log.png" (simple numbering)
             const outputFilename = `${index}_${name}.png`;
-            const inputPath = path.join(SCREENSHOTS_DIR, locale, device, file);
+            const inputPath = path.join(screenshotsDir, locale, device, file);
             const outputPath = path.join(screenshotsOutputDir, outputFilename);
 
             await copyFile(inputPath, outputPath);
@@ -277,12 +300,13 @@ async function organizeForAndroid(outputDir: string, locales: string[]): Promise
   }
 }
 
-async function organizeScreenshots(options: Options): Promise<void> {
+export async function organizeScreenshots(options: OrganizeScreenshotsOptions): Promise<void> {
   const outputDir = path.resolve(options.output);
+  const screenshotsDir = path.resolve(options.screenshotsDirectory ?? SCREENSHOTS_DIR);
 
   logger.info("Organizing screenshots", {
     platform: options.platform,
-    inputDirectory: SCREENSHOTS_DIR,
+    inputDirectory: screenshotsDir,
     outputDirectory: outputDir,
   });
 
@@ -297,16 +321,18 @@ async function organizeScreenshots(options: Options): Promise<void> {
   }
 
   // Get all locales
-  const locales = await readdir(SCREENSHOTS_DIR);
+  const locales = await readdir(screenshotsDir);
 
   if (options.platform === "ios") {
-    await organizeForIOS(outputDir, locales);
+    await organizeForIOS(screenshotsDir, outputDir, locales);
   } else {
-    await organizeForAndroid(outputDir, locales);
+    await organizeForAndroid(screenshotsDir, outputDir, locales);
   }
 
   logger.info("Finished organizing screenshots");
 }
 
-const options = parseOptions();
-void organizeScreenshots(options);
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const options = parseOptions();
+  void organizeScreenshots(options);
+}


### PR DESCRIPTION
## Summary
- Switched iOS Fastlane screenshot uploads to `sync_screenshots` so reruns compare local and remote sets instead of overwriting blindly.
- Enabled Fastlane's beta screenshot sync flag and reused the same skip-screenshots decision for full App Store deploys.
- Updated screenshot organization to sort filenames deterministically by screenshot order and added coverage for rerun-safe behavior.
- Documented the new sync behavior in the mobile README.

## Testing
- `packages/mobile/src/fastlane-config.test.ts` checks the Fastfile uses `sync_screenshots` and no longer references `overwrite_screenshots`.
- `packages/screenshots/src/organize-for-fastlane.test.ts` verifies rerunning organization removes stale files and preserves ordered output.
- Not run: full repo validation (`vp run check`, `vp run test`, `vp run build`).