### PR TITLE
fix(pwa): publish crawler policy

### DIFF
--- a/.changeset/brave-birds-smile.md
+++ b/.changeset/brave-birds-smile.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Publish a robots policy that allows crawlers to access the PWA's public content.

--- a/.changeset/brave-birds-smile.md
+++ b/.changeset/brave-birds-smile.md
@@ -2,4 +2,4 @@
 "@trizum/pwa": patch
 ---
 
-Publish a robots policy that allows crawlers to access the PWA's public content.
+Publish a robots policy that allows public content while keeping party routes out of crawlers.

--- a/.changeset/brave-birds-smile.md
+++ b/.changeset/brave-birds-smile.md
@@ -2,4 +2,4 @@
 "@trizum/pwa": patch
 ---
 
-Publish a robots policy that allows public content while keeping party routes out of crawlers.
+Publish a robots policy that allows crawlers to access public files and observe route-level indexing headers.

--- a/packages/pwa/public/robots.txt
+++ b/packages/pwa/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: Google-adstxt
+Disallow:
+
+User-agent: *
+Allow: /

--- a/packages/pwa/public/robots.txt
+++ b/packages/pwa/public/robots.txt
@@ -1,5 +1,3 @@
-User-agent: Google-adstxt
-Disallow:
-
 User-agent: *
 Allow: /
+Disallow: /party/

--- a/packages/pwa/public/robots.txt
+++ b/packages/pwa/public/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
 Allow: /
-Disallow: /party/


### PR DESCRIPTION
## Description

Publishes a root `robots.txt` as a real PWA static asset instead of allowing
Cloudflare's SPA fallback to return `index.html` for that path.

The policy applies to every user agent and permits crawlers to fetch public
site content, including party routes, so route-level `X-Robots-Tag: noindex,
nofollow` response headers can be observed. Root files such as `/app-ads.txt`
remain crawlable.

Existing files in `packages/pwa/public` continue to use Cloudflare's
asset-first routing and bypass the Worker when their paths match.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (not applicable: static crawler policy)
- [x] I've run `vp run lingui:extract` (no new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

Not applicable; this change has no UI.

## Additional Notes

The production build was checked to confirm every source file in
`packages/pwa/public` appears in `dist/client`. The generated `robots.txt` and
`app-ads.txt` are byte-for-byte identical to their source files.
