### PR TITLE
fix(pwa): render home illustration in Safari

### DIFF
--- a/.changeset/calm-icons-render.md
+++ b/.changeset/calm-icons-render.md
@@ -1,0 +1,5 @@
+---
+"@trizum/pwa": patch
+---
+
+Render the home illustration correctly in Safari.

--- a/packages/icon-sprite/package.json
+++ b/packages/icon-sprite/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@trizum/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
     "@typescript/native": "catalog:",
     "vite": "catalog:",
     "vite-plus": "catalog:"

--- a/packages/icon-sprite/src/generate.test.ts
+++ b/packages/icon-sprite/src/generate.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -131,5 +133,34 @@ describe("generateIconSpriteArtifacts", () => {
     });
 
     expect(result.usedIds).toEqual(["lucide.arrow-left"]);
+  });
+
+  it("rejects local fragment references that Safari cannot render from external sprites", () => {
+    const rootDir = createTempProject();
+    tempDirectories.push(rootDir);
+
+    writeFile(rootDir, "src/app.tsx", 'const icon = "illustration.gradient";\n');
+    writeFile(
+      rootDir,
+      "src/icons/illustration/gradient.svg",
+      [
+        '<svg viewBox="0 0 24 24">',
+        '<defs><linearGradient id="paint"><stop stop-color="#fff"/></linearGradient></defs>',
+        '<circle cx="12" cy="12" r="10" fill="url(#paint)"/>',
+        "</svg>",
+        "",
+      ].join("\n"),
+    );
+
+    expect(() =>
+      generateIconSpriteArtifacts({
+        rootDir,
+        config: {
+          generatedSpriteFile: "src/generated/iconSprite.svg",
+          generatedTypesFile: "src/generated/iconSprite.gen.ts",
+          iconSources: [createSetDirectoryIconSource({ directory: "src/icons" })],
+        },
+      }),
+    ).toThrow(/cannot reliably resolve url\(#…\) references in Safari/u);
   });
 });

