### PR TITLE
fix(mobile): render Android splash as vector

### DIFF
--- a/.changeset/bright-moons-launch.md
+++ b/.changeset/bright-moons-launch.md
@@ -1,0 +1,5 @@
+---
+"@trizum/mobile": patch
+---
+
+Render the Android launch splash from a native vector drawable for crisp output at every screen density.

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -122,6 +122,7 @@ packages/mobile/
 | `dev:android`     | Run in dev mode with live reload (Android)             |
 | `dev:ios`         | Run in dev mode with live reload (iOS)                 |
 | `assets:generate` | Generate app icons and splash screens                  |
+| `assets:check`    | Check the generated Android splash vector for drift    |
 | `sync:check`      | Fail if Capacitor sync changes mobile files            |
 | `check:android`   | Validate Android sync, lint, tests, APK, and AAB build |
 | `ruby:check`      | Dry-run Ruby bundles used by mobile CI                 |
@@ -489,3 +490,7 @@ vp run assets:generate
 ```
 
 Source assets are in `packages/mobile/assets/`.
+
+The Android launch theme uses a native vector drawable generated from the
+canonical mark in `packages/pwa/public/maskable.svg`. Run `assets:check` to
+verify that the checked-in drawable matches that source.

--- a/packages/mobile/android/app/src/main/res/drawable/splash_icon.xml
+++ b/packages/mobile/android/app/src/main/res/drawable/splash_icon.xml
@@ -3,12 +3,16 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="288dp"
     android:height="288dp"
-    android:viewportWidth="512"
-    android:viewportHeight="512">
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M138.738 197.734H356.862C356.862 197.734 397.947 197.734 397.947 166.36C397.947 134.986 356.862 134.986 356.862 134.986C335.199 134.986 311.295 134.986 301.584 161.878M273.945 232.843C273.945 232.843 238.089 317.254 199.245 357.592C185.578 371.785 174.594 377.014 154.425 377.014C134.256 377.014 113.388 366.556 114.087 344.893C114.786 323.23 138.738 323.23 138.738 323.23H176.835M273.945 323.23H356.862"
-        android:strokeColor="#FFFFFFFF"
-        android:strokeLineCap="round"
-        android:strokeWidth="17.928" />
+    android:viewportWidth="576"
+    android:viewportHeight="576">
+    <group
+        android:translateX="32"
+        android:translateY="32">
+        <path
+            android:fillColor="#00000000"
+            android:pathData="M138.738 197.734H356.862C356.862 197.734 397.947 197.734 397.947 166.36C397.947 134.986 356.862 134.986 356.862 134.986C335.199 134.986 311.295 134.986 301.584 161.878M273.945 232.843C273.945 232.843 238.089 317.254 199.245 357.592C185.578 371.785 174.594 377.014 154.425 377.014C134.256 377.014 113.388 366.556 114.087 344.893C114.786 323.23 138.738 323.23 138.738 323.23H176.835M273.945 323.23H356.862"
+            android:strokeColor="#FFFFFFFF"
+            android:strokeLineCap="round"
+            android:strokeWidth="17.928" />
+    </group>
 </vector>

--- a/packages/mobile/android/app/src/main/res/drawable/splash_icon.xml
+++ b/packages/mobile/android/app/src/main/res/drawable/splash_icon.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generated from packages/pwa/public/maskable.svg by the mobile asset generator. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="288dp"
+    android:height="288dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M138.738 197.734H356.862C356.862 197.734 397.947 197.734 397.947 166.36C397.947 134.986 356.862 134.986 356.862 134.986C335.199 134.986 311.295 134.986 301.584 161.878M273.945 232.843C273.945 232.843 238.089 317.254 199.245 357.592C185.578 371.785 174.594 377.014 154.425 377.014C134.256 377.014 113.388 366.556 114.087 344.893C114.786 323.23 138.738 323.23 138.738 323.23H176.835M273.945 323.23H356.862"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeWidth="17.928" />
+</vector>

--- a/packages/mobile/android/app/src/main/res/values/styles.xml
+++ b/packages/mobile/android/app/src/main/res/values/styles.xml
@@ -17,6 +17,8 @@
 
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
-        <item name="android:background">@drawable/splash</item>
+        <item name="windowSplashScreenBackground">@android:color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
+        <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
     </style>
 </resources>

--- a/packages/mobile/check-android.sh
+++ b/packages/mobile/check-android.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+cd "$SCRIPT_DIR"
+vp run assets:check
+
 "$SCRIPT_DIR/check-sync-clean.sh" android
 
 cd "$SCRIPT_DIR/android"

--- a/packages/mobile/generate-icons.sh
+++ b/packages/mobile/generate-icons.sh
@@ -49,12 +49,12 @@ svgexport $TEMP_ICON_ONLY_SVG $ASSETS_DIR/icon-only.png 1024:1024
 
 echo "Exporting icon-foreground.png"
 # Remove black background from temporary icon foreground SVG
-sed -i 's/fill="black"/fill="transparent"/g' $TEMP_ICON_FOREGROUND_SVG
+sed -i.bak 's/fill="black"/fill="transparent"/g' $TEMP_ICON_FOREGROUND_SVG
 svgexport $TEMP_ICON_FOREGROUND_SVG $ASSETS_DIR/icon-foreground.png 1024:1024
 
 echo "Exporting icon-background.png"
 # Remove white foreground from temporary icon background SVG
-sed -i 's/stroke="white"/stroke="transparent"/g' $TEMP_ICON_BACKGROUND_SVG
+sed -i.bak 's/stroke="white"/stroke="transparent"/g' $TEMP_ICON_BACKGROUND_SVG
 svgexport $TEMP_ICON_BACKGROUND_SVG $ASSETS_DIR/icon-background.png 1024:1024
 
 echo "Exporting splash.png"
@@ -66,6 +66,9 @@ svgexport $TEMP_SPLASH_DARK_SVG $ASSETS_DIR/splash-dark.png 2732:2732
 echo "Done generating base icons!"
 
 capacitor-assets generate --ios --android
+
+echo "Generating Android splash vector drawable..."
+node "$SCRIPT_DIR/src/generate-android-splash-icon.ts"
 
 # Generate Play Store icon (512x512) for fastlane metadata
 echo "Exporting Play Store icon..."

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -24,6 +24,7 @@
     }
   },
   "scripts": {
+    "assets:check": "node src/generate-android-splash-icon.ts --check",
     "capacitor:copy:before": "./copy-client.sh",
     "cleanup": "rm -rf dist",
     "dev": "tsc --watch",

--- a/packages/mobile/src/generate-android-splash-icon.test.ts
+++ b/packages/mobile/src/generate-android-splash-icon.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+import { generateAndroidSplashIcon } from "./generate-android-splash-icon.js";
+
+const logoSvg = `<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="512" height="512" fill="black"/>
+<path d="M10 10H20" stroke="white" stroke-width="4" stroke-linecap="round"/>
+</svg>`;
+
+describe("generateAndroidSplashIcon", () => {
+  it("translates the logo path into a native Android vector drawable", () => {
+    expect(generateAndroidSplashIcon(logoSvg)).toContain('android:pathData="M10 10H20"');
+    expect(generateAndroidSplashIcon(logoSvg)).toContain('android:strokeWidth="4"');
+    expect(generateAndroidSplashIcon(logoSvg)).toContain('android:width="288dp"');
+  });
+
+  it("rejects SVG features that cannot be translated losslessly", () => {
+    const unsupportedSvg = logoSvg.replace("</svg>", '<circle cx="10" cy="10" r="2"/></svg>');
+
+    expect(() => generateAndroidSplashIcon(unsupportedSvg)).toThrow(
+      "Logo SVG must contain exactly one background rect followed by one path",
+    );
+  });
+
+  it("rejects changes to the canonical logo colors", () => {
+    expect(() =>
+      generateAndroidSplashIcon(logoSvg.replace('stroke="white"', 'stroke="red"')),
+    ).toThrow('path must have stroke="white"');
+  });
+});

--- a/packages/mobile/src/generate-android-splash-icon.test.ts
+++ b/packages/mobile/src/generate-android-splash-icon.test.ts
@@ -26,4 +26,31 @@ describe("generateAndroidSplashIcon", () => {
       generateAndroidSplashIcon(logoSvg.replace('stroke="white"', 'stroke="red"')),
     ).toThrow('path must have stroke="white"');
   });
+
+  it("keeps the stroked mark inside Android's circular splash safe area", () => {
+    const drawable = generateAndroidSplashIcon(
+      logoSvg
+        .replace("M10 10H20", "M397.947 166.36M114.087 344.893")
+        .replace('stroke-width="4"', 'stroke-width="17.928"'),
+    );
+    const viewportWidth = Number(drawable.match(/android:viewportWidth="([\d.]+)"/)?.[1]);
+    const strokeWidth = Number(drawable.match(/android:strokeWidth="([\d.]+)"/)?.[1]);
+    const translateX = Number(drawable.match(/android:translateX="([\d.]+)"/)?.[1] ?? 0);
+    const translateY = Number(drawable.match(/android:translateY="([\d.]+)"/)?.[1] ?? 0);
+    const safeRadius = viewportWidth / 3;
+    const center = viewportWidth / 2;
+    const clippedExtrema = [
+      { x: 397.947, y: 166.36 },
+      { x: 114.087, y: 344.893 },
+    ];
+
+    for (const point of clippedExtrema) {
+      const distanceFromCenter = Math.hypot(
+        point.x + translateX - center,
+        point.y + translateY - center,
+      );
+
+      expect(distanceFromCenter + strokeWidth / 2).toBeLessThanOrEqual(safeRadius);
+    }
+  });
 });

--- a/packages/mobile/src/generate-android-splash-icon.ts
+++ b/packages/mobile/src/generate-android-splash-icon.ts
@@ -3,6 +3,10 @@ import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const ANDROID_SPLASH_ICON_SIZE_DP = 288;
+const SOURCE_ICON_VIEWPORT_SIZE = 512;
+const ANDROID_SPLASH_ICON_VIEWPORT_SIZE = 576;
+const ANDROID_SPLASH_ICON_INSET =
+  (ANDROID_SPLASH_ICON_VIEWPORT_SIZE - SOURCE_ICON_VIEWPORT_SIZE) / 2;
 
 type SvgAttributes = Record<string, string>;
 
@@ -100,14 +104,18 @@ export function generateAndroidSplashIcon(svgSource: string) {
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="${ANDROID_SPLASH_ICON_SIZE_DP}dp"
     android:height="${ANDROID_SPLASH_ICON_SIZE_DP}dp"
-    android:viewportWidth="512"
-    android:viewportHeight="512">
-    <path
-        android:fillColor="#00000000"
-        android:pathData="${escapeXmlAttribute(pathData)}"
-        android:strokeColor="#FFFFFFFF"
-        android:strokeLineCap="round"
-        android:strokeWidth="${strokeWidth}" />
+    android:viewportWidth="${ANDROID_SPLASH_ICON_VIEWPORT_SIZE}"
+    android:viewportHeight="${ANDROID_SPLASH_ICON_VIEWPORT_SIZE}">
+    <group
+        android:translateX="${ANDROID_SPLASH_ICON_INSET}"
+        android:translateY="${ANDROID_SPLASH_ICON_INSET}">
+        <path
+            android:fillColor="#00000000"
+            android:pathData="${escapeXmlAttribute(pathData)}"
+            android:strokeColor="#FFFFFFFF"
+            android:strokeLineCap="round"
+            android:strokeWidth="${strokeWidth}" />
+    </group>
 </vector>
 `;
 }

