### PR TITLE
chore(pwa): publish app ads declaration

### DIFF
--- a/.changeset/quiet-rice-listen.md
+++ b/.changeset/quiet-rice-listen.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Publish the Google advertising seller declaration at `/app-ads.txt`.

--- a/packages/pwa/public/app-ads.txt
+++ b/packages/pwa/public/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-8039329288910865, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Description

Publishes the Google advertising seller declaration as a static PWA asset at
`/app-ads.txt` so advertising platforms can verify the authorized seller.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [x] Other: advertising metadata

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [ ] I've run `vp run build`
- [x] I've added tests for new functionality (not applicable: static metadata only)
- [x] I've run `vp run lingui:extract` (no new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this change has no UI.

## Additional Notes

The PWA production build completed successfully and the generated
`dist/client/app-ads.txt` exactly matched the source file. The workspace build
then stopped during the mobile iOS sync because the local Ruby environment does
not have the locked CocoaPods gems installed.