--- a/packages/icon-sprite/src/index.ts
+++ b/packages/icon-sprite/src/index.ts
@@ -37,6 +37,7 @@ const STRING_LITERAL_REGEX = /(["'`])([^"'`\r\n]+)\1/g;
 const SVG_ROOT_REGEX = /<svg\b([^>]*)>([\s\S]*?)<\/svg>/i;
 const SVG_ATTRIBUTE_REGEX = /\b([a-zA-Z_:][-a-zA-Z0-9_:.]*)=(["'])(.*?)\2/g;
 const VIEWBOX_REGEX = /\bviewBox=(["'])([^"']+)\1/i;
+const LOCAL_FRAGMENT_REFERENCE_REGEX = /url\(\s*["']?#[^)]+/u;
 const STRIPPED_SVG_ATTRIBUTES = new Set(["class", "height", "role", "width", "xmlns"]);
 
 export function defineIconSpriteConfig(config: IconSpriteConfig) {
@@ -290,6 +291,12 @@ function createSymbolSource(id: string, filePath: string) {
 
   if ("error" in optimized) {
     throw new Error(`Failed to optimize icon "${id}" from ${filePath}: ${String(optimized.error)}`);
+  }
+
+  if (LOCAL_FRAGMENT_REFERENCE_REGEX.test(optimized.data)) {
+    throw new Error(
+      `Icon "${id}" contains a local SVG fragment reference. External SVG sprites cannot reliably resolve url(#…) references in Safari; use direct paint values instead.`,
+    );
   }
 
   const svgMatch = optimized.data.match(SVG_ROOT_REGEX);

--- a/packages/icon-sprite/tsconfig.json
+++ b/packages/icon-sprite/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "./dist",
     "moduleResolution": "nodenext",
     "module": "nodenext",
+    "types": ["node"],
     "composite": true,
     "declaration": true,
     "noEmit": false

--- a/packages/pwa/src/icons/illustration/shared-expenses.svg
+++ b/packages/pwa/src/icons/illustration/shared-expenses.svg
@@ -1,34 +1,4 @@
 <svg viewBox="0 0 620 560" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="shared-expenses-green" x1="78" y1="68" x2="155" y2="157" gradientUnits="userSpaceOnUse">
-      <stop stop-color="var(--color-success-700, #047857)"/>
-      <stop offset=".52" stop-color="var(--color-success-500, #10b981)"/>
-      <stop offset="1" stop-color="var(--color-success-400, #34d399)"/>
-    </linearGradient>
-    <linearGradient id="shared-expenses-blue" x1="460" y1="66" x2="533" y2="157" gradientUnits="userSpaceOnUse">
-      <stop stop-color="var(--color-blue-700, #1d4ed8)"/>
-      <stop offset="1" stop-color="var(--color-blue-400, #60a5fa)"/>
-    </linearGradient>
-    <linearGradient id="shared-expenses-purple" x1="67" y1="372" x2="139" y2="454" gradientUnits="userSpaceOnUse">
-      <stop stop-color="var(--color-violet-700, #6d28d9)"/>
-      <stop offset="1" stop-color="var(--color-violet-400, #a78bfa)"/>
-    </linearGradient>
-    <linearGradient id="shared-expenses-yellow" x1="484" y1="370" x2="555" y2="456" gradientUnits="userSpaceOnUse">
-      <stop stop-color="var(--color-warning-600, #ca8a04)"/>
-      <stop offset="1" stop-color="var(--color-warning-300, #fde047)"/>
-    </linearGradient>
-    <linearGradient id="shared-expenses-check" x1="376" y1="417" x2="431" y2="472" gradientUnits="userSpaceOnUse">
-      <stop stop-color="var(--color-success-700, #047857)"/>
-      <stop offset="1" stop-color="var(--color-success-500, #10b981)"/>
-    </linearGradient>
-    <filter id="shared-expenses-shadow" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
-      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#020c17" flood-opacity=".42"/>
-    </filter>
-    <filter id="shared-expenses-glow" x="-40%" y="-40%" width="180%" height="180%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="15"/>
-    </filter>
-  </defs>
-
   <ellipse
     cx="310"
     cy="277"
@@ -40,10 +10,10 @@
     opacity=".58"
   />
 
-  <circle cx="117" cy="111" r="56" fill="var(--color-success-500, #10b981)" opacity=".1" filter="url(#shared-expenses-glow)"/>
-  <circle cx="494" cy="111" r="56" fill="var(--color-blue-500, #3b82f6)" opacity=".1" filter="url(#shared-expenses-glow)"/>
-  <circle cx="102" cy="409" r="56" fill="var(--color-violet-500, #8b5cf6)" opacity=".1" filter="url(#shared-expenses-glow)"/>
-  <circle cx="519" cy="409" r="56" fill="var(--color-warning-400, #facc15)" opacity=".1" filter="url(#shared-expenses-glow)"/>
+  <circle cx="117" cy="111" r="56" fill="var(--color-success-500, #10b981)" opacity=".1"/>
+  <circle cx="494" cy="111" r="56" fill="var(--color-blue-500, #3b82f6)" opacity=".1"/>
+  <circle cx="102" cy="409" r="56" fill="var(--color-violet-500, #8b5cf6)" opacity=".1"/>
+  <circle cx="519" cy="409" r="56" fill="var(--color-warning-400, #facc15)" opacity=".1"/>
 
   <g opacity=".75">
     <circle cx="250" cy="83" r="5" stroke="currentColor" stroke-width="4"/>
@@ -54,7 +24,7 @@
     <circle cx="451" cy="335" r="5" stroke="currentColor" stroke-width="4" opacity=".7"/>
   </g>
 
-  <g filter="url(#shared-expenses-shadow)">
+  <g>
     <rect x="196" y="122" width="220" height="316" rx="23" fill="var(--shared-expenses-surface, #09233a)"/>
     <rect x="197.5" y="123.5" width="217" height="313" rx="21.5" stroke="currentColor" stroke-width="3" opacity=".42"/>
 
@@ -75,36 +45,36 @@
     <text x="388" y="405" fill="currentColor" font-family="Inter, ui-sans-serif, sans-serif" font-size="24" font-weight="700" text-anchor="end">71.00</text>
   </g>
 
-  <g filter="url(#shared-expenses-shadow)">
-    <circle cx="117" cy="111" r="49" fill="url(#shared-expenses-green)"/>
+  <g>
+    <circle cx="117" cy="111" r="49" fill="var(--color-success-500, #10b981)"/>
     <circle cx="117" cy="111" r="48" stroke="var(--color-success-300, #6ee7b7)" stroke-width="2" opacity=".85"/>
     <circle cx="117" cy="102" r="11" stroke="white" stroke-width="4"/>
     <path d="M101 132c1-13 7-19 16-19s15 6 16 19" stroke="white" stroke-width="4" stroke-linecap="round"/>
   </g>
 
-  <g filter="url(#shared-expenses-shadow)">
-    <circle cx="494" cy="111" r="49" fill="url(#shared-expenses-blue)"/>
+  <g>
+    <circle cx="494" cy="111" r="49" fill="var(--color-blue-500, #3b82f6)"/>
     <circle cx="494" cy="111" r="48" stroke="var(--color-blue-300, #93c5fd)" stroke-width="2" opacity=".9"/>
     <circle cx="494" cy="102" r="11" stroke="white" stroke-width="4"/>
     <path d="M478 132c1-13 7-19 16-19s15 6 16 19" stroke="white" stroke-width="4" stroke-linecap="round"/>
   </g>
 
-  <g filter="url(#shared-expenses-shadow)">
-    <circle cx="102" cy="409" r="49" fill="url(#shared-expenses-purple)"/>
+  <g>
+    <circle cx="102" cy="409" r="49" fill="var(--color-violet-500, #8b5cf6)"/>
     <circle cx="102" cy="409" r="48" stroke="var(--color-violet-300, #c4b5fd)" stroke-width="2" opacity=".88"/>
     <circle cx="102" cy="400" r="11" stroke="white" stroke-width="4"/>
     <path d="M86 430c1-13 7-19 16-19s15 6 16 19" stroke="white" stroke-width="4" stroke-linecap="round"/>
   </g>
 
-  <g filter="url(#shared-expenses-shadow)">
-    <circle cx="519" cy="409" r="49" fill="url(#shared-expenses-yellow)"/>
+  <g>
+    <circle cx="519" cy="409" r="49" fill="var(--color-warning-400, #facc15)"/>
     <circle cx="519" cy="409" r="48" stroke="var(--color-warning-300, #fde047)" stroke-width="2" opacity=".95"/>
     <circle cx="519" cy="400" r="11" stroke="white" stroke-width="4"/>
     <path d="M503 430c1-13 7-19 16-19s15 6 16 19" stroke="white" stroke-width="4" stroke-linecap="round"/>
   </g>
 
-  <g filter="url(#shared-expenses-shadow)">
-    <circle cx="402" cy="445" r="32" fill="url(#shared-expenses-check)"/>
+  <g>
+    <circle cx="402" cy="445" r="32" fill="var(--color-success-500, #10b981)"/>
     <circle cx="402" cy="445" r="31" stroke="var(--color-success-400, #34d399)" stroke-width="2"/>
     <path d="m387 445 10 10 20-23" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
   </g>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,15 +488,18 @@ importers:
       '@trizum/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
       '@typescript/native':
         specifier: 'catalog:'
         version: typescript@7.0.2
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.4
-        version: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.4(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)
+        version: 0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(terser@5.44.1)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)
 
   packages/logging:
     dependencies:


### PR DESCRIPTION
## Description

Fix the home-page shared-expenses illustration disappearing in Safari.

Safari does not reliably resolve nested `url(#...)` gradients and filters inside an externally loaded SVG sprite. On iOS 26.5 it dropped the card and participant groups entirely; desktop WebKit also lost the gradient paints. The illustration now uses direct themed fills and no fragment-based filters, preserving its full structure and colors across browsers.

The icon-sprite generator now rejects local fragment references with a Safari-specific error so future sprite assets cannot reintroduce this rendering failure.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Translation
- [ ] Other (describe below)

## Checklist

- [x] I've read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I've run `vp run check`
- [x] I've run `vp run test` and all tests pass
- [x] I've run `vp run build`
- [x] I've added tests for new functionality (if applicable)
- [x] I've run `vp run lingui:extract` (if I added new strings)
- [x] I've added a changeset (if this is a user-facing change)

## Screenshots

The original iOS 26.5 simulator reproduced the missing illustration. After the fix, the same simulator renders the four participants, expense card, amounts, and settlement check. The card-region pixel signal increased from 0 rendered pixels to 9,851 (14.2% of the sampled region).

## Additional Notes

Validation included the existing home-screen Playwright journey in both Chromium and WebKit. The full workspace build passed with the repository's pinned Ruby toolchain, including Capacitor's iOS `pod install`.