--- a/packages/mobile/src/generate-android-splash-icon.ts
+++ b/packages/mobile/src/generate-android-splash-icon.ts
@@ -1,0 +1,145 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ANDROID_SPLASH_ICON_SIZE_DP = 288;
+
+type SvgAttributes = Record<string, string>;
+
+function parseAttributes(source: string, elementName: string): SvgAttributes {
+  const attributes: SvgAttributes = {};
+  const attributePattern = /([\w:-]+)="([^"]*)"/g;
+
+  for (const match of source.matchAll(attributePattern)) {
+    const [, name, value] = match;
+    if (!name || value === undefined) {
+      continue;
+    }
+    attributes[name] = value;
+  }
+
+  const unsupportedSyntax = source.replace(attributePattern, "").trim();
+  if (unsupportedSyntax) {
+    throw new Error(`${elementName} contains unsupported attribute syntax: ${unsupportedSyntax}`);
+  }
+
+  return attributes;
+}
+
+function assertAttributes(elementName: string, attributes: SvgAttributes, supported: string[]) {
+  const unsupported = Object.keys(attributes).filter((attribute) => !supported.includes(attribute));
+  if (unsupported.length > 0) {
+    throw new Error(`${elementName} contains unsupported attributes: ${unsupported.join(", ")}`);
+  }
+}
+
+function assertAttribute(
+  elementName: string,
+  attributes: SvgAttributes,
+  attributeName: string,
+  expectedValue: string,
+) {
+  const actualValue = attributes[attributeName];
+  if (actualValue !== expectedValue) {
+    throw new Error(
+      `${elementName} must have ${attributeName}="${expectedValue}", received ${JSON.stringify(actualValue)}`,
+    );
+  }
+}
+
+function escapeXmlAttribute(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export function generateAndroidSplashIcon(svgSource: string) {
+  const normalizedSource = svgSource.replaceAll(/<!--[\s\S]*?-->/g, "").trim();
+  const match = normalizedSource.match(
+    /^<svg(?<svgAttributes>[^>]*)>\s*<rect(?<rectAttributes>[^>]*)\/>\s*<path(?<pathAttributes>[^>]*)\/>\s*<\/svg>$/,
+  );
+
+  if (!match?.groups) {
+    throw new Error("Logo SVG must contain exactly one background rect followed by one path");
+  }
+
+  const svgAttributes = parseAttributes(match.groups.svgAttributes, "svg");
+  const rectAttributes = parseAttributes(match.groups.rectAttributes, "rect");
+  const pathAttributes = parseAttributes(match.groups.pathAttributes, "path");
+
+  assertAttributes("svg", svgAttributes, ["width", "height", "viewBox", "fill", "xmlns"]);
+  assertAttribute("svg", svgAttributes, "width", "512");
+  assertAttribute("svg", svgAttributes, "height", "512");
+  assertAttribute("svg", svgAttributes, "viewBox", "0 0 512 512");
+  assertAttribute("svg", svgAttributes, "fill", "none");
+  assertAttribute("svg", svgAttributes, "xmlns", "http://www.w3.org/2000/svg");
+
+  assertAttributes("rect", rectAttributes, ["width", "height", "fill"]);
+  assertAttribute("rect", rectAttributes, "width", "512");
+  assertAttribute("rect", rectAttributes, "height", "512");
+  assertAttribute("rect", rectAttributes, "fill", "black");
+
+  assertAttributes("path", pathAttributes, ["d", "stroke", "stroke-width", "stroke-linecap"]);
+  assertAttribute("path", pathAttributes, "stroke", "white");
+  assertAttribute("path", pathAttributes, "stroke-linecap", "round");
+
+  const pathData = pathAttributes.d;
+  if (!pathData) {
+    throw new Error("Logo path must contain path data");
+  }
+
+  const strokeWidth = Number(pathAttributes["stroke-width"]);
+  if (!Number.isFinite(strokeWidth) || strokeWidth <= 0) {
+    throw new Error("Logo path stroke-width must be a positive number");
+  }
+
+  return `<?xml version="1.0" encoding="utf-8"?>
+<!-- Generated from packages/pwa/public/maskable.svg by the mobile asset generator. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="${ANDROID_SPLASH_ICON_SIZE_DP}dp"
+    android:height="${ANDROID_SPLASH_ICON_SIZE_DP}dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="${escapeXmlAttribute(pathData)}"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeWidth="${strokeWidth}" />
+</vector>
+`;
+}
+
+async function run() {
+  const packageDirectory = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+  const sourcePath = path.resolve(packageDirectory, "../pwa/public/maskable.svg");
+  const outputPath = path.resolve(
+    packageDirectory,
+    "android/app/src/main/res/drawable/splash_icon.xml",
+  );
+  const checkOnly = process.argv.slice(2).includes("--check");
+  const source = await readFile(sourcePath, "utf8");
+  const generated = generateAndroidSplashIcon(source);
+
+  if (checkOnly) {
+    const existing = await readFile(outputPath, "utf8").catch(() => "");
+    if (existing !== generated) {
+      throw new Error(
+        "Android splash icon is out of date. Run `vp run --filter @trizum/mobile assets:generate`.",
+      );
+    }
+    return;
+  }
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, generated);
+}
+
+const executedPath = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : undefined;
+if (executedPath === import.meta.url) {
+  await run();
+}


### PR DESCRIPTION
## Description

Replace Android's density-scaled launch bitmap with a native vector drawable derived deterministically from the canonical Trizum logo SVG.

The Android launch theme now supplies the platform splash background, icon, and post-splash theme explicitly. The generator symmetrically insets the source mark so its full stroke stays inside Android's circular splash safe area on OEM devices. The Android validation gate rejects generated-vector drift or unsupported changes to the source SVG.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

An API 35 emulator confirmed the vector renders crisply but did not reproduce the OEM mask behavior. A physical-device capture exposed diagonal clipping at the top-right and bottom-left stroke extrema. The generator now places those extrema, including half the stroke width, inside Android's documented circular safe area; a regression test covers the geometry.

## Additional Notes

- `vp run --filter @trizum/mobile check:android` passes, including generated-asset drift, Capacitor sync cleanliness, Android lint, unit tests, debug APK, and release AAB.
- `vp run check` and `vp run test` pass. Check reports three unrelated, pre-existing React warnings.
- The workspace `vp run build` completed the PWA build, then stopped during iOS sync because the documented local CocoaPods bundle is not installed. This PR does not change iOS files.
