### PR TITLE
fix(mobile): publish iOS marketing URL

### DIFF
--- a/.changeset/tiny-cats-travel.md
+++ b/.changeset/tiny-cats-travel.md
@@ -1,0 +1,5 @@
+---
+"@trizum/mobile": patch
+---
+
+Publish the trizum developer website as the iOS App Store Marketing URL.

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -256,6 +256,7 @@ ios/App/fastlane/
 │   │   ├── keywords.txt           # Keywords, comma-separated (max 100 chars)
 │   │   ├── promotional_text.txt   # Promotional text (max 170 chars)
 │   │   ├── release_notes.txt      # What's new
+│   │   ├── marketing_url.txt      # Developer website URL
 │   │   ├── support_url.txt        # Support URL
 │   │   └── privacy_url.txt        # Privacy policy URL (required)
 │   └── review_information/        # App Review contact info

--- a/packages/mobile/ios/App/fastlane/metadata/en-US/marketing_url.txt
+++ b/packages/mobile/ios/App/fastlane/metadata/en-US/marketing_url.txt
@@ -1,0 +1,1 @@
+https://trizum.app/about

--- a/packages/mobile/ios/App/fastlane/metadata/es-ES/marketing_url.txt
+++ b/packages/mobile/ios/App/fastlane/metadata/es-ES/marketing_url.txt
@@ -1,0 +1,1 @@
+https://trizum.app/about


### PR DESCRIPTION
## Description

Adds `https://trizum.app/about` as the localized iOS App Store Marketing URL
for English and Spanish. This makes the public App Store listing expose the
Developer Website link AdMob uses to discover the app-ads.txt host.

The mobile metadata documentation and patch changeset are updated alongside
the new Fastlane files.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (not applicable: App Store metadata only)
- [x] I've run `vp run lingui:extract` (no new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this change has no in-app UI.

## Additional Notes

After merging, run the iOS `upload_metadata` Fastlane lane or include metadata
in the next full App Store deployment so App Store Connect receives the new
Marketing URL.
